### PR TITLE
Introduced configurable tripoles and quadpoles line thickness 

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -59,6 +59,8 @@
 \ctikzset{bipoles/.is family}
 \ctikzset{bipoles/border margin/.initial=1.1}
 \ctikzset{bipoles/thickness/.initial=2} 
+\ctikzset{tripoles/thickness/.initial=2} 
+\ctikzset{quadpoles/thickness/.initial=2} 
 \ctikzset{nodes width/.initial=.04}
 \newdimen\pgf@circ@Rlen 
 \ctikzset{bipoles/length/.code={\pgf@circ@Rlen = #1}}

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -336,7 +336,7 @@
 
       % Triangle
       \pgfscope
-        \pgfsetlinewidth{2\pgflinewidth}
+        \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/quadpoles/thickness}\pgflinewidth}
         \pgftransformxshift{.7\pgf@circ@res@left}
         \pgf@circ@res@step=\pgf@circ@res@right
         \advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -405,7 +405,7 @@
 	
 	\pgfusepath{draw}
 	
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/quadpoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint{\stretto\pgf@circ@res@left}{.7*\stretto\pgf@circ@res@down}}
 	\pgfpatharc{90}{270}{.7*\stretto\pgf@circ@res@down}
 	

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -117,7 +117,7 @@
 				\pgfpointadd{\pgfpointshapeborder{spdt1}{\pgfpoint{-\pgf@circ@res@other}{-100pt}}}
 				{\pgfpoint{-.05\pgf@circ@res@up}{-.05\pgf@circ@res@up}}
 			}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 		\endpgfscope
 	  }
@@ -246,7 +246,7 @@
 	
 	\pgfusepath{draw}
 	
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint
 		{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american and port/port width}\pgf@circ@res@left}
 		{\pgf@circ@res@up}}
@@ -296,7 +296,7 @@
 	
 	\pgfusepath{draw}
 	
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 
 	\pgf@circ@res@step = \pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/circle width}\pgf@circ@res@right
 	\pgf@circ@res@other = \pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/port width}\pgf@circ@res@right
@@ -347,7 +347,7 @@
 	\pgf@circ@res@other=\pgfkeysvalueof{/tikz/circuitikz/tripoles/american nor port/port width}\pgf@circ@res@right
 	\pgf@circ@res@step = \pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/circle width}\pgf@circ@res@right
 		
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
 	\pgfpathcurveto
 		{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american nor port/aaa}\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -402,7 +402,7 @@
 	
 	\pgfusepath{draw}
 	\pgf@circ@res@other=\pgfkeysvalueof{/tikz/circuitikz/tripoles/american or port/port width}\pgf@circ@res@right
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
 	\pgfpathcurveto
 		{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american or port/aaa}\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -448,7 +448,7 @@
 	
 	\pgfusepath{draw}
 	\pgf@circ@res@other=\pgfkeysvalueof{/tikz/circuitikz/tripoles/american xor port/port width}\pgf@circ@res@right
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
 	\pgfpathcurveto
 		{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american xor port/aaa}\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -510,7 +510,7 @@
 	\pgf@circ@res@other=\pgfkeysvalueof{/tikz/circuitikz/tripoles/american xnor port/port width}\pgf@circ@res@right
 	\pgf@circ@res@step = \pgfkeysvalueof{/tikz/circuitikz/tripoles/american xnor port/circle width}\pgf@circ@res@right
 
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
 	\pgfpathcurveto
 		{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american xnor port/aaa}\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -621,7 +621,7 @@
 		\pgf@circ@res@other = \pgfkeysvalueof{/tikz/circuitikz/bipoles/not port/circle width}\pgf@circ@res@right
 						
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgftransformxshift{.7\pgf@circ@res@left}
 		\pgf@circ@res@step=\pgf@circ@res@right
 		\advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -719,7 +719,7 @@
 		\pgf@circ@res@other = \pgfkeysvalueof{/tikz/circuitikz/bipoles/not port/circle width}\pgf@circ@res@right
 						
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgftransformxshift{.7\pgf@circ@res@left}
 		\pgf@circ@res@step=\pgf@circ@res@right
 		\advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -746,7 +746,7 @@
 				\pgfusepath{draw}
 		%draw inner shape
 		
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		
 		\pgfpathmoveto{\pgfpoint{.6\pgf@circ@res@left}{.3\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{.3\pgf@circ@res@down}}
@@ -829,7 +829,7 @@
 		\pgf@circ@res@other = \pgfkeysvalueof{/tikz/circuitikz/bipoles/not port/circle width}\pgf@circ@res@right
 						
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgftransformxshift{.7\pgf@circ@res@left}
 		\pgf@circ@res@step=\pgf@circ@res@right
 		\advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -850,7 +850,7 @@
 				\pgfusepath{draw}
 		%draw inner shape
 		
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		
 		\pgfpathmoveto{\pgfpoint{.6\pgf@circ@res@left}{.3\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{.3\pgf@circ@res@down}}
@@ -990,7 +990,7 @@
 			%
 			%
 			%
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfpathrectanglecorners
 				{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/european #1 port/reserved}\pgf@circ@res@left}{\pgf@circ@res@up}}
 				{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/european #1 port/reserved}\pgf@circ@res@right}{\pgf@circ@res@down}}
@@ -1224,7 +1224,7 @@
 		\pgfpathlineto{\pgfpoint
 			{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base width}\pgf@circ@res@left}
 			{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base height}\pgf@circ@res@down}}
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgfusepath{draw}
 		\endpgfscope
 		
@@ -1324,7 +1324,7 @@
 	\pgfpathlineto{\pgfpoint
 		{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base width}\pgf@circ@res@left}
 		{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base height}\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5\pgflinewidth}}
-	\pgfsetlinewidth{2\pgflinewidth}
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 	\pgfusepath{draw}
 	\endpgfscope
 	%draw lower connection		
@@ -1413,7 +1413,7 @@
 			\pgfpathlineto{\pgfpoint
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos/gate width}\pgf@circ@res@left}
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos/gate height}\pgf@circ@res@down}}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 			\endpgfscope
 		\ifpgf@circuit@mos@arrows
@@ -1484,7 +1484,7 @@
 			\pgfpathlineto{\pgfpoint
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/pmos/gate width}\pgf@circ@res@left}
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/pmos/gate height}\pgf@circ@res@down}}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 			\endpgfscope
 			
@@ -1549,7 +1549,7 @@
         {\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base width}\pgf@circ@res@left}
         {\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base height}\pgf@circ@res@down}}
         \fi
-      \pgfsetlinewidth{2\pgflinewidth}
+      \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgfusepath{draw}
 		\endpgfscope
 		%Bulk connection line
@@ -1576,7 +1576,7 @@
     \pgfpathlineto{\pgfpoint
       {\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/gate width}\pgf@circ@res@left}
       {\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/gate height}\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
-    \pgfsetlinewidth{2\pgflinewidth}
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
     \pgfusepath{draw}
     \endpgfscope
     
@@ -1772,7 +1772,7 @@
 			\pgfpathlineto{\pgfpoint
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/njfet/gate width}\pgf@circ@res@left}
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/njfet/gate height}\pgf@circ@res@down}}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 			\endpgfscope
 			
@@ -1823,7 +1823,7 @@
 			\pgfpathlineto{\pgfpoint
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/pjfet/gate width}\pgf@circ@res@left}
 				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/pjfet/gate height}\pgf@circ@res@down}}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 			\endpgfscope
 			
@@ -1871,7 +1871,7 @@
       \pgfpathlineto{\pgfpoint
         {\pgfkeysvalueof{/tikz/circuitikz/tripoles/isfet/base width}\pgf@circ@res@left}
         {\pgfkeysvalueof{/tikz/circuitikz/tripoles/isfet/base height}\pgf@circ@res@down}}
-      \pgfsetlinewidth{2\pgflinewidth} %% added
+      \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth} %% added
       \pgfusepath{draw} %% added
       \endpgfscope %% added
       
@@ -1901,7 +1901,7 @@
       %\pgfpathlineto{\pgfpoint
        % {\pgfkeysvalueof{/tikz/circuitikz/tripoles/isfet/gate width}\pgf@circ@res@left}
        % {\pgfkeysvalueof{/tikz/circuitikz/tripoles/isfet/gate height}\pgf@circ@res@down}}
-      %\pgfsetlinewidth{2\pgflinewidth}
+      %\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
       %\pgfusepath{draw}
       %\endpgfscope
       
@@ -2346,7 +2346,7 @@
 
 						
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgftransformxshift{.7\pgf@circ@res@left}
 		\pgf@circ@res@step=\pgf@circ@res@right
 		\advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -2456,7 +2456,7 @@
 	\pgfusepath{draw}
 				
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgfpathmoveto{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/port width}\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/port width}\pgf@circ@res@left}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/tripoles/american nand port/port width}\pgf@circ@res@right}{\pgf@circ@res@up}}
@@ -2575,7 +2575,7 @@
 	\pgfusepath{draw}
 
 	\pgfscope
-		\pgfsetlinewidth{2\pgflinewidth}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 		\pgftransformxshift{.7\pgf@circ@res@left}
 		\pgf@circ@res@step=\pgf@circ@res@right
 		\advance\pgf@circ@res@step by -\pgf@circ@res@left
@@ -2954,7 +2954,7 @@
 			\pgfpathmoveto{\pgfpointorigin}
 			\pgfpathmoveto{\pgfpointpolar{90}{0.3\pgf@circ@res@step}}
 			\pgfpathlineto{\pgfpointpolar{270}{0.3\pgf@circ@res@step}}
-			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/tripoles/thickness}\pgflinewidth}
 			\pgfusepath{draw}
 			
 		\endpgfscope				  


### PR DESCRIPTION
… similar to the one for bipoles

new keys:
tripoles/thickness
quadpoles/thickness
with initial value of 2 (was hard coded before)

**Please note that these changes are not tested, since I'm unfamiliar with the build procedure.**