### PR TITLE
Added the HEMT transistor and Cute Choke

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -427,6 +427,7 @@ If (default behaviour) \texttt{cuteinductors} option is active (or the style \te
 \begin{itemize}
   	\ctikzset{inductor=cute}
   	\circuititembip{L}{Inductor}{cute inductor}
+    \circuititembip{cute choke}{Choke}{}
 	\circuititembip{vL}{Variable inductor}{variable cute inductor}
 \end{itemize}
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -559,6 +559,7 @@ Similarly, if (default behaviour) \texttt{europeanvoltages} option is active (or
 \begin{itemize}
 	\circuititem{nmos}{\scshape nmos}{}
 	\circuititem{pmos}{\scshape pmos}{}
+    \circuititem{hemt}{\scshape hemt}{}
 	\circuititem{npn}{\scshape npn}{}
 	\circuititem{pnp}{\scshape pnp}{}
 	\circuititem{npn,photo}{\scshape npn}{}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -112,6 +112,18 @@
 \ctikzset{bipoles/cuteinductor/width/.initial=.6}
 \ctikzset{bipoles/cuteinductor/coils/.initial=5}
 \ctikzset{bipoles/cuteinductor/coil aspect/.initial=.5}%percentage of inductor width, which is covered by lower coil
+%% Cute choke settings
+\ctikzset{bipoles/cutechoke/height/.initial=.3}
+\ctikzset{bipoles/cutechoke/lower coil height/.initial=.15}	
+\ctikzset{bipoles/cutechoke/width/.initial=.6}
+\ctikzset{bipoles/cutechoke/coils/.initial=5}
+\ctikzset{bipoles/cutechoke/coil aspect/.initial=.5}%percentage of choke width, which is covered by lower coil
+\ctikzset{bipoles/cutechoke/cstep/.initial=2}
+\ctikzset{bipoles/cutechoke/cdist/.initial=8}
+\ctikzset{bipoles/cutechoke/cthick/.initial=8}
+\newif\ifpgf@circuit@bipole@twolines
+\pgf@circuit@bipole@twolinesfalse
+%
 \ctikzset{bipoles/americaninductor/height/.initial=.3}
 \ctikzset{bipoles/americaninductor/height 2/.initial=.1}
 \ctikzset{bipoles/americaninductor/width/.initial=.8}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -118,9 +118,9 @@
 \ctikzset{bipoles/cutechoke/width/.initial=.6}
 \ctikzset{bipoles/cutechoke/coils/.initial=5}
 \ctikzset{bipoles/cutechoke/coil aspect/.initial=.5}%percentage of choke width, which is covered by lower coil
-\ctikzset{bipoles/cutechoke/cstep/.initial=2}
-\ctikzset{bipoles/cutechoke/cdist/.initial=8}
-\ctikzset{bipoles/cutechoke/cthick/.initial=8}
+\ctikzset{bipoles/cutechoke/cstep/.initial=.3}
+\ctikzset{bipoles/cutechoke/cdist/.initial=1.3}
+\ctikzset{bipoles/cutechoke/cthick/.initial=1}
 \newif\ifpgf@circuit@bipole@twolines
 \pgf@circuit@bipole@twolinesfalse
 %

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -367,6 +367,18 @@
 \ctikzset{tripoles/pmos/bodydiode conn/.initial=.6}
 \ctikzset{tripoles/pmos/curr direction/.initial=-1}
 
+\ctikzset{tripoles/hemt/width/.initial=.7}
+\ctikzset{tripoles/hemt/gate height/.initial=.35}
+\ctikzset{tripoles/hemt/base height/.initial=.5}
+\ctikzset{tripoles/hemt/conn height/.initial=0}
+\ctikzset{tripoles/hemt/height/.initial=1.1}
+\ctikzset{tripoles/hemt/base width/.initial=.5}
+\ctikzset{tripoles/hemt/gate width/.initial=.62}
+\ctikzset{tripoles/hemt/bodydiode scale/.initial=.3}
+\ctikzset{tripoles/hemt/bodydiode distance/.initial=.3}
+\ctikzset{tripoles/hemt/bodydiode conn/.initial=.6}
+\ctikzset{tripoles/hemt/curr direction/.initial=1}
+
 \ctikzset{tripoles/nfet/width/.initial=.7}
 \ctikzset{tripoles/nfet/gate height/.initial=.35}
 \ctikzset{tripoles/nfet/base height/.initial=.5}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -392,6 +392,43 @@
 	\pgfusepath{stroke}
 }
 
+%% cute choke
+
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/cutechoke/lower coil height}}{cutechoke}{\ctikzvalof{bipoles/cutechoke/height}}{\ctikzvalof{bipoles/cutechoke/width}}{
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+	\pgftransformationadjustments
+
+	\pgfmathsetlength{\pgf@circ@res@other}%width of small coil
+	{0.5*\ctikzvalof{bipoles/cutechoke/coil aspect}*\ctikzvalof{bipoles/cutechoke/width}*\pgf@circ@Rlen/(\ctikzvalof{bipoles/cutechoke/coils}-1)}
+
+
+	\pgfmathsetlength{\pgf@circ@res@step}
+		{(\ctikzvalof{bipoles/cutechoke/width}*\pgf@circ@Rlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/cutechoke/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/cutechoke/coils}/2}
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*0.5*\pgflinewidth}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth}}%correct value would be 0.5 but arcs are not really flat, therefore 0.4 is better is (almost) all cases
+	\foreach \x in {2,...,\ctikzvalof{bipoles/cutechoke/coils}}
+	{
+		\pgfpatharc{180}{0}{\pgf@circ@res@step and \pgf@circ@res@up}
+		\pgfpatharc{0}{-180}{\pgf@circ@res@other and -\pgf@circ@res@down}
+	}
+	\pgfpatharc{180}{0}{\pgf@circ@res@step and \pgf@circ@res@up}
+	\pgfsetbuttcap
+	\pgfsetbeveljoin
+	\pgfusepath{stroke}
+    
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}}}
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgfusepath{stroke}
+    
+    \ifpgf@circuit@bipole@twolines
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}+\ctikzvalof{bipoles/cutechoke/cstep}}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}+\ctikzvalof{bipoles/cutechoke/cstep}}}
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgfusepath{stroke}
+    \fi
+}
+
 %% variable cute inductor
 
 \pgfcircdeclarebipole{}{\ctikzvalof{bipoles/vcuteinductor/lower coil height}}{vcuteinductor}{\ctikzvalof{bipoles/vcuteinductor/height}}{\ctikzvalof{bipoles/vcuteinductor/width}}{

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -416,15 +416,15 @@
 	\pgfsetbeveljoin
 	\pgfusepath{stroke}
     
-    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}}}
-    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}\pgf@circ@res@up}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}\pgf@circ@res@up}}
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}*\ctikzvalof{bipoles/cutechoke/cthick}\pgfstartlinewidth}
     \pgfusepath{stroke}
     
     \ifpgf@circuit@bipole@twolines
-    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}+\ctikzvalof{bipoles/cutechoke/cstep}}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}+\ctikzvalof{bipoles/cutechoke/cstep}}}
-    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}\pgf@circ@res@up+\ctikzvalof{bipoles/cutechoke/cstep}\pgf@circ@res@up}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth+\ctikzvalof{bipoles/cutechoke/cdist}\pgf@circ@res@up+\ctikzvalof{bipoles/cutechoke/cstep}\pgf@circ@res@up}}
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}*\ctikzvalof{bipoles/cutechoke/cthick}\pgfstartlinewidth}
     \pgfusepath{stroke}
     \fi
 }

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -167,6 +167,7 @@
 \def\pgf@circ@europeaninductor@path#1{\pgf@circ@bipole@path{fullgeneric}{#1}}
 \def\pgf@circ@americaninductor@path#1{\pgf@circ@bipole@path{americaninductor}{#1}}
 \def\pgf@circ@cuteinductor@path#1{\pgf@circ@bipole@path{cuteinductor}{#1}}
+\def\pgf@circ@cutechoke@path#1{\pgf@circ@bipole@path{cutechoke}{#1}}
 \def\pgf@circ@inductor@path#1{%
 	\pgfextra{
 		\edef\pgf@circ@temp{\ctikzvalof{inductor}}%
@@ -326,6 +327,7 @@
 \compattikzset{gas filled surge arrester/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@gfsurgearrester@path, l=#1}}
 \compattikzset{american inductor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@americaninductor@path, l=#1}}
 \compattikzset{cute inductor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cuteinductor@path, l=#1}}
+\compattikzset{cute choke/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cutechoke@path, l=#1}}
 \compattikzset{european inductor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@europeaninductor@path, l=#1}}
 \compattikzset{variable inductor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@vinductor@path, l=#1}}
 \compattikzset{variable european inductor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@veuropeaninductor@path, l=#1}}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -685,6 +685,7 @@
 \pgf@circ@definetranspath{elmech}
 \pgf@circ@definetranspath{nmos}
 \pgf@circ@definetranspath{pmos}
+\pgf@circ@definetranspath{hemt}
 \pgf@circ@definetranspath{npn}
 \pgf@circ@definetranspath{pnp}
 \pgf@circ@definetranspath{nfet}

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1513,6 +1513,41 @@
 			\pgfusepath{draw,fill}		
 }
 
+%% HEMT FET Transistor
+\pgfcircdeclaretransistor{hemt}{}{%
+			\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/gate height}\pgf@circ@res@up}}
+
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
+			\pgfusepath{draw}
+			
+			\pgfscope
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base height}\pgf@circ@res@down}}
+			\pgfsetlinewidth{2\pgflinewidth}
+			\pgfusepath{draw}
+			\endpgfscope
+		
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/hemt/base width}\pgf@circ@res@left}
+				{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*.5*\pgflinewidth}{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfusepath{draw}
+}
+
 \long\def\drawfetcore#1{
 	\pgftransformationadjustments
 		%top connection


### PR DESCRIPTION
The [HEMT transistor](https://en.wikipedia.org/wiki/High-electron-mobility_transistor) (High-electron-mobility transistor) is a "quite new" type of transistor based on heterojunctions and 2DEG gases.
Since it is widely used in the RF field and is becoming popular also in the power electronics research field due to new GaN devices, I tried to implement that component also for circuitikz.
I hope it would be a good addition.

The RF choke is also quite used in RF and Power Electronics and, while could be done easily with the inductor, having a symbol I think would be useful.
I created the symbol with one (default) or two lines

Below is an example of all the symbol variants and aside an example of a circuit (class E inverter) using both HEMT and choke.
![hemt_choke](https://user-images.githubusercontent.com/2548281/28708508-cef77e28-737c-11e7-9c03-333920ccd596.png)
```latex
\begin{circuitikz}
\coordinate (Q1) at (0,0);
\node (HEMT) [hemt] at (Q1) {$Q_1$};
\node [above] at (HEMT.G) {$\mathrm{G}$};
\node [left] at (HEMT.D) {$\mathrm{D}$};
\node [left] at (HEMT.S) {$\mathrm{S}$};
\path [draw] (0,0) to [cute choke] (2,0);
\makeatletter
\pgf@circuit@bipole@twolinestrue
\makeatother
\path [draw] (2,0) to [cute choke] (2,2);
\end{circuitikz}
\begin{circuitikz}[scale=0.8, transform shape]
\coordinate (Vcc) at (0,3.5);
\coordinate (Gnd) at (0,0);
%
\node [vcc] at (Vcc) {$\mathrm{V_{cc}}$};
\node [ground] (Gnd) {};
\node (HEMT) [hemt, anchor=S] at (Gnd) {};
\node [left] at ($(HEMT) + (0.2,0)$) {$S$};
\node [above] at (HEMT.G) {$\mathrm{V_{g}}$};
%
\draw (Vcc) 
to [cute choke, l_=$L_c$] ($(HEMT.D) + (0,1)$) coordinate (Lc-)
to [short, i>_=$I_c$] ($(HEMT.D) + (0,0.5)$) coordinate (HEMT_D_node)
to [short, i>_=$i_{s}$, *-] (HEMT.D)
;
\draw (HEMT_D_node) 
to [short, -*] ++(0.8,0) coordinate (C1t)
to [short, i_>=$i_{1}$] ++(0,-0.5) ++(0,0.5)
to [C, n=C1, -*] (C1t |- Gnd)
to [short, -*] (Gnd)
;
\node at ($(C1) + (3mm,3mm)$) {$C_1$};
\draw (C1t)  to [short, i=$i_L$] ++(0.5,0)
to [C=$C_{L}$] ++(1,0)
to [L=$L_L$] ++(1,0) 
-- ++(0.5,0) coordinate (L3b)
to [R, l_=$R_L$] (L3b |- Gnd)
to (Gnd)
;
\draw (L3b |- Gnd) to [open, v_=$V_L$] (L3b);
\end{circuitikz}
```
