### PR TITLE
Added bidirectional diode drawing to bipoles.

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -363,7 +363,8 @@ Other miscellaneous resistor-like devices:
 	\circuititembip{empty photodiode}{Empty photodiode}{pDo}
 	\circuititembip{empty led}{Empty led}{leDo}
 	\circuititembip{empty varcap}{Empty varcap}{VCo}
-	\circuititembip{full diode}{Full diode}{D*}
+        \circuititembip{empty bidirectionaldiode}{Empty bidirectionaldiode}{biDo}
+        \circuititembip{full diode}{Full diode}{D*}
 	\circuititembip{full Schottky diode}{Full Schottky diode}{sD*}
 	\circuititembip{full Zener diode}{Full Zener diode}{zD*}
 	\circuititembip{full ZZener diode}{Full ZZener diode}{zzD*}
@@ -371,7 +372,8 @@ Other miscellaneous resistor-like devices:
 	\circuititembip{full photodiode}{Full photodiode}{pD*}
 	\circuititembip{full led}{Full led}{leD*}
 	\circuititembip{full varcap}{Full varcap}{VC*}
-	\circuititembip{stroke diode}{Stroke diode}{D-}
+        \circuititembip{full bidirectionaldiode}{Full bidirectionaldiode}{biD*}
+        \circuititembip{stroke diode}{Stroke diode}{D-}
 	\circuititembip{stroke Schottky diode}{Stroke Schottky diode}{sD-}
 	\circuititembip{stroke Zener diode}{Stroke Zener diode}{zD-}
 	\circuititembip{stroke ZZener diode}{Stroke ZZener diode}{zzD-}

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -284,6 +284,10 @@
 	\ctikzset{bipoles/fullgeneric/width/.initial=.6}
 	\ctikzset{bipoles/diode/height/.initial=.3}
 	\ctikzset{bipoles/diode/width/.initial=.25}
+        \ctikzset{bipoles/bidirectionaldiode/height/.initial=.66}
+        \ctikzset{bipoles/bidirectionaldiode/width/.initial=.6}
+        \ctikzset{bipoles/bidirectionaldiode/diode width left/.initial=.3}
+        \ctikzset{bipoles/bidirectionaldiode/diode width right/.initial=.3}
 	
 	\ctikzset{tripoles/thyristor/height/.initial=.66}
 	\ctikzset{tripoles/thyristor/height 2/.initial=.3}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -206,6 +206,10 @@
 \ctikzset{bipoles/battery2/width/.initial=.3}
 \ctikzset{bipoles/diode/height/.initial=.50}
 \ctikzset{bipoles/diode/width/.initial=.40}
+\ctikzset{bipoles/bidirectionaldiode/height/.initial=1.1}
+\ctikzset{bipoles/bidirectionaldiode/width/.initial=1}
+\ctikzset{bipoles/bidirectionaldiode/diode width left/.initial=.3}
+\ctikzset{bipoles/bidirectionaldiode/diode width right/.initial=.3}
 \ctikzset{bipoles/varcap/height/.initial=.50}
 \ctikzset{bipoles/varcap/width/.initial=.45}
 \ctikzset{bipoles/spst/height/.initial=.35}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1273,6 +1273,75 @@
 	\pgfusepath{draw}
 }
 
+%% Empty bidirectionaldiode
+
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/bidirectionaldiode/height}}{emptybidirectionaldiode}{\ctikzvalof{bipoles/bidirectionaldiode/height}}{\ctikzvalof{bipoles/bidirectionaldiode/width}}
+{
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+
+        \pgf@circ@res@other = \ctikzvalof{bipoles/bidirectionaldiode/diode width left}\pgf@circ@res@left
+        \pgf@circ@res@step = \ctikzvalof{bipoles/bidirectionaldiode/diode width right}\pgf@circ@res@right
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+	\pgfpathlineto{\pgfpoint{0.95\pgf@circ@res@step}{0.707*(\pgf@circ@res@other-\pgf@circ@res@step)}} % sqrt(1/2)
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+	\pgfpathlineto{\pgfpoint{0.95\pgf@circ@res@other}{-0.707*(\pgf@circ@res@other-\pgf@circ@res@step)}} % sqrt(1/2)
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{-1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	
+	\pgfusepath{draw}
+	
+	\pgfsetlinewidth{\pgfstartlinewidth}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+	
+	\pgfusepath{draw}
+	
+}
+
+
+%% Full bidirectionaldiode
+
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/bidirectionaldiode/height}}{fullbidirectionaldiode}{\ctikzvalof{bipoles/bidirectionaldiode/height}}{\ctikzvalof{bipoles/bidirectionaldiode/width}}
+{
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+
+        \pgf@circ@res@other = \ctikzvalof{bipoles/bidirectionaldiode/diode width left}\pgf@circ@res@left
+        \pgf@circ@res@step = \ctikzvalof{bipoles/bidirectionaldiode/diode width right}\pgf@circ@res@right
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+	\pgfpathlineto{\pgfpoint{0.95\pgf@circ@res@step}{0.707*(\pgf@circ@res@other-\pgf@circ@res@step)}} % sqrt(1/2)
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+	\pgfpathlineto{\pgfpoint{0.95\pgf@circ@res@other}{-0.707*(\pgf@circ@res@other-\pgf@circ@res@step)}} % sqrt(1/2)
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{-1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{1.414*(\pgf@circ@res@other-\pgf@circ@res@step)}}
+	
+	\pgfusepath{draw, fill}
+	
+	\pgfsetlinewidth{\pgfstartlinewidth}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+	
+	\pgfusepath{draw}
+	
+}
+
 %% (Closing) SPST
 \pgfcircdeclarebipole{}{\ctikzvalof{bipoles/spst/depth}}{cspst}{\ctikzvalof{bipoles/spst/height}}{\ctikzvalof{bipoles/spst/width}}{
 	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -405,6 +405,7 @@
 \def\pgf@circ@fulllediode@path#1{\pgf@circ@bipole@path{fulllediode}{#1}}
 \def\pgf@circ@fullpdiode@path#1{\pgf@circ@bipole@path{fullpdiode}{#1}}
 \def\pgf@circ@fullvarcap@path#1{\pgf@circ@bipole@path{fullvarcap}{#1}}
+\def\pgf@circ@fullbidirectionaldiode@path#1{\pgf@circ@bipole@path{fullbidirectionaldiode}{#1}}
 \def\pgf@circ@emptydiode@path#1{\pgf@circ@bipole@path{emptydiode}{#1}}
 \def\pgf@circ@emptyzdiode@path#1{\pgf@circ@bipole@path{emptyzdiode}{#1}}
 \def\pgf@circ@emptyzzdiode@path#1{\pgf@circ@bipole@path{emptyzzdiode}{#1}}
@@ -413,6 +414,7 @@
 \def\pgf@circ@emptylediode@path#1{\pgf@circ@bipole@path{emptylediode}{#1}}
 \def\pgf@circ@emptypdiode@path#1{\pgf@circ@bipole@path{emptypdiode}{#1}}
 \def\pgf@circ@emptyvarcap@path#1{\pgf@circ@bipole@path{emptyvarcap}{#1}}
+\def\pgf@circ@emptybidirectionaldiode@path#1{\pgf@circ@bipole@path{emptybidirectionaldiode}{#1}}
 
 \compattikzset{full diode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fulldiode@path}}
 \compattikzset{full Schottky diode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullsdiode@path}}
@@ -422,6 +424,7 @@
 \compattikzset{full photodiode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullpdiode@path}}
 \compattikzset{full led/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fulllediode@path}}
 \compattikzset{full varcap/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullvarcap@path}}
+\compattikzset{full bidirectionaldiode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullbidirectionaldiode@path}}
 \compattikzset{full thyristor/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullthyristor@path}}
 \compattikzset{full triac/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@fulltriac@path}}
 
@@ -433,6 +436,7 @@
 \compattikzset{empty photodiode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptypdiode@path}}
 \compattikzset{empty led/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptylediode@path}}
 \compattikzset{empty varcap/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptyvarcap@path}}
+\compattikzset{empty bidirectionaldiode/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptybidirectionaldiode@path}}
 \compattikzset{empty thyristor/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptythyristor@path}}
 \compattikzset{empty triac/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@emptytriac@path}}
 
@@ -459,6 +463,7 @@
 \compattikzset{diode/.style = {\comnpatname \pgfcircdiodestylemacro diode}}
 \compattikzset{thyristor/.style =  {\comnpatname \pgfcircdiodestylemacro thyristor}}
 \compattikzset{triac/.style =  {\comnpatname \ifpgf@circuit@fulldiode full \else empty \fi triac}}%no stroke triac!
+\compattikzset{bidirectionaldiode/.style =  {\comnpatname \ifpgf@circuit@fulldiode full \else empty \fi bidirectionaldiode}}%no stroke bidirectionaldiode! (based on triac)
 
 %% Define Shortcuts
 \compattikzset{Do/.style = {\comnpatname empty diode}}
@@ -469,6 +474,7 @@
 \compattikzset{pDo/.style = {\comnpatname empty photodiode}}
 \compattikzset{leDo/.style = {\comnpatname empty led}}
 \compattikzset{VCo/.style = {\comnpatname empty varcap}}
+\compattikzset{biDo/.style = {\comnpatname empty bidirectionaldiode}}
 \compattikzset{Tyo/.style = {\comnpatname empty thyristor}}
 \compattikzset{Tro/.style = {\comnpatname empty triac}}
 
@@ -480,6 +486,7 @@
 \compattikzset{pD*/.style = {\comnpatname full photodiode}}
 \compattikzset{leD*/.style = {\comnpatname full led}}
 \compattikzset{VC*/.style = {\comnpatname full varcap}}
+\compattikzset{biD*/.style = {\comnpatname full bidirectionaldiode}}
 \compattikzset{Ty*/.style = {\comnpatname full thyristor}}
 \compattikzset{Tr*/.style = {\comnpatname full triac}}
 
@@ -491,6 +498,7 @@
 \compattikzset{pD/.style = {\comnpatname photodiode}}
 \compattikzset{leD/.style = {\comnpatname led}}
 \compattikzset{VC/.style = {\comnpatname varcap}}
+\compattikzset{biD/.style = {\comnpatname bidirectionaldiode}}
 \compattikzset{Ty/.style = {\comnpatname thyristor}}
 \compattikzset{Tr/.style = {\comnpatname triac}}
 
@@ -504,6 +512,7 @@
 \compattikzset{VC-/.style = {\comnpatname stroke varcap}}
 \compattikzset{Ty-/.style = {\comnpatname stroke thyristor}}
 \compattikzset{Tr-/.style = {\comnpatname empty triac}}%no stroke triac!
+\compattikzset{biD-/.style = {\comnpatname empty bidirectionaldiode}}%no stroke bidirectionaldiode! (based on triac)
 
 % % % % % %
 % % End of Diodes


### PR DESCRIPTION
Added drawings for empty and full bidirectional diodes (DIAC).
Both are based on Triac drawing, removing the gate terminal.
Tested only as standalone files, not after incorporation. 