### PR TITLE
Update circuitikz.sty

### DIFF
--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -18,11 +18,29 @@
 
 %% Version 3.0 of pgf/TikZ is required
 \RequirePackage{tikz}
+\RequirePackage{bm}
 \usetikzlibrary{calc}
-\usepgflibrary{arrows}
+\usepgflibrary{arrows}			% Deprecated, but still needed for the latex' style.
+\usetikzlibrary{arrows.meta}
 
 
 % The options are listed in the manual in this order
+
+\DeclareOption{europeanmeters}{
+	\ctikzset{meter=european}
+}
+
+\DeclareOption{roteuropeanmeters}{
+	\ctikzset{meter=roteuropean}
+}
+
+\DeclareOption{americanmeters}{
+	\ctikzset{meter=american}
+}
+
+\DeclareOption{rotamericanmeters}{
+	\ctikzset{meter=rotamerican}
+}
 
 \DeclareOption{europeanvoltage}{
 	\ctikzset{voltage=european}
@@ -273,6 +291,8 @@
 	\ctikzset{bipoles/generic potentiometer/width/.initial=.6}
 	\ctikzset{bipoles/ageneric/height/.initial=.23}
 	\ctikzset{bipoles/ageneric/width/.initial=.6}
+	\ctikzset{bipoles/bgeneric/height/.initial=.23}
+	\ctikzset{bipoles/bgeneric/width/.initial=.6}
 	\ctikzset{bipoles/memristor/height/.initial=.23}
 	\ctikzset{bipoles/memristor/wave height/.initial=.375}
 	\ctikzset{bipoles/memristor/width/.initial=.60}
@@ -313,9 +333,14 @@
 \input pgfcirccurrent.tex
 \input pgfcircflow.tex
 
-\ExecuteOptions{nofetbodydiode,nofetsolderdot,nooldvoltagedirection,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility}
+\ExecuteOptions{nofetbodydiode,nofetsolderdot,nooldvoltagedirection,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility,rotamericanmeters}
 
 \ProcessOptions\relax
+
+% Latex specific
+\ctikzset{mathbold/.initial=\bm}
+\ctikzset{textbold/.initial=\bfseries}
+%
 
 \input pgfcircpath.tex
 


### PR DESCRIPTION
First of all, a big thank you to all the contributors of this fantastic project! I was so happy with it, that I spent some time to understand it, and then I made some changes, when I thought it could be better suited for my needs or improve it (it may have solved a few bugs, also). Part of this work may be useful to other users, so here is the result.




CIRCUITIKZ.STY and T-CIRCUITIKZ.TEX

- bm package needed for the ohmmeter: $\bm \Omega$ (the compatibility with context [$\bf \Omega$] was easier to implement with \bm than with \boldmath, cf. following comment).
- The "mathbold" key is \bm in Latex and \bf in Context. The "textbold" key is \bfseries in Latex and \bf in Context. This allows us to use bold characters in Context as well.
- arrows.meta (N.B. needed for the voltage arrow shape). arrows is deprecated, but still needed for the latex' style.
- options for ammeter, voltmeter, ohmmeter, etc.
    \usepackage[europeanmeters]{circuitikz} or "european meters" or "meter=european": symbol without arrow, with the letter vertically oriented.
    \usepackage[roteuropeanmeters]{circuitikz} or "rotated european meters" or "meter=roteuropean": symbol without arrow, with the letter oriented in the same direction as the bipole.
    \usepackage[americanmeters]{circuitikz} or "american meters" or "meter=american": symbol with an arrow, with the letter vertically oriented.
    \usepackage[rotamericanmeters]{circuitikz} or "rotated american meters" or "meter=rotamerican": symbol with an arrow, with the letter oriented in the same direction as the bipole (default).


PGFCIRCPATH.TEX (see pgfcirc.defines.tex for other bipoles)

- The following bipoles are defined, accordingly to what written before: american ammeter, rotated american ammeter, european ammeter, rotated european ammeter, ammeter [default=rotated american ammeter]; similarly for voltmeters; similarly for ohmmeters. american meter, rotated american meter, european meter, meter [default=rotated american meter]: same as ammeter, but without the "A" letter inside [any other letter can be then defined with inl and rotinl, see pgfcirc.defines.tex].


PGFCIRC.DEFINES.TEX

- bipoles/arrow size: size factor for the current and voltage arrow tips (default=1). The arrow tip size is now completely independent on \pgf@circ@Rlen: before that, it scaled with this parameter and the arrows were far too small when I used small bipoles (bipole/length=.7cm for instance).
- arrow color: color of the current and voltage arrows.

- oswitch and cswitch: some cute open and closed switches.
- bgeneric: oval generic bipole.

- meter corresponds to the general shapes and parameters for ammeter, voltmeter, etc.
    - inl: writes some text inside a bipole (vertically oriented).
    - rotinl: same as before, but oriented in the same direction as the bipole.
    - rotinladd: adds this value to the orientation angle of "inl" and "rotinl" (rotinladd=180 is very useful if the label appears upside down).
    - inlsize: text size (\small, \large, etc. in Latex or \smaller [better than \tfx whose behavior seems strange in math mode], \bigger, \tfa, \tfb, etc. in Context). N.B. more generally, anything that is wished before "inl" and "rotinl" can be written in "inlsize" (\it, \textcolor, normal text...).
    - bipoles/meter/inlsize: same as before, but only for meter, ammeter, etc.
N.B. All these keys can be also used for meter, ammeter, etc.
    - (\pgf@circuit@europeanmeter and \pgf@circuit@inl are used for ammeter etc. settings).

- \pgf@circuit@bipole@isvoltage@usualarrow: default is false, i.e. the voltage arrow of a voltage source is drawn differently (shorter) than the voltage arrow of any other bipole.
    - "is voltage usual arrow" or "bipole/is voltage/usual arrow = true" to set it true.
    - "is voltage source arrow" or "bipole/is voltage/usual arrow = false" to set it false.

- bump angle (along with bump angle a and bump angle b): sets the "angle" for the voltage arrow of a voltage source (decrease this angle and increase "bump a" in order to have a longer arrow).

- "straight voltages" sets the straightvoltages option and "curved voltages" unsets it [cf. "\tikzset{european currents/.style = { \circuitikzbasekey/current = european } }" syntax].

- voltage/straight label distance (not to be confused with bipoles/voltage/straight label distance, that would correspond to the distance of the straight voltage arrow to the bipole): distance of the label to the arrow, in "\pgf@circ@Rlen /4" units (1 roughly corresponds to 10pt if \pgf@circ@Rlen=1.4cm) [default=.25].

- current/labelshift: shifts the current label (useful if the label is too close to a bipole) [1 should correspond to the height of the bipole].


PGFCIRCLABEL.TEX

- \def\pgf@circ@labanctext{\pgf@circ@labanc}: prevents error when angles are not close to 90 or 0 (\pgf@circ@labanctext was not defined). It should solve a bug in the \pgf@circ@drawreglabels macro.


PGFCIRCMONOPOLES.TEX

- eground and eground2: other shapes for ground (in european style).


COLOR SETTINGS

The behavior of the color option depends on where "color=..." is written (this peculiarity did not change).
(0,0) to[color=red,R,etc.] (2,0): bipole and labels are red.
(0,0) to[R,color=red,etc.] (2,0): bipole only is red.
(0,0) to[color=red,R,color=green,etc.] (2,0): bipole is green and labels are red.
The default color of the arrow is the same as the path color (cf. \draw[color=...]), but it can now be separately set to another color, with the "arrow color" option:
(0,0) to[color=red,R,color=green,arrow color=blue,etc.] (2,0).


PFDCIRCSHAPES.TEX AND PGFCIRCVOLTAGE.TEX
In order to separate the voltage arrow color from the path color, I included the arrows as nodes. I had then to create node shapes for the voltage arrows: "vstraight" for a straight voltage arrow and "vcurved" for the other kind. I had to create an arrow tip shape as well with \pgfdeclarearrow: "voltarr" (it was easy then to have the correct orientation for the arrow tip).


PGFCIRCUTILS.TEX

\pgf@circ@ifpgfkeyempty: like "pgf@circ@ifkeyempty", but without \pgfextra (I used it to set the color of the current and voltage arrows [in pgfcircshapes.tex], when this one has been defined).

