### PR TITLE
Add files via upload

### DIFF
--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -18,11 +18,29 @@
 
 %% Version 3.0 of pgf/TikZ is required
 \RequirePackage{tikz}
+\RequirePackage{bm}
 \usetikzlibrary{calc}
-\usepgflibrary{arrows}
+\usepgflibrary{arrows}			% Deprecated, but still needed for the latex' style.
+\usetikzlibrary{arrows.meta}
 
 
 % The options are listed in the manual in this order
+
+\DeclareOption{europeanmeters}{
+	\ctikzset{meter=european}
+}
+
+\DeclareOption{roteuropeanmeters}{
+	\ctikzset{meter=roteuropean}
+}
+
+\DeclareOption{americanmeters}{
+	\ctikzset{meter=american}
+}
+
+\DeclareOption{rotamericanmeters}{
+	\ctikzset{meter=rotamerican}
+}
 
 \DeclareOption{europeanvoltage}{
 	\ctikzset{voltage=european}
@@ -273,6 +291,8 @@
 	\ctikzset{bipoles/generic potentiometer/width/.initial=.6}
 	\ctikzset{bipoles/ageneric/height/.initial=.23}
 	\ctikzset{bipoles/ageneric/width/.initial=.6}
+	\ctikzset{bipoles/bgeneric/height/.initial=.23}
+	\ctikzset{bipoles/bgeneric/width/.initial=.6}
 	\ctikzset{bipoles/memristor/height/.initial=.23}
 	\ctikzset{bipoles/memristor/wave height/.initial=.375}
 	\ctikzset{bipoles/memristor/width/.initial=.60}
@@ -313,9 +333,14 @@
 \input pgfcirccurrent.tex
 \input pgfcircflow.tex
 
-\ExecuteOptions{nofetbodydiode,nofetsolderdot,nooldvoltagedirection,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility}
+\ExecuteOptions{nofetbodydiode,nofetsolderdot,nooldvoltagedirection,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility,rotamericanmeters}
 
 \ProcessOptions\relax
+
+% Latex specific
+\ctikzset{mathbold/.initial=\bm}
+\ctikzset{textbold/.initial=\bfseries}
+%
 
 \input pgfcircpath.tex
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -65,6 +65,7 @@
 \newdimen\pgf@circ@Rlen 
 \ctikzset{bipoles/length/.code={\pgf@circ@Rlen = #1}}
 \pgf@circ@Rlen = 1.4cm
+\ctikzset{bipoles/arrow size/.initial=1}
 
 \ctikzset{monopoles/.is family}
 \ctikzset{monopoles/ground/width/.initial=.25}
@@ -215,6 +216,10 @@
 \ctikzset{bipoles/nos/width/.initial=.35}
 \ctikzset{bipoles/ncs/height/.initial=.35}
 \ctikzset{bipoles/ncs/width/.initial=.35}
+\ctikzset{bipoles/oswitch/height/.initial=.35}
+\ctikzset{bipoles/oswitch/width/.initial=.35}
+\ctikzset{bipoles/cswitch/height/.initial=.2}
+\ctikzset{bipoles/cswitch/width/.initial=.35}
 \ctikzset{bipoles/generic/height/.initial=.30}
 \ctikzset{bipoles/generic/width/.initial=.80}
 \ctikzset{bipoles/european gas filled surge arrester/height/.initial=.30}
@@ -235,6 +240,8 @@
 \ctikzset{bipoles/generic potentiometer/width/.initial=.80}
 \ctikzset{bipoles/ageneric/height/.initial=.30}
 \ctikzset{bipoles/ageneric/width/.initial=.80}
+\ctikzset{bipoles/bgeneric/height/.initial=.30}
+\ctikzset{bipoles/bgeneric/width/.initial=.80}
 \ctikzset{bipoles/memristor/height/.initial=.30}
 \ctikzset{bipoles/memristor/wave height/.initial=.5}
 \ctikzset{bipoles/memristor/width/.initial=.80}
@@ -258,6 +265,13 @@
 \ctikzset{bipoles/ohmmeter/width/.initial=.60}
 \ctikzset{bipoles/voltmeter/height/.initial=.60}
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
+\ctikzset{bipoles/meter/height/.initial=.60}
+\ctikzset{bipoles/meter/width/.initial=.60}
+\ctikzset{bipoles/meter/inlsize/.initial=}		% Can be \small, \large, etc. in Latex or \smaller [better than \tfx whose behavior seems strange in math mode], \bigger, \tfa, \tfb, etc. in Context.
+\ctikzset{inl/.initial=}
+\ctikzset{rotinl/.initial=}
+\ctikzset{rotinladd/.initial=0}
+\ctikzset{inlsize/.initial=}
 \ctikzset{bipoles/buffer/height/.initial=1}
 \ctikzset{bipoles/buffer/width/.initial=1}
 \ctikzset{bipoles/not port/width/.initial=1}
@@ -788,6 +802,9 @@
 \ctikzset{bipole/name/.initial = }
 \newif\ifpgf@circuit@bipole@isvoltage
 \ctikzset{bipole/is voltage/.is if=pgf@circuit@bipole@isvoltage}
+\newif\ifpgf@circuit@bipole@isvoltage@usualarrow
+\pgf@circuit@bipole@isvoltage@usualarrowfalse
+\ctikzset{bipole/is voltage/usual arrow/.is if=pgf@circuit@bipole@isvoltage@usualarrow}
 \newif\ifpgf@circuit@bipole@voltageoutsideofsymbol
 \ctikzset{bipole/is voltageoutsideofsymbol/.is if=pgf@circuit@bipole@voltageoutsideofsymbol}
 \newif\ifpgf@circuit@bipole@strokedsymbol
@@ -868,6 +885,17 @@
 
 
 
+% ammeter, voltmeter, etc. settings.
+\newif\ifpgf@circuit@europeanmeter
+\newif\ifpgf@circuit@inl
+\pgf@circuit@europeanmeterfalse	% default is then americanmeter.
+\pgf@circuit@inlfalse			% default is then rotinl.
+\ctikzset{meter/.is choice}
+\ctikzset{meter/european/.code = \pgf@circuit@europeanmetertrue\pgf@circuit@inltrue}
+\ctikzset{meter/roteuropean/.code = \pgf@circuit@europeanmetertrue\pgf@circuit@inlfalse}
+\ctikzset{meter/american/.code = \pgf@circuit@europeanmeterfalse\pgf@circuit@inltrue}
+\ctikzset{meter/rotamerican/.code = \pgf@circuit@europeanmeterfalse\pgf@circuit@inlfalse}
+
 \newif\ifpgf@circuit@europeanresistor
 \ctikzset{resistor/.is choice}
 \ctikzset{resistor/american/.code = \pgf@circuit@europeanresistorfalse }
@@ -894,6 +922,7 @@
 
 \ctikzset{thickness/.initial=2}
 \ctikzset{color/.initial=black}
+\ctikzset{arrow color/.initial=}
 \pgfkeys{/tikz/color/.add code={}{\ctikzset{color={#1}}}}
 
 
@@ -905,14 +934,20 @@
 \ctikzset{straight/true/.code = {\pgf@circuit@bipole@voltage@straighttrue}}
 \ctikzset{straight/false/.code = {\pgf@circuit@bipole@voltage@straightfalse}}
 \ctikzset{straightvoltage/.style = {/tikz/circuitikz/straight=true}}
+\tikzset{straight voltages/.style = { \circuitikzbasekey/straight = true } }
+\tikzset{curved voltages/.style = { \circuitikzbasekey/straight = false } }
 \newif\ifpgf@circuit@bipole@voltage@straight
 \ctikzset{bipole/straight/.is if=pgf@circuit@bipole@voltage@straight}
+\ctikzset{voltage/straight label distance/.initial=.25}		% Distance from the arrow, in \pgf@circ@Rlen /4 units (1 roughly correponds to 10pt if \pgf@circ@Rlen=1.4cm).
 
 
 \ctikzset{voltage/.is family}
 \ctikzset{voltage/distance from node/.initial=.5} %\pgf@circ@Rlen units
 \ctikzset{voltage/distance from line/.initial=.08} % pos, tra 0 e 1
 \ctikzset{voltage/bump a/.initial=1.2}
+\ctikzset{voltage/bump angle a/.initial=60}
+\ctikzset{voltage/bump angle b/.initial=120}
+\ctikzset{voltage/bump angle/.code={\pgfmathsubtract{180}{#1} \pgfkeysalso{\circuitikzbasekey/voltage/bump angle a=#1,\circuitikzbasekey/voltage/bump angle b/.expanded=\pgfmathresult}}}			% Sets the "angle" for the voltage arrow of a voltage source (decrease this angle and increase "bump a" in order to have a longer arrow).
 \ctikzset{voltage/bump b/.initial=1.5}
 \ctikzset{voltage/european label distance/.initial=1.4}
 \ctikzset{voltage/american label distance/.initial=1.1}
@@ -926,6 +961,9 @@
 \ctikzset{bipoles/ageneric/voltage/distance from node/.initial=.4}
 \ctikzset{bipoles/ageneric/voltage/bump b/.initial=2}
 \ctikzset{bipoles/ageneric/voltage/european label distance/.initial=1.8}
+\ctikzset{bipoles/bgeneric/voltage/distance from node/.initial=.4}
+\ctikzset{bipoles/bgeneric/voltage/bump b/.initial=2}
+\ctikzset{bipoles/bgeneric/voltage/european label distance/.initial=1.8}
 \ctikzset{bipoles/fullgeneric/voltage/distance from node/.initial=.4}
 \ctikzset{bipoles/fullgeneric/voltage/bump b/.initial=2}
 \ctikzset{bipoles/fullgeneric/voltage/european label distance/.initial=1.8}
@@ -951,7 +989,15 @@
 
 \ctikzset{current/.is family}
 \ctikzset{current/distance/.initial = .5}
+\ctikzset{current/labelshift/.initial=0}
 
+\tikzset{american meters/.style = { \circuitikzbasekey/meter = american } }
+\tikzset{rotated american meters/.style = { \circuitikzbasekey/meter = rotamerican } }
+\tikzset{european meters/.style = { \circuitikzbasekey/meter = european } }
+\tikzset{rotated european meters/.style = { \circuitikzbasekey/meter = roteuropean } }
+
+\tikzset{is voltage usual arrow/.style = { \circuitikzbasekey/bipole/is voltage/usual arrow = true } }		% Usual voltage arrow for voltage sources.
+\tikzset{is voltage source arrow/.style = { \circuitikzbasekey/bipole/is voltage/usual arrow = false } }	% Default voltage arrow for voltage sources (a small one).
 
 \tikzset{american currents/.style = { \circuitikzbasekey/current = american } }
 \tikzset{european currents/.style = { \circuitikzbasekey/current = european } }

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1327,6 +1327,36 @@
 	\pgfusepath{draw}
 }
 
+%% Cute open Switch
+\pgfcircdeclarebipole{}{0}{oswitch}{\ctikzvalof{bipoles/oswitch/height}}{\ctikzvalof{bipoles/oswitch/width}}{
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	\pgfpathlineto{\pgfpoint{.9\pgf@circ@res@right}{\pgf@circ@res@up}}
+		\pgfsetroundcap
+	\pgfusepath{draw}
+
+	\pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	\pgfnode{circ}{center}{}{}{\pgfusepath{draw}}
+	\pgftransformshift{\pgfpoint{2\pgf@circ@res@right}{0pt}}
+	\pgfnode{circ}{center}{}{}{\pgfusepath{draw}}
+}
+
+%% Cute closed Switch
+\pgfcircdeclarebipole{}{0}{cswitch}{\ctikzvalof{bipoles/cswitch/height}}{\ctikzvalof{bipoles/cswitch/width}}{
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	\pgfpathlineto{\pgfpoint{1.1\pgf@circ@res@right}{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth+\pgfkeysvalueof{/tikz/circuitikz/nodes width}*\pgf@circ@Rlen}}
+		\pgfsetroundcap
+	\pgfusepath{draw}
+
+	\pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+	\pgfnode{circ}{center}{}{}{\pgfusepath{draw}}
+	\pgftransformshift{\pgfpoint{2\pgf@circ@res@right}{0pt}}
+	\pgfnode{circ}{center}{}{}{\pgfusepath{draw}}
+}
+
 %% Push Button
 \pgfcircdeclarebipole{}{\ctikzvalof{bipoles/pushbutton/height 2}}{pushbutton}{\ctikzvalof{bipoles/pushbutton/height}}{\ctikzvalof{bipoles/pushbutton/width}}{
 	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
@@ -1342,7 +1372,7 @@
 	\pgfnode{ocirc}{center}{}{}{\pgfusepath{draw}}
 }
 
-% % METERINGSHAPE
+% % METERINGSHAPE WITHOUT ARROW
 \long\def\drawmeteringcircle{
 	\def\pgf@circ@temp{right}
 	\ifx\tikz@res@label@pos\pgf@circ@temp
@@ -1367,7 +1397,10 @@
 		\pgfpathcircle{\pgfpointorigin}{.9\pgf@circ@res@up}
 		\pgfusepath{draw}
 	\endpgfscope
-	%draw arrow
+}
+
+% % ARROW FOR METERINGSHAPE
+\long\def\drawmeteringarrow{
 	\pgfscope
 		\pgfsetarrowsend{latex}
 		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
@@ -1375,21 +1408,21 @@
 		\pgfusepath{draw}
 	\endpgfscope
 }
-%AMPEREMETER
-\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/ammeter/height}}{ammeter}{\ctikzvalof{bipoles/ammeter/height}}{\ctikzvalof{bipoles/ammeter/width}}{
+
+% METER (with arrow, default)
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/meter/height}}{rotamericanmeter}{\ctikzvalof{bipoles/meter/height}}{\ctikzvalof{bipoles/meter/width}}{
 	\drawmeteringcircle
-	\pgfnode{circle}{center}{\textbf{A}}{}{}
+	\drawmeteringarrow
 }
-%OHMMETER
-\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/ohmmeter/height}}{ohmmeter}{\ctikzvalof{bipoles/ohmmeter/height}}{\ctikzvalof{bipoles/ohmmeter/width}}{
+% METER (without arrow)
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/meter/height}}{europeanmeter}{\ctikzvalof{bipoles/meter/height}}{\ctikzvalof{bipoles/meter/width}}{
 	\drawmeteringcircle
-	\pgfnode{circle}{center}{\boldmath$\Omega$}{}{}
 }
-%VOLTMETER
-\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/voltmeter/height}}{voltmeter}{\ctikzvalof{bipoles/voltmeter/height}}{\ctikzvalof{bipoles/voltmeter/width}}{
+% METER (with arrow, and "vertically" oriented bipole)
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/meter/height}}{americanmeter}{\ctikzvalof{bipoles/meter/height}}{\ctikzvalof{bipoles/meter/width}}{
 	\drawmeteringcircle
-	\pgfnode{circle}{center}{\textbf{V}}{}{}
-		
+	\pgftransformrotate{-\pgf@circ@direction}
+	\drawmeteringarrow
 }
 
 %% Short circuit
@@ -1410,6 +1443,17 @@
 		%\divide \pgf@circ@res@step by 14
 
 		\pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+					
+		\pgfusepath{draw} 
+}
+
+
+%% Generic bipole - oval
+
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/bgeneric/height}}{bgeneric}{\ctikzvalof{bipoles/bgeneric/height}}{\ctikzvalof{bipoles/bgeneric/width}}{
+
+		\pgfpathellipse{\pgfpointorigin}{\pgfpoint{\pgf@circ@res@right}{0cm}}{\pgfpoint{0cm}{\pgf@circ@res@up}}
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
 					
 		\pgfusepath{draw} 

--- a/tex/pgfcirccurrent.tex
+++ b/tex/pgfcirccurrent.tex
@@ -192,8 +192,8 @@
 				\edef\pgf@circ@ffffff{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}
 				}
 		\fi
-	coordinate[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff](Iarrow)
-	(Iarrow.\pgf@circ@bipole@current@label@where) node[anchor=\pgf@circ@dir]{\pgf@circ@finallabels{current/label}}
+	node[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff](Iarrow){}
+	($(Iarrow.\pgf@circ@bipole@current@label@where)+\ctikzvalof{current/labelshift}*(\ctikzvalof{bipole/name}.\pgf@circ@bipole@current@label@where)-\ctikzvalof{current/labelshift}*(\ctikzvalof{bipole/name}.center)$) node[anchor=\pgf@circ@dir, inner sep=4pt]{\pgf@circ@finallabels{current/label}}
 }
 
 \endinput

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -177,6 +177,7 @@
 	%Use mid-anchor at x-axis and base-anchor at y-axis, respectively.
 	%All points between will be addressed by angled-anchors:
 	\pgfextra{
+		\def\pgf@circ@labanctext{\pgf@circ@labanc}
 		\pgfmathadd{\pgf@circ@labanc}{90}
 		\edef\pgf@circ@temp{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}
 		\pgfmathparse{mod(\pgf@circ@temp,180)>135?mod(\pgf@circ@temp,180)-180:mod(\pgf@circ@temp,180)}

--- a/tex/pgfcircmonopoles.tex
+++ b/tex/pgfcircmonopoles.tex
@@ -12,6 +12,83 @@
 
 %% Ground symbol
 
+\pgfdeclareshape{eground}{
+	\anchor{center}{
+		\pgfpointorigin
+	}
+	\behindforegroundpath{		
+		\pgf@circ@res@step=\ctikzvalof{monopoles/ground/width}\pgf@circ@Rlen
+		
+		\pgfscope		
+			\pgfpathmoveto{\pgfpointorigin}
+			\pgfpathlineto{\pgfpoint{0pt}{-\pgf@circ@res@step}}
+			\pgfusepath{draw}
+
+			\pgfstartlinewidth=\pgflinewidth
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/monopoles/tground/thickness}\pgfstartlinewidth}
+
+			\pgfpathmoveto{\pgfpoint{-1\pgf@circ@res@step}{-\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{1\pgf@circ@res@step}{-\pgf@circ@res@step}}
+			\pgfusepath{draw}
+						
+			\pgfsetlinewidth{\pgfstartlinewidth}
+			\pgfpathmoveto{\pgfpoint{-1.1\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{-.6\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfpathmoveto{\pgfpoint{-.6\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{-.1\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfpathmoveto{\pgfpoint{-.1\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{.9\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfusepath{draw}
+		
+			
+			\pgfsetlinewidth{\pgfstartlinewidth}
+	
+		\endpgfscope
+	}
+
+}
+
+\pgfdeclareshape{eground2}{
+	\anchor{center}{
+		\pgfpointorigin
+	}
+	\behindforegroundpath{		
+		\pgf@circ@res@step=\ctikzvalof{monopoles/ground/width}\pgf@circ@Rlen
+		
+		\pgfscope		
+			\pgfpathmoveto{\pgfpointorigin}
+			\pgfpathlineto{\pgfpoint{0pt}{-\pgf@circ@res@step}}
+			\pgfusepath{draw}
+
+			\pgfstartlinewidth=\pgflinewidth
+			\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/monopoles/tground/thickness}\pgfstartlinewidth}
+
+			\pgfpathmoveto{\pgfpoint{-1\pgf@circ@res@step}{-\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{1\pgf@circ@res@step}{-\pgf@circ@res@step}}
+			\pgfusepath{draw}
+						
+			\pgfsetlinewidth{\pgfstartlinewidth}
+			\pgfpathmoveto{\pgfpoint{-1.1\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfpathmoveto{\pgfpoint{-.45\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{.25\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@step}{-1.7\pgf@circ@res@step}}
+			\pgfpathlineto{\pgfpoint{.9\pgf@circ@res@step}{-1\pgf@circ@res@step}}
+			\pgfusepath{draw}
+		
+			
+			\pgfsetlinewidth{\pgfstartlinewidth}
+	
+		\endpgfscope
+	}
+
+}
+
+
+
+
 \pgfdeclareshape{ground}{
   \anchor{center}{
     \pgfpointorigin

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -91,6 +91,8 @@
 		--($(\ctikzvalof{bipole/name}start) ! .5\pgflinewidth ! (\ctikzvalof{bipole/name}end)$) %ugly workaround to get correct linejoins(node breaks path?)
 	\fi
 		($(\tikztostart) ! .5 ! (\tikztotarget)$)%%positio of middle node 
+		\pgf@circ@ifkeyempty{inl}\else node[inner sep=0pt,rotate=\ctikzvalof{rotinladd}]{\ctikzvalof{inlsize}\ctikzvalof{inl}} \fi
+		\pgf@circ@ifkeyempty{rotinl}\else node[inner sep=0pt,rotate=\pgf@circ@direction+\ctikzvalof{rotinladd}]{\ctikzvalof{inlsize}\ctikzvalof{rotinl}} \fi
 		node[#1shape, rotate=\pgf@circ@direction, yscale=\ctikzvalof{mirror value}, xscale=\ctikzvalof{invert value}] 
 			(\ctikzvalof{bipole/name}) {}
 			\ifpgf@circuit@bipole@inverted
@@ -228,16 +230,18 @@
 \def\pgf@circ@ospst@path#1{\pgf@circ@bipole@path{ospst}{#1}}
 \def\pgf@circ@nos@path#1{\pgf@circ@bipole@path{nos}{#1}}
 \def\pgf@circ@ncs@path#1{\pgf@circ@bipole@path{ncs}{#1}}
+\def\pgf@circ@oswitch@path#1{\pgf@circ@bipole@path{oswitch}{#1}}
+\def\pgf@circ@cswitch@path#1{\pgf@circ@bipole@path{cswitch}{#1}}
 \def\pgf@circ@pushbutton@path#1{\pgf@circ@bipole@path{pushbutton}{#1}}
 \def\pgf@circ@open@path#1{\pgf@circ@bipole@path{open}{#1}}
 \def\pgf@circ@generic@path#1{\pgf@circ@bipole@path{generic}{#1}}
 \def\pgf@circ@ageneric@path#1{\pgf@circ@bipole@path{ageneric}{#1}}
+\def\pgf@circ@bgeneric@path#1{\pgf@circ@bipole@path{bgeneric}{#1}}
 \def\pgf@circ@tgeneric@path#1{\pgf@circ@bipole@path{tgeneric}{#1}}
 \def\pgf@circ@fullgeneric@path#1{\pgf@circ@bipole@path{fullgeneric}{#1}}
 \def\pgf@circ@tfullgeneric@path#1{\pgf@circ@bipole@path{tfullgeneric}{#1}}
-\def\pgf@circ@ammeter@path#1{\pgf@circ@bipole@path{ammeter}{#1}}
-\def\pgf@circ@ohmmeter@path#1{\pgf@circ@bipole@path{ohmmeter}{#1}}
-\def\pgf@circ@voltmeter@path#1{\pgf@circ@bipole@path{voltmeter}{#1}}
+\def\pgf@circ@meter@letter{\ifpgf@circuit@inl inl\else rotinl\fi}
+\def\pgf@circ@meter@path#1{\ifpgf@circuit@europeanmeter\pgf@circ@bipole@path{europeanmeter}{#1}\else\ifpgf@circuit@inl\pgf@circ@bipole@path{americanmeter}{#1}\else\pgf@circ@bipole@path{rotamericanmeter}{#1}\fi\fi}
 \def\pgf@circ@empty@path#1{}
 \def\pgf@circ@photoresistor@path#1{\pgf@circ@bipole@path{photoresistor}{#1}}
 \def\pgf@circ@emptythyristor@path#1{\pgf@circ@bipole@path{emptythyristor}{#1}}
@@ -359,6 +363,7 @@
 
 \compattikzset{generic/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@generic@path, l=#1}}
 \compattikzset{ageneric/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ageneric@path, l=#1}}
+\compattikzset{bgeneric/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@bgeneric@path, l=#1}}
 \compattikzset{tgeneric/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@tgeneric@path, l=#1}}
 \compattikzset{fullgeneric/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@fullgeneric@path, l=#1}}
 \compattikzset{tfullgeneric/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@tfullgeneric@path, l=#1}}
@@ -515,15 +520,36 @@
 \compattikzset{opening switch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ospst@path, l=#1}}
 \compattikzset{ncs/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ncs@path, l=#1}}
 \compattikzset{nos/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@nos@path, l=#1}}
+\compattikzset{cswitch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cswitch@path, l=#1}}
+\compattikzset{oswitch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@oswitch@path, l=#1}}
 \compattikzset{normal closed switch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ncs@path, l=#1}}
 \compattikzset{normal open switch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@nos@path, l=#1}}
 \compattikzset{switch/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cspst@path, l=#1}}
 \compattikzset{push button/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@pushbutton@path, l=#1}}
 \compattikzset{toggle switch/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@toggleswitch@path}}
 
-\compattikzset{ammeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ammeter@path}}
-\compattikzset{voltmeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@voltmeter@path}}
-\compattikzset{ohmmeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ohmmeter@path}}
+\compattikzset{american ammeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ammeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ammeter/width}, /tikz/to path=\pgf@circ@bipole@path{americanmeter},inl={\ctikzvalof{textbold}A},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated american ammeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ammeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ammeter/width}, /tikz/to path=\pgf@circ@bipole@path{rotamericanmeter},rotinl={\ctikzvalof{textbold}A},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{european ammeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ammeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ammeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},inl={\ctikzvalof{textbold}A},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated european ammeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ammeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ammeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},rotinl={\ctikzvalof{textbold}A},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{ammeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ammeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ammeter/width}, /tikz/to path=\pgf@circ@meter@path,\pgf@circ@meter@letter={\ctikzvalof{textbold}A},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+
+\compattikzset{american voltmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/voltmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/voltmeter/width}, /tikz/to path=\pgf@circ@bipole@path{americanmeter},inl={\ctikzvalof{textbold}V},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated american voltmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/voltmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/voltmeter/width}, /tikz/to path=\pgf@circ@bipole@path{rotamericanmeter},rotinl={\ctikzvalof{textbold}V},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{european voltmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/voltmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/voltmeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},inl={\ctikzvalof{textbold}V},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated european voltmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/voltmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/voltmeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},rotinl={\ctikzvalof{textbold}V},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{voltmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/voltmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/voltmeter/width}, /tikz/to path=\pgf@circ@meter@path,\pgf@circ@meter@letter={\ctikzvalof{textbold}V},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+
+\compattikzset{american ohmmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ohmmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ohmmeter/width}, /tikz/to path=\pgf@circ@bipole@path{americanmeter},inl=$\ctikzvalof{mathbold}\Omega$,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated american ohmmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ohmmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ohmmeter/width}, /tikz/to path=\pgf@circ@bipole@path{rotamericanmeter},rotinl=$\ctikzvalof{mathbold}\Omega$,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{european ohmmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ohmmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ohmmeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},inl=$\ctikzvalof{mathbold}\Omega$,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated european ohmmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ohmmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ohmmeter/width}, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},rotinl=$\ctikzvalof{mathbold}\Omega$,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{ohmmeter/.style = {\circuitikzbasekey, bipoles/meter/height=\ctikzvalof{bipoles/ohmmeter/height},bipoles/meter/width=\ctikzvalof{bipoles/ohmmeter/width}, /tikz/to path=\pgf@circ@meter@path,\pgf@circ@meter@letter=$\ctikzvalof{mathbold}\Omega$,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+
+\compattikzset{american meter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@bipole@path{americanmeter},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{rotated american meter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@bipole@path{rotamericanmeter},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{european meter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@bipole@path{europeanmeter},inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
+\compattikzset{meter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@meter@path,inlsize=\ctikzvalof{bipoles/meter/inlsize}}}
 
 % short forms
 \compattikzset{esource/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@esource@path, \circuitikzbasekey/bipole/is voltage=true,\circuitikzbasekey/bipole/is voltageoutsideofsymbol=true,  v=#1}}

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -145,28 +145,108 @@
 	}
 		\anchor{tip}{
 		\pgfpointorigin
-			\pgf@circ@res@step = \pgf@circ@Rlen
-				\divide \pgf@circ@res@step by 16
+		\pgfmathsetlength{\pgf@circ@res@step}{\ctikzvalof{bipoles/arrow size}/16*1.4cm}
 		\pgf@x	=\pgf@circ@res@step
 		}
 	\behindforegroundpath{		
 		
 		\pgfscope
-			\pgf@circ@res@step = \pgf@circ@Rlen
-			\divide \pgf@circ@res@step by 16
-
+			\pgfmathsetlength{\pgf@circ@res@step}{\ctikzvalof{bipoles/arrow size}/16*1.4cm}
 			\pgfpathmoveto{\pgfpoint{-.7\pgf@circ@res@step}{0pt}}
 			\pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{-.8\pgf@circ@res@step}}
 			\pgfpathlineto{\pgfpoint{1\pgf@circ@res@step}{0pt}}
 			\pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{.8\pgf@circ@res@step}}
 			\pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{0pt}}			
-			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}
+			\pgf@circ@ifpgfkeyempty{arrow color} \else \pgfsetcolor{\ctikzvalof{arrow color}} \fi		% Sets the arrow color if this one has been defined.
 			\pgfusepath{draw,fill}
 
 		\endpgfscope
 	}
 
 }
+
+%% Voltage arrow, straight style
+
+\pgfdeclareshape{vstraight}{
+	\anchor{center}{
+		\pgfpointorigin
+	}
+	\behindforegroundpath{		
+		\pgfscope
+			\pgfmathsetlength{\pgf@circ@res@step}{\ctikzvalof{bipoles/arrow size}/16*1.4cm}
+			\pgfpathmoveto{\pgfpointorigin}
+			\ifpgf@circuit@bipole@voltage@backward
+				\pgfpathlineto{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vfrom}{center}}{\pgfpointanchor{pgfcirc@Vto}{center}}}
+			\else
+				\pgfpathlineto{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vto}{center}}{\pgfpointanchor{pgfcirc@Vfrom}{center}}}
+			\fi
+			\pgf@circ@ifpgfkeyempty{arrow color} \else \pgfsetcolor{\ctikzvalof{arrow color}} \fi		% Sets the arrow color if this one has been defined.
+			\pgfsetarrowsstart{voltarr[length=\ctikzvalof{bipoles/arrow size}/16*1.4cm]}	
+			\ifpgf@circuit@bipole@isvoltage
+				\ifpgf@circuit@bipole@isvoltage@usualarrow
+				\else
+					\pgfsetshortenstart{-\pgf@circ@res@step}	
+				\fi
+			\fi
+			\pgfusepath{draw}
+		\endpgfscope
+	}
+}
+
+%% Voltage arrow, curved style
+
+\pgfdeclareshape{vcurved}{
+	\anchor{center}{
+		\pgfpointorigin
+	}
+	\behindforegroundpath{		
+		\pgfscope
+			\pgfmathsetlength{\pgf@circ@res@step}{\ctikzvalof{bipoles/arrow size}/16*1.4cm}
+			\pgfpathmoveto{\pgfpointorigin}
+			\ifpgf@circuit@bipole@voltage@backward
+				\pgfpathcurveto{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vfrom}{center}}{\pgfpointanchor{pgfcirc@Vcont1}{center}}}{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vfrom}{center}}{\pgfpointanchor{pgfcirc@Vcont2}{center}}}{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vfrom}{center}}{\pgfpointanchor{pgfcirc@Vto}{center}}}
+			\else
+				\pgfpathcurveto{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vto}{center}}{\pgfpointanchor{pgfcirc@Vcont2}{center}}}{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vto}{center}}{\pgfpointanchor{pgfcirc@Vcont1}{center}}}{\pgfpointdiff{\pgfpointanchor{pgfcirc@Vto}{center}}{\pgfpointanchor{pgfcirc@Vfrom}{center}}}
+			\fi
+			\pgf@circ@ifpgfkeyempty{arrow color} \else \pgfsetcolor{\ctikzvalof{arrow color}} \fi		% Sets the arrow color if this one has been defined.
+			\pgfsetarrowsstart{voltarr[length=\ctikzvalof{bipoles/arrow size}/16*1.4cm]}	
+			\pgfsetshortenstart{-\pgf@circ@res@step}	
+			\pgfusepath{draw}
+		\endpgfscope
+	}
+}
+
+
+%% Voltage arrow tip
+
+\pgfdeclarearrow{
+name = voltarr,
+parameters = { \the\pgfarrowlength },
+setup code = {
+			% The different end values:
+			\pgfarrowssettipend{1\pgfarrowlength}
+			\pgfarrowssetlineend{0\pgfarrowlength}
+			\pgfarrowssetvisualbackend{-.7\pgfarrowlength}
+			\pgfarrowssetbackend{-.7\pgfarrowlength}
+			% The hull
+			\pgfarrowshullpoint{1\pgfarrowlength}{0pt}
+			\pgfarrowshullpoint{-.7\pgfarrowlength}{.8\pgfarrowlength}
+			\pgfarrowshullpoint{-.7\pgfarrowlength}{-.8\pgfarrowlength}
+			% Saves: Only the length:
+			\pgfarrowssavethe\pgfarrowlength
+},
+drawing code = {
+			\pgfpathmoveto{\pgfqpoint{-.7\pgfarrowlength}{0pt}}
+			\pgfpathlineto{\pgfqpoint{-.7\pgfarrowlength}{-.8\pgfarrowlength}}
+			\pgfpathlineto{\pgfqpoint{1\pgfarrowlength}{0pt}}
+			\pgfpathlineto{\pgfqpoint{-.7\pgfarrowlength}{.8\pgfarrowlength}}
+			\pgfpathclose
+			\pgfusepathqfillstroke
+},
+defaults = { length = 2pt }
+}
+
+
 
 %% Flow arrow
 

--- a/tex/pgfcircutils.tex
+++ b/tex/pgfcircutils.tex
@@ -52,6 +52,12 @@
 	\ifx\pgf@circ@temp\pgf@temp
 }
 
+\def\pgf@circ@ifpgfkeyempty#1{
+	\ctikzset{#1/.get=\pgf@circ@temp}
+	\edef\pgf@temp{}
+	\ifx\pgf@circ@temp\pgf@temp
+}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%    Math routines
 

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -179,19 +179,15 @@
 	\ifpgf@circuit@europeanvoltage
 		\ifpgf@circuit@bipole@voltage@straight
 			\ifpgf@circuit@bipole@voltage@backward
-				(pgfcirc@Vto) --(pgfcirc@Vfrom) node[currarrow, sloped,  allow upside down, pos=1,anchor=tip] {}
+				(pgfcirc@Vfrom) node[vstraight]{}
 			\else
-				(pgfcirc@Vfrom) --(pgfcirc@Vto) node[currarrow, sloped,  allow upside down, pos=1,anchor=tip] {}
+				(pgfcirc@Vto) node[vstraight]{}
 			\fi
 		\else
 			\ifpgf@circuit@bipole@voltage@backward
-				(pgfcirc@Vto) .. controls (pgfcirc@Vcont2)  and (pgfcirc@Vcont1) ..
-					node[currarrow, sloped,  allow upside down, pos=1] {}
-				(pgfcirc@Vfrom)
+				(pgfcirc@Vfrom) node[vcurved]{}
 			\else
-				(pgfcirc@Vfrom) .. controls (pgfcirc@Vcont1)  and (pgfcirc@Vcont2) ..
-					node[currarrow, sloped,  allow upside down, pos=1] {}
-				(pgfcirc@Vto)
+				(pgfcirc@Vto) node[vcurved]{}
 			\fi
 		\fi
 	\else
@@ -218,17 +214,17 @@
 %% Output routine for voltage sources
 \def\pgf@circ@drawvoltagegenerator{
 	\ifpgf@circuit@bipole@voltage@below
-		coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-120)$)
-		coordinate (pgfcirc@Vto) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-60)$)
+		coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-\ctikzvalof{voltage/bump angle b})$)
+		coordinate (pgfcirc@Vto) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-\ctikzvalof{voltage/bump angle a})$)
 	\else
-		coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.120)$)
-		coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.60)$)
+		coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.\ctikzvalof{voltage/bump angle b})$)
+		coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.\ctikzvalof{voltage/bump angle a})$)
 	\fi
 	\ifpgf@circuit@europeanvoltage
 		\ifpgf@circuit@bipole@voltage@backward
-			(pgfcirc@Vto)  -- node[currarrow, sloped,  allow upside down, pos=1] {} (pgfcirc@Vfrom)
+			(pgfcirc@Vfrom) node[vstraight]{}
 		\else
-			(pgfcirc@Vfrom)  -- node[currarrow, sloped,  allow upside down, pos=1] {} (pgfcirc@Vto)
+			(pgfcirc@Vto) node[vstraight]{}
 		\fi
 	\else% american voltage
 		\ifpgf@circuit@bipole@voltageoutsideofsymbol
@@ -334,14 +330,29 @@
 	}%end pgfextra
 
 		\ifpgf@circuit@bipole@isvoltage
-			\pgf@circ@drawvoltagegenerator
+			\ifpgf@circuit@bipole@isvoltage@usualarrow
+				\pgf@circ@drawvoltagegeneric
+			\else
+				\pgf@circ@drawvoltagegenerator
+			\fi
 		\else
 			\pgf@circ@drawvoltagegeneric
 		\fi
 
 	%	(\ctikzvalof{bipole/name}.\pgf@circ@bipole@voltage@label@where) %Zeile sinnlos!?
 		\ifpgf@circuit@bipole@voltage@straight
-			coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
+			coordinate (Vlab) at ($(\ctikzvalof{bipole/name}.center) !
+				\ifpgf@circuit@bipole@isvoltage
+					\ifpgf@circuit@bipole@isvoltage@usualarrow
+						\ctikzvalof{voltage/straight label distance}*\pgf@circ@Rlen/4+\distfromline
+					\else
+						\eudist
+					\fi
+				\else
+					\ctikzvalof{voltage/straight label distance}*\pgf@circ@Rlen/4+\distfromline
+				\fi !
+				(\ctikzvalof{bipole/name}.\pgf@circ@bipole@voltage@label@where)$)
+%			coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
 			node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt]
 					  at (Vlab) { \pgf@circ@finallabels{voltage/label} }
 		\else

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -7,6 +7,7 @@
 \startmodule[circuitikz]
 \usetikzlibrary[calc]
 \usetikzlibrary[arrows]
+\usetikzlibrary[arrows.meta]
 
 \unprotect
 
@@ -118,6 +119,10 @@
 % Context specific
 
 \ctikzset{tripoles/op amp/font/.initial=\switchtobodyfont[small]}
+% Context specific
+\ctikzset{mathbold/.initial=\bf}
+\ctikzset{textbold/.initial=\bf}
+%
 
 \input pgfcircpath.tex
 


### PR DESCRIPTION
First of all, a big thank you to all the contributors of this fantastic project! I was so happy with it, that I spent some time to understand it, and then I made some changes, when I thought it could be better suited for my needs or improve it (it may have solved a few bugs, also). Part of this work may be useful to other users, so here is the result.




CIRCUITIKZ.STY and T-CIRCUITIKZ.TEX

- bm package needed for the ohmmeter: $\bm \Omega$ (the compatibility with context [$\bf \Omega$] was easier to implement with \bm than with \boldmath, cf. following comment).
- The "mathbold" key is \bm in Latex and \bf in Context. The "textbold" key is \bfseries in Latex and \bf in Context. This allows us to use bold characters in Context as well.
- arrows.meta (N.B. needed for the voltage arrow shape). arrows is deprecated, but still needed for the latex' style.
- options for ammeter, voltmeter, ohmmeter, etc.
    \usepackage[europeanmeters]{circuitikz} or "european meters" or "meter=european": symbol without arrow, with the letter vertically oriented.
    \usepackage[roteuropeanmeters]{circuitikz} or "rotated european meters" or "meter=roteuropean": symbol without arrow, with the letter oriented in the same direction as the bipole.
    \usepackage[americanmeters]{circuitikz} or "american meters" or "meter=american": symbol with an arrow, with the letter vertically oriented.
    \usepackage[rotamericanmeters]{circuitikz} or "rotated american meters" or "meter=rotamerican": symbol with an arrow, with the letter oriented in the same direction as the bipole (default).


PGFCIRCPATH.TEX (see pgfcirc.defines.tex for other bipoles)

- The following bipoles are defined, accordingly to what written before: american ammeter, rotated american ammeter, european ammeter, rotated european ammeter, ammeter [default=rotated american ammeter]; similarly for voltmeters; similarly for ohmmeters. american meter, rotated american meter, european meter, meter [default=rotated american meter]: same as ammeter, but without the "A" letter inside [any other letter can be then defined with inl and rotinl, see pgfcirc.defines.tex].


PGFCIRC.DEFINES.TEX

- bipoles/arrow size: size factor for the current and voltage arrow tips (default=1). The arrow tip size is now completely independent on \pgf@circ@Rlen: before that, it scaled with this parameter and the arrows were far too small when I used small bipoles (bipole/length=.7cm for instance).
- arrow color: color of the current and voltage arrows.

- oswitch and cswitch: some cute open and closed switches.
- bgeneric: oval generic bipole.

- meter corresponds to the general shapes and parameters for ammeter, voltmeter, etc.
    - inl: writes some text inside a bipole (vertically oriented).
    - rotinl: same as before, but oriented in the same direction as the bipole.
    - rotinladd: adds this value to the orientation angle of "inl" and "rotinl" (rotinladd=180 is very useful if the label appears upside down).
    - inlsize: text size (\small, \large, etc. in Latex or \smaller [better than \tfx whose behavior seems strange in math mode], \bigger, \tfa, \tfb, etc. in Context). N.B. more generally, anything that is wished before "inl" and "rotinl" can be written in "inlsize" (\it, \textcolor, normal text...).
    - bipoles/meter/inlsize: same as before, but only for meter, ammeter, etc.
N.B. All these keys can be also used for meter, ammeter, etc.
    - (\pgf@circuit@europeanmeter and \pgf@circuit@inl are used for ammeter etc. settings).

- \pgf@circuit@bipole@isvoltage@usualarrow: default is false, i.e. the voltage arrow of a voltage source is drawn differently (shorter) than the voltage arrow of any other bipole.
    - "is voltage usual arrow" or "bipole/is voltage/usual arrow = true" to set it true.
    - "is voltage source arrow" or "bipole/is voltage/usual arrow = false" to set it false.

- bump angle (along with bump angle a and bump angle b): sets the "angle" for the voltage arrow of a voltage source (decrease this angle and increase "bump a" in order to have a longer arrow).

- "straight voltages" sets the straightvoltages option and "curved voltages" unsets it [cf. "\tikzset{european currents/.style = { \circuitikzbasekey/current = european } }" syntax].

- voltage/straight label distance (not to be confused with bipoles/voltage/straight label distance, that would correspond to the distance of the straight voltage arrow to the bipole): distance of the label to the arrow, in "\pgf@circ@Rlen /4" units (1 roughly corresponds to 10pt if \pgf@circ@Rlen=1.4cm) [default=.25].

- current/labelshift: shifts the current label (useful if the label is too close to a bipole) [1 should correspond to the height of the bipole].


PGFCIRCLABEL.TEX

- \def\pgf@circ@labanctext{\pgf@circ@labanc}: prevents error when angles are not close to 90 or 0 (\pgf@circ@labanctext was not defined). It should solve a bug in the \pgf@circ@drawreglabels macro.


PGFCIRCMONOPOLES.TEX

- eground and eground2: other shapes for ground (in european style).


COLOR SETTINGS

The behavior of the color option depends on where "color=..." is written (this peculiarity did not change).
(0,0) to[color=red,R,etc.] (2,0): bipole and labels are red.
(0,0) to[R,color=red,etc.] (2,0): bipole only is red.
(0,0) to[color=red,R,color=green,etc.] (2,0): bipole is green and labels are red.
The default color of the arrow is the same as the path color (cf. \draw[color=...]), but it can now be separately set to another color, with the "arrow color" option:
(0,0) to[color=red,R,color=green,arrow color=blue,etc.] (2,0).


PFDCIRCSHAPES.TEX AND PGFCIRCVOLTAGE.TEX
In order to separate the voltage arrow color from the path color, I included the arrows as nodes. I had then to create node shapes for the voltage arrows: "vstraight" for a straight voltage arrow and "vcurved" for the other kind. I had to create an arrow tip shape as well with \pgfdeclarearrow: "voltarr" (it was easy then to have the correct orientation for the arrow tip).


PGFCIRCUTILS.TEX

\pgf@circ@ifpgfkeyempty: like "pgf@circ@ifkeyempty", but without \pgfextra (I used it to set the color of the current and voltage arrows [in pgfcircshapes.tex], when this one has been defined).


HEREAFTER, AN EXAMPLE (.TEX AND .PDF) THAT SUMMARIZES THE NEW FEATURES.

```latex
\documentclass[12pt]{article}

\usepackage{tikz}

\usepackage[european,cuteinductors,straightvoltages,europeanmeters]{circuitikz}
	\tikzset{is voltage usual arrow}
	\ctikzset{bipoles/length=.72cm}
	\def\pgf@temp{.7}								% Meter height and width defaults were .60
	\ctikzset{bipoles/.cd,meter/width/.expanded=\pgf@temp, meter/height/.expanded=\pgf@temp, ammeter/width/.expanded=\pgf@temp, ammeter/height/.expanded=\pgf@temp, voltmeter/width/.expanded=\pgf@temp, voltmeter/height/.expanded=\pgf@temp, ohmmeter/width/.expanded=\pgf@temp, ohmmeter/height/.expanded=\pgf@temp}
	\ctikzset{bipoles/meter/inlsize=\footnotesize, inlsize=\tiny}
	\ctikzset{bipoles/arrow size=.86}			% Size of the current and voltage arrows (default is 1).
	\ctikzset{voltage/bump a=1.5}
	\ctikzset{voltage/bump angle=40}
	\ctikzset{monopoles/ground/width=.35}
	\def\pgf@temp{.5}
	\ctikzset{bipoles/.cd,oswitch/height/.initial=\pgf@temp, oswitch/width/.initial=\pgf@temp, cswitch/height/.initial=.2, cswitch/width/.initial=\pgf@temp}
	\tikzset{10pt/.style={\circuitikzbasekey/bipoles/length=.6cm}}
	\tikzset{12pt/.style={\circuitikzbasekey/bipoles/length=.72cm}}
	\tikzset{14pt/.style={\circuitikzbasekey/bipoles/length=.864cm}}


\begin{document}

\begin{tikzpicture}[12pt,color=black,x=1.5cm,y=1.5cm]
\draw (0,0) to[ammeter] ++(1,.5) to[rotated european ammeter] ++(1,.5) to[american ammeter] ++(1,.5) to[rotated american ammeter] ++(1,.5) to[meter] ++(1,.5) to[meter,inl=$\bm \alpha$] ++(1,.5) to[meter,rotinl=$\bm \beta$] ++(1,.5) to[rotated american ammeter] ++(.2,-1) to[rotated american ammeter,invert,rotinladd=90] ++(.2,-1) to [rotated european ammeter] ++(-1,-.5) to [rotated european ammeter,rotinladd=180] ++(-1,-.5) to[ammeter,inlsize=\large] ++(-1,-.5);
\draw[curved voltages] (0,-1) node[eground]{} to[oswitch] ++(1,0) to [cswitch] ++(1,0) to[bgeneric,v=$U$] ++(1,0) to[bgeneric,straight voltages,v=$U$,inl=$X$] ++(1,0) to[bgeneric,straight voltages,v=$U$,voltage/straight label distance=.5] ++(1,0) to[R,i=300 mA] ++(1.5,0) to[R,i=300 mA,current/labelshift=.6] ++(1.5,0);
\draw[circuitikz,monopoles/ground/width=.28] (0,-2) node[eground2]{} to[V,v_=$U$,*-*] ++(5,0) to[V,is voltage source arrow,v_=$U$,*-*] ++(5,0);
\draw[color=blue] (0,-3) to[color=red,R,v=$U$,i=$I$] ++(1.6,0) to[R,v=$U$,i=$I$,color=red] ++(1.6,0) to[color=red,R,v=$U$,i=$I$,arrow color=red] ++(1.6,0) to[R,v=$U$,i=$I$,color=red,arrow color=red] ++(1.6,0) to[color=red,R,v=$U$,i=$I$,color=green,arrow color=black] ++(1.6,0);

\end{tikzpicture}


\end{document}
```

[circuit_example.pdf](https://github.com/circuitikz/circuitikz/files/2531392/circuit_example.pdf)


