### PR TITLE
Compile manual using the current circuitikz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ manual-latex: changelog
 	rm -f doc/tmp.pdf
 	#cd doc;pdflatex compatibility.tex; pdflatex circuitikzmanual.tex; pdflatex circuitikzmanual.tex
 	#compile with xelatex for smaller filesize!
-	cd doc;xelatex $(XELATEXOPTIONS) compatibility.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
+	cd doc; TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) compatibility.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
 	#optimize for smaller filesize(faktor 2!)--> only useful if using pdflatex
 	#gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -sOutputFile=doc/tmp.pdf doc/circuitikzmanual.pdf
 	#mv doc/tmp.pdf doc/circuitikzmanual.pdf

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -856,7 +856,8 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
 \noindent The default orientation of labels is controlled by the options \texttt{smartlabels}, \texttt{rotatelabels} and \texttt{straightlabels} (or the corresponding \texttt{label/align} keys). Here are examples to see the differences:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
-\ctikzset{label/align = straight}
+% commented out, it does not compile in 0.8.3    
+% \ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
 \foreach \i in \DIR {
   \draw (0,0) to[R=\i, *-o] (\i:2.5);


### PR DESCRIPTION
This pull request contains:
1. a change so that the manual is compiled against the circuitikz.sty in the repository, and not the installed one (nice to check changes and adding docs at the same time) 
2. a hack to make the manual compilable (`label/align = straight` throws an error). 

