### PR TITLE
Move the "european voltages" away

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ manual-latex: changelog
 	rm -f doc/tmp.pdf
 	#cd doc;pdflatex compatibility.tex; pdflatex circuitikzmanual.tex; pdflatex circuitikzmanual.tex
 	#compile with xelatex for smaller filesize!
-	cd doc;xelatex $(XELATEXOPTIONS) compatibility.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
+	cd doc; TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) compatibility.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
 	#optimize for smaller filesize(faktor 2!)--> only useful if using pdflatex
 	#gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -sOutputFile=doc/tmp.pdf doc/circuitikzmanual.pdf
 	#mv doc/tmp.pdf doc/circuitikzmanual.pdf

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -856,8 +856,7 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
 \noindent The default orientation of labels is controlled by the options \texttt{smartlabels}, \texttt{rotatelabels} and \texttt{straightlabels} (or the corresponding \texttt{label/align} keys). Here are examples to see the differences:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
-% commented out, it does not compile in 0.8.3    
-% \ctikzset{label/align = straight}
+\ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
 \foreach \i in \DIR {
   \draw (0,0) to[R=\i, *-o] (\i:2.5);

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -15,7 +15,9 @@
 	%\setmainfont{Gentium Book Basic} 
 }
 
-\usepackage[siunitx]{circuitikz}
+\usepackage[siunitx, 
+    % oldvoltagedirection
+    ]{circuitikz}
 
 \usepackage{ifxetex,ifluatex}
 \ifxetex
@@ -1106,11 +1108,21 @@ See introduction note at Currents (chapter \ref{currents}, page \pageref{current
    \draw (0,0) to[I=$~$,l=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
 \end{LTXexample}
+
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
    \draw (0,0) to[I,l=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
 \end{LTXexample}	
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+
+
 
 \subsubsection{American style} For those who like it (not me). Use option \texttt{americanvoltage} or set \verb![american voltages]!.
 
@@ -1150,6 +1162,37 @@ See introduction note at Currents (chapter \ref{currents}, page \pageref{current
 \end{circuitikz}
 \end{LTXexample}
 
+\subsubsection{Voltage position} It is possible to move away the arrows and the plus or minus signs with the key \texttt{voltages shift} (default value is \texttt{0}, which gives the standard position):
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[]
+   \draw (0,0) to[R, v=$v_1$, i=$i_1$] (2,0);
+   \draw (0,-1) to[R, v=$v_1$, i=$i_1$, 
+      voltage shift=0.5] (2,-1);
+   \draw (0,-2) to[R, v=$v_1$, i=$i_1$, 
+      voltage shift=1.0, ] (2,-2);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[american voltages, voltage shift=0.5]
+   \draw (0,0) to[R, v=$v_1$, i=$i_1$] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+Notes that \texttt{american voltage} will not affect batteries (and that the default direction of \texttt{european voltages} is a bit strange).
+
+\begin{LTXexample}[varwidth=true]
+    \begin{circuitikz}[voltage shift=0.5]
+   \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[american voltages, voltage shift=0.5]
+   \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
+\end{circuitikz}
+\end{LTXexample}
 
 \subsection{Nodes}
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -856,7 +856,8 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
 \noindent The default orientation of labels is controlled by the options \texttt{smartlabels}, \texttt{rotatelabels} and \texttt{straightlabels} (or the corresponding \texttt{label/align} keys). Here are examples to see the differences:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
-\ctikzset{label/align = straight}
+% commented out, it does not compile in 0.8.3    
+% \ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
 \foreach \i in \DIR {
   \draw (0,0) to[R=\i, *-o] (\i:2.5);

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -914,6 +914,9 @@
 \ctikzset{voltage/distance from line/.initial=.08} % pos, tra 0 e 1
 \ctikzset{voltage/bump a/.initial=1.2}
 \ctikzset{voltage/bump b/.initial=1.5}
+\ctikzset{voltage/shift/.initial=0.0} % shift form the cable of voltage symbols
+\ctikzset{voltage shift/.style={voltage/shift=#1}}
+\tikzset{voltage shift/.style={\circuitikzbasekey/voltage/shift=#1}}
 \ctikzset{voltage/european label distance/.initial=1.4}
 \ctikzset{voltage/american label distance/.initial=1.1}
 % special cases

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -178,6 +178,7 @@
 	%All points between will be addressed by angled-anchors:
 	\pgfextra{
 		\pgfmathadd{\pgf@circ@labanc}{90}
+                \def\pgf@circ@labanctext{\pgf@circ@labanc}
 		\edef\pgf@circ@temp{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}
 		\pgfmathparse{mod(\pgf@circ@temp,180)>135?mod(\pgf@circ@temp,180)-180:mod(\pgf@circ@temp,180)}
 		\edef\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -157,6 +157,8 @@
 		\pgfkeysifdefined{\pgf@temp}
 			{ \edef\bumpb{\ctikzvalof{bipoles/\pgfkeysvalueof{/tikz/circuitikz/bipole/kind}/voltage/bump b}} }
 			{ \edef\bumpb{\ctikzvalof{voltage/bump b}} }
+                \edef\shiftv{\ctikzvalof{voltage/shift}}
+                \pgfmathsetmacro{\bumpb}{\bumpb + \shiftv} %% adjust the bump is shift
 	}
 	% %\pgf@circ@Rlen/16 is equal to the length of the currarrow
 	coordinate (pgfcirc@midtmp) at ($(\tikztostart) ! \pgf@circ@Rlen/16 ! (anchorstartnode)$) %absolute move, minimum space is length of arrowhead
@@ -169,9 +171,13 @@
 	coordinate (pgfcirc@Vto) at ($(pgfcirc@midtmp) ! \distfromline ! \pgf@circ@voltage@angle : (anchorendnode)$)
 
 	\ifpgf@circuit@bipole@voltage@below
+                coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto) ! \shiftv!90 :  (anchorendnode)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom) ! \shiftv!-90 :  (anchorstartnode)$)
 		coordinate (pgfcirc@Vcont1) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-110)$)
 		coordinate (pgfcirc@Vcont2) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-70)$)
 	\else
+                coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto) ! -\shiftv!90 :  (anchorendnode)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom) ! -\shiftv!-90 :  (anchorstartnode)$)
 		coordinate (pgfcirc@Vcont1) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.110)$)
 		coordinate (pgfcirc@Vcont2) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.70)$)
 	\fi
@@ -217,12 +223,19 @@
 
 %% Output routine for voltage sources
 \def\pgf@circ@drawvoltagegenerator{
+        % the following is affected indirectly by voltage/shift, you can move the arrow with voltage/bump a. 
+        % it's not perfect, but I can't find the way to do it correctly...
+        \pgfextra{
+            \edef\shiftv{\ctikzvalof{voltage/shift}}
+            \edef\bumpa{\ctikzvalof{voltage/bump a}}
+            \pgfmathsetmacro{\bumpaplus}{\bumpa + \shiftv}
+        }
 	\ifpgf@circuit@bipole@voltage@below
-		coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-120)$)
-		coordinate (pgfcirc@Vto) at ($(\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.-60)$)
+		coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-120)$)
+		coordinate (pgfcirc@Vto) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-60)$)
 	\else
-		coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.120)$)
-		coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \ctikzvalof{voltage/bump a} ! (\ctikzvalof{bipole/name}.60)$)
+		coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.120)$)
+		coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.60)$)
 	\fi
 	\ifpgf@circuit@europeanvoltage
 		\ifpgf@circuit@bipole@voltage@backward
@@ -314,6 +327,7 @@
 			\ifpgf@circuit@bipole@voltage@below
 				\pgf@circuit@bipole@voltage@belowfalse
 			\else
+
 				\pgf@circuit@bipole@voltage@belowtrue
 			\fi
 		\fi
@@ -329,6 +343,9 @@
 		\pgfkeysifdefined{\pgf@temp}
 			{ \edef\eudist{\ctikzvalof{bipoles/\pgfkeysvalueof{/tikz/circuitikz/bipole/kind}/voltage/european label distance}} }
 			{ \edef\eudist{\ctikzvalof{voltage/european label distance}} }
+                \edef\shiftv{\ctikzvalof{voltage/shift}}
+                % adjust the label distance to the shift. 
+                \pgfmathsetmacro{\eudistplus}{\eudist+\shiftv}
 
 	\pgfsetcornersarced{\pgfpointorigin}% do not use rounded corners!
 	}%end pgfextra
@@ -347,7 +364,7 @@
 		\else
 		coordinate (Vlab) at ($(\ctikzvalof{bipole/name}.center) !
 			\ifpgf@circuit@europeanvoltage
-				\eudist
+				\eudistplus
 			\else
 				\ctikzvalof{voltage/american label distance}
 			\fi !


### PR DESCRIPTION
Add a key to move the voltage a bit away from the component. This pull request touch the same code @fotesan, and will not easily merge, but it's possible to manually merge them together (I can have a shot at it if needed). 

![image](https://user-images.githubusercontent.com/6414907/47968867-d5eef880-e06f-11e8-854c-982356fc702e.png)
 