### PR TITLE
Added stacked labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ manual-latex: changelog
 	rm -f doc/tmp.pdf
 	#cd doc;pdflatex compatibility.tex; pdflatex circuitikzmanual.tex; pdflatex circuitikzmanual.tex
 	#compile with xelatex for smaller filesize!
-	cd doc;xelatex $(XELATEXOPTIONS) compatibility.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex; xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
+	cd doc; TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) compatibility.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex;  TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
 	#optimize for smaller filesize(faktor 2!)--> only useful if using pdflatex
 	#gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -sOutputFile=doc/tmp.pdf doc/circuitikzmanual.pdf
 	#mv doc/tmp.pdf doc/circuitikzmanual.pdf

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -856,8 +856,7 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
 \noindent The default orientation of labels is controlled by the options \texttt{smartlabels}, \texttt{rotatelabels} and \texttt{straightlabels} (or the corresponding \texttt{label/align} keys). Here are examples to see the differences:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
-% commented out, it does not compile in 0.8.3    
-% \ctikzset{label/align = straight}
+\ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
 \foreach \i in \DIR {
   \draw (0,0) to[R=\i, *-o] (\i:2.5);

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -880,7 +880,30 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
   \draw (0,0) to[R=\i, *-o] (\i:2.5);
 }
 \end{circuitikz}
-\end{LTXexample}	
+\end{LTXexample}
+
+You also can use stacked (two lines) labels.  The example should be self-explanatory: the two lines are specified as \texttt{l2=}\emph{line1}\texttt{ and }\emph{line2}. You can use the keys \texttt{l2 halign} to control horizontal position (\texttt{l}eft, \texttt{c}enter, \texttt{r}ight) and \texttt{l2 valign} to control the vertical one (\texttt{b}ottom, \texttt{c}center, \texttt{t}op).
+
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[ american, ]
+    %
+    % default is l2 halign=l, l2 valign=c
+    %
+    \begin{scope}[color=blue]
+        \draw (0,0) to[R, l2_=$R_{CC}$ and \SI{4.7}{k\ohm},            , l2 valign=t] (2,0);
+        \draw (0,0) to[R, l2_=$R_{CC}$ and \SI{4.7}{k\ohm},            ,            ] (0,2);
+        \draw (0,0) to[R, l2_=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=c, l2 valign=b] (-2,0);
+        \draw (0,0) to[R, l2_=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=r, l2 valign=c] (0, -2);
+    \end{scope}
+    \begin{scope}[yshift=-6cm, color=red]
+        \draw (0,0) to[R, l2^=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=c, l2 valign=b] (2,0);
+        \draw (0,0) to[R, l2^=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=c,            ] (0,2);
+        \draw (0,0) to[R, l2^=$R_{CC}$ and \SI{4.7}{k\ohm},            , l2 valign=t] (-2,0);
+        \draw (0,0) to[R, l2^=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=c, l2 valign=t](0, -3);
+    \end{scope}
+\end{circuitikz}
+\end{LTXexample}
 
 \subsection{Currents}\label{currents}
 The counting direction of currents and voltages have changed with version 0.5, for compability reasons there is a option to use the olddirections(see options). For the new scheme, the following rules apply:

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -856,7 +856,8 @@ The position of (a) and (l) labels can be adjusted with \_ and \^, respectively.
 \noindent The default orientation of labels is controlled by the options \texttt{smartlabels}, \texttt{rotatelabels} and \texttt{straightlabels} (or the corresponding \texttt{label/align} keys). Here are examples to see the differences:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
-\ctikzset{label/align = straight}
+% commented out, it does not compile in 0.8.3    
+% \ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
 \foreach \i in \DIR {
   \draw (0,0) to[R=\i, *-o] (\i:2.5);

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -178,6 +178,7 @@
 	%All points between will be addressed by angled-anchors:
 	\pgfextra{
 		\pgfmathadd{\pgf@circ@labanc}{90}
+                \def\pgf@circ@labanctext{\pgf@circ@labanc}
 		\edef\pgf@circ@temp{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}
 		\pgfmathparse{mod(\pgf@circ@temp,180)>135?mod(\pgf@circ@temp,180)-180:mod(\pgf@circ@temp,180)}
 		\edef\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -236,4 +236,35 @@
 \ctikzset{t/.code = { 
 	\ctikzsetvalof{bipoles/twoport/text}{#1}
 }}
+
+%%%% Stacked labels
+%%%% Original version by Claudio Fiandrino https://tex.stackexchange.com/a/65792/38080
+
+
+\ctikzset{lx/.code args={#1 and #2}{
+  \pgfkeys{/tikz/circuitikz/bipole/label/name=\parbox{1cm}{\centering #1  \\ #2}}
+    \ctikzsetvalof{bipole/label/unit}{}
+    \ifpgf@circ@siunitx
+        \pgf@circ@handleSI{#2}
+        \ifpgf@circ@siunitx@res
+            \edef\pgf@temp{\pgf@circ@handleSI@val}
+            \pgfkeyslet{/tikz/circuitikz/bipole/label/name}{\pgf@temp}
+            \edef\pgf@temp{\pgf@circ@handleSI@unit}
+            \pgfkeyslet{/tikz/circuitikz/bipole/label/unit}{\pgf@temp}
+        \else
+        \fi
+    \else
+    \fi
+}}
+
+\ctikzset{lx^/.style args={#1 and #2}{
+    lx=#2 and #1,
+    \circuitikzbasekey/bipole/label/position=90 }
+}
+
+\ctikzset{lx_/.style args={#1 and #2}{
+    lx=#1 and #2,
+    \circuitikzbasekey/bipole/label/position=-90 }
+}
+
 \endinput

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -238,11 +238,33 @@
 }}
 
 %%%% Stacked labels
-%%%% Original version by Claudio Fiandrino https://tex.stackexchange.com/a/65792/38080
-
-
-\ctikzset{lx/.code args={#1 and #2}{
-  \pgfkeys{/tikz/circuitikz/bipole/label/name=\parbox{1cm}{\centering #1  \\ #2}}
+%
+% stacked labels by Romano Giannetti romano@rgtti.com
+% heavil2 based on Claudo Fiandrinos's https://tex.stackexchange.com/a/65792/38080
+% \expandafter trick inspired by Matthew Leingang's https://tex.stackexchange.com/a/12272/38080
+%
+% labels are in a tabular, globally aligned:
+%        vertically with key l2 valign (default c)
+%        c: center t: top b: bottom
+%        horizontally with key l2 align (default l)
+%        l: left c: centered r: right
+% you can switch sides using l2_=... and l2^=...
+% syntax is l2_ = line1 and line2 (same for l2^)
+%
+\ctikzset{%
+    l2 valign/.store in=\ltwo@valign, l2 valign=c,
+    l2 halign/.store in=\ltwo@halign, l2 halign=l,
+}
+\ctikzset{l2/.code n args={2}{
+  \pgfkeys{/tikz/circuitikz/bipole/label/name=%
+        \bgroup
+        \setlength{\tabcolsep}{2pt}%
+        \def\ltwo@tabu{\tabular[\ltwo@valign]}%
+        \expandafter\ltwo@tabu\expandafter{\ltwo@halign}%
+        #1\\ #2%
+        \endtabular
+        \egroup
+    }%
     \ctikzsetvalof{bipole/label/unit}{}
     \ifpgf@circ@siunitx
         \pgf@circ@handleSI{#2}
@@ -256,14 +278,12 @@
     \else
     \fi
 }}
-
-\ctikzset{lx^/.style args={#1 and #2}{
-    lx=#2 and #1,
+\ctikzset{l2^/.style args={#1 and #2}{
+        l2={#1}{#2},
     \circuitikzbasekey/bipole/label/position=90 }
 }
-
-\ctikzset{lx_/.style args={#1 and #2}{
-    lx=#1 and #2,
+\ctikzset{l2_/.style args={#1 and #2}{
+        l2={#1}{#2},
     \circuitikzbasekey/bipole/label/position=-90 }
 }
 


### PR DESCRIPTION
Thanks to an idea from Claudio Fiandrino (see https://tex.stackexchange.com/a/65792/38080), adding two-lines labels (for name and value of the component). 

![image](https://user-images.githubusercontent.com/6414907/48228293-19fe3800-e3a5-11e8-81e5-476e058137e2.png)
