### PR TITLE
Sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Added new sources (cute european versions, noise sources) 
     - Added new types of amplifiers, and option to flip inputs and outputs
     - Added bidirectional diodes (diac) thanks to Andre Lucas Chinazzo 
+    - Added L,R,C sensors (with european, american and cute variants)
 
 * Version 0.8.3 (2017-05-28) 
 	- Removed unwanted lines at to-paths if the starting point is a node without a explicit anchor.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -347,6 +347,7 @@ Other miscellaneous resistor-like devices:
 	\circuititembip{phR}{Photoresistor}{photoresistor}
 	\circuititembip{thermocouple}{Thermocouple}{}
 	\circuititembip{thR}{Thermistor}{thermistor}
+	\circuititembip{sR}{Resistive sensor}{resistive sensor}
 	\circuititembip{thRp}{PTC thermistor}{thermistor ptc}
 	\circuititembip{thRn}{NTC thermistor}{thermistor ntc}
 	\circuititembip{fuse}{Fuse}{}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -330,6 +330,7 @@ If (default behaviour) \texttt{americanresistors} option is active (or the style
   	\circuititembip{R}{Resistor}{american resistor}
 	\circuititembip{vR}{Variable resistor}{variable american resistor}
 	\circuititembip{pR}{Potentiometer}{american potentiometer}
+	\circuititembip{sR}{Resisitive sensor}{american resisitive sensor}
 \end{itemize}
 
 If  instead \texttt{europeanresistors} option is active (or the style \texttt{[european resistors]} is used), the resistors, variable resistors and potentiometers are displayed as follows:
@@ -338,6 +339,7 @@ If  instead \texttt{europeanresistors} option is active (or the style \texttt{[e
   	\circuititembip{R}{Resistor}{european resistor}
 	\circuititembip{vR}{Variable resistor}{european variable resistor}
 	\circuititembip{pR}{Potentiometer}{european potentiometer}
+	\circuititembip{sR}{Resisitive sensor}{european resisitive sensor}
 	\ctikzset{resistor=american} % reset default
 \end{itemize}
 
@@ -347,7 +349,6 @@ Other miscellaneous resistor-like devices:
 	\circuititembip{phR}{Photoresistor}{photoresistor}
 	\circuititembip{thermocouple}{Thermocouple}{}
 	\circuititembip{thR}{Thermistor}{thermistor}
-	\circuititembip{sR}{Resistive sensor}{resistive sensor}
 	\circuititembip{thRp}{PTC thermistor}{thermistor ptc}
 	\circuititembip{thRn}{NTC thermistor}{thermistor ntc}
 	\circuititembip{fuse}{Fuse}{}
@@ -423,6 +424,7 @@ If otherwise \texttt{americangfsurgearrester} option is active (or the style \te
 	\circuititembip{polar capacitor}{Polar capacitor}{pC}
 	\circuititembip{ecapacitor}{Electrolytic capacitor}{eC,elko}
 	\circuititembip{variable capacitor}{Variable capacitor}{vC}
+	\circuititembip{capacitive sensor}{Capacitive sensor}{sC}
 	\circuititembip{piezoelectric}{Piezoelectric Element}{PZ}
 \end{itemize}	
 
@@ -430,8 +432,9 @@ If (default behaviour) \texttt{cuteinductors} option is active (or the style \te
 \begin{itemize}
   	\ctikzset{inductor=cute}
   	\circuititembip{L}{Inductor}{cute inductor}
-    \circuititembip{cute choke}{Choke}{}
+        \circuititembip{cute choke}{Choke}{}
 	\circuititembip{vL}{Variable inductor}{variable cute inductor}
+	\circuititembip{sL}{Inductive sensor}{cute inductive sensor}
 \end{itemize}
 
 If \texttt{americaninductors} option is active (or the style \texttt{[american inductors]} is used), the inductors are displayed as follows:
@@ -439,6 +442,7 @@ If \texttt{americaninductors} option is active (or the style \texttt{[american i
   	\ctikzset{inductor=american}
   	\circuititembip{L}{Inductor}{american inductor}
 	\circuititembip{vL}{Variable inductor}{variable american inductor}
+	\circuititembip{sL}{Inductive sensor}{american inductive sensor}
 \end{itemize}
 
 Finally, if \texttt{europeaninductors} option is active (or the style \texttt{[european inductors]} is used), the inductors are displayed as follows:
@@ -446,6 +450,8 @@ Finally, if \texttt{europeaninductors} option is active (or the style \texttt{[e
   	\ctikzset{inductor=european}
   	\circuititembip{L}{Inductor}{european inductor}
 	\circuititembip{vL}{Variable inductor}{variable european inductor}
+	\circuititembip{sL}{Inductive sensor}{european inductive sensor}
+        \ctikzset{inductor=cute} % back to default
 \end{itemize}
 
 There is also a transmission line: 
@@ -1556,6 +1562,19 @@ Since only bipoles (but see section~\ref{sec:transasbip}) can be placed "along a
 \subsection{Anchors}
 
 In order to allow connections with other components, all components define anchors. 
+
+\subsubsection{Sensors} generic sensors have an extra label to help positioning the type of dependence, if needed:
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,2) to[sR, l=$R$, name=mySR] ++(3,0);
+   \node [font=\tiny, right] at(mySR.label) {-t\si{\degree}};
+   \draw (0,0) to[sL, l=$L$, name=mySL] ++(3,0);
+   \node [draw, circle, inner sep=2pt] at(mySL.label) {};
+\end{circuitikz}
+\end{LTXexample}
+
+The anchor is positioned just on the corner of the segmented line crossing the component.
 
 \subsubsection{Logical ports} All logical ports, except \textsc{not}, have two inputs and one output. They are called respectively \texttt{in 1}, \texttt{in 2}, \texttt{out}:
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -303,6 +303,9 @@
 \ctikzset{bipoles/phaseshifter/width/.initial=.7}
 \ctikzset{bipoles/vphaseshifter/width/.initial=.7}
 \ctikzset{bipoles/detector/width/.initial=.7}
+% resistive sensor american style
+\ctikzset{bipoles/resistivesens/height/.initial=.6}
+\ctikzset{bipoles/resistivesens/width/.initial=.8}
 
 
 \newif\ifpgf@circuit@trans@depletiontype

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -3477,4 +3477,42 @@
 	
 }
 
+\pgfcircdeclarebipole
+{}
+{\ctikzvalof{bipoles/resistivesens/height}}
+{resistivesens}
+{\ctikzvalof{bipoles/resistivesens/height}}
+{\ctikzvalof{bipoles/resistivesens/width}}
+{%
+    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgftransformationadjustments
+    \pgfmathsetlength{\pgf@circ@res@step}{\ctikzvalof{bipoles/resistor/width}\pgf@circ@Rlen+\pgfhorizontaltransformationadjustment*0.5*\pgflinewidth}
+    \divide \pgf@circ@res@step by 12
 
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*0.5*\pgflinewidth}{\pgf@circ@res@zero}}
+
+    \pgf@circ@res@other = \pgf@circ@res@left
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@up}}
+    \advance\pgf@circ@res@other by 2\pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@down}}
+    \advance\pgf@circ@res@other by 2\pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@up}}
+    \advance\pgf@circ@res@other by 2\pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@down}}
+    \advance\pgf@circ@res@other by 2\pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@up}}
+    \advance\pgf@circ@res@other by 2\pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{.5\pgf@circ@res@down}}
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@zero}}
+    \pgfsetbeveljoin
+    \pgfusepath{draw}
+
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@other}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{-.9\pgf@circ@res@other}{\pgf@circ@res@down}}
+        \pgfusepath{draw}
+    \endpgfscope
+}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -252,8 +252,35 @@
 		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
 		\pgfusepath{draw}
+
 }
 
+%% Capacitive sensor 
+
+
+\pgfcircdeclarebipole{\anchor{label}{%
+        \southwest
+        \pgf@x=2.6\pgf@x
+        \pgf@y=1.4\pgf@y
+    }%
+    }{\ctikzvalof{bipoles/capacitor/height}}{capacitivesens}{\ctikzvalof{bipoles/capacitor/height}}{\ctikzvalof{bipoles/capacitor/width}}{
+		\pgf@circ@res@step = \ctikzvalof{bipoles/capacitor/width}\pgf@circ@Rlen
+		\divide \pgf@circ@res@step by 5
+
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+		\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+
+		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+		\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+		\pgfusepath{draw}
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{2.6\pgf@circ@res@right}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{-2.6\pgf@circ@res@right}{1.4\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{-4.4\pgf@circ@res@right}{1.4\pgf@circ@res@down}}
+        \pgfusepath{draw}
+    \endpgfscope
+}
 
 %% Polar Capacitor
 
@@ -392,6 +419,44 @@
 	\pgfusepath{stroke}
 }
 
+%% cute inductive sensor
+
+\pgfcircdeclarebipole{%
+{% anchor for labelling the type of dependency
+    \anchor{label}{%
+        \southwest
+        \pgf@x=0.8\pgf@x
+        \pgf@y=2.6\pgf@y
+    }%
+}}{\ctikzvalof{bipoles/cuteinductor/lower coil height}}{scuteinductor}{\ctikzvalof{bipoles/cuteinductor/height}}{\ctikzvalof{bipoles/cuteinductor/width}}{
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+	\pgftransformationadjustments
+
+	\pgfmathsetlength{\pgf@circ@res@other}%width of small coil
+	{0.5*\ctikzvalof{bipoles/cuteinductor/coil aspect}*\ctikzvalof{bipoles/cuteinductor/width}*\pgf@circ@Rlen/(\ctikzvalof{bipoles/cuteinductor/coils}-1)}
+
+
+	\pgfmathsetlength{\pgf@circ@res@step}
+		{(\ctikzvalof{bipoles/cuteinductor/width}*\pgf@circ@Rlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/cuteinductor/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/cuteinductor/coils}/2}
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*0.5*\pgflinewidth}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth}}%correct value would be 0.5 but arcs are not really flat, therefore 0.4 is better is (almost) all cases
+	\foreach \x in {2,...,\ctikzvalof{bipoles/cuteinductor/coils}}
+	{
+		\pgfpatharc{180}{0}{\pgf@circ@res@step and \pgf@circ@res@up}
+		\pgfpatharc{0}{-180}{\pgf@circ@res@other and -\pgf@circ@res@down}
+	}
+	\pgfpatharc{180}{0}{\pgf@circ@res@step and \pgf@circ@res@up}
+	\pgfsetbuttcap
+	\pgfsetbeveljoin
+	\pgfusepath{stroke}
+        \pgfscope
+            \pgfpathmoveto{\pgfpoint{.8\pgf@circ@res@right}{2\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{-.8\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{-1.6\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
+            \pgfusepath{draw}
+        \endpgfscope
+}
+
 %% cute choke
 
 \pgfcircdeclarebipole{}{\ctikzvalof{bipoles/cutechoke/lower coil height}}{cutechoke}{\ctikzvalof{bipoles/cutechoke/height}}{\ctikzvalof{bipoles/cutechoke/width}}{
@@ -460,7 +525,6 @@
 	\pgfsetbeveljoin
 	\pgfusepath{stroke}
 }
-
 %% american inductor
 
 \pgfcircdeclarebipole{}{\ctikzvalof{bipoles/americaninductor/height 2}}{americaninductor}{\ctikzvalof{bipoles/americaninductor/height}}{\ctikzvalof{bipoles/americaninductor/width}}{
@@ -480,6 +544,41 @@
 	\pgfsetbuttcap
 	\pgfsetbeveljoin
 	\pgfusepath{stroke}
+}
+
+
+%% american inductive sensor
+
+\pgfcircdeclarebipole{%
+{% anchor for labelling the type of dependency
+    \anchor{label}{%
+        \southwest
+        \pgf@x=0.8\pgf@x
+        \pgf@y=2.6\pgf@y
+    }%
+}}{\ctikzvalof{bipoles/americaninductor/height 2}}{samericaninductor}{\ctikzvalof{bipoles/americaninductor/height}}{\ctikzvalof{bipoles/americaninductor/width}}{
+	\pgf@circ@res@step=\ctikzvalof{bipoles/americaninductor/width}\pgf@circ@Rlen
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}	
+	\pgftransformationadjustments
+	\advance \pgf@circ@res@step by \pgfhorizontaltransformationadjustment\pgflinewidth
+	\divide \pgf@circ@res@step by \ctikzvalof{bipoles/americaninductor/coils}
+	\divide \pgf@circ@res@step by 2
+	\pgf@circ@res@other = \ctikzvalof{bipoles/americaninductor/coil height}\pgf@circ@Rlen
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*0.5*\pgflinewidth}{-\pgfverticaltransformationadjustment*0.4*\pgfstartlinewidth}}%correct value would be 0.5 but arcs are not really flat, therefore 0.4 is better is (almost) all cases
+	\foreach \x in {1,...,\ctikzvalof{bipoles/americaninductor/coils}}
+	{
+	\pgfpatharc{180}{0}{\pgf@circ@res@step and  \pgf@circ@res@other}
+	}
+	\pgfsetbuttcap
+	\pgfsetbeveljoin
+	\pgfusepath{stroke}
+        \pgfscope
+            \pgfpathmoveto{\pgfpoint{.8\pgf@circ@res@right}{2\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{-.8\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{-1.6\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
+            \pgfusepath{draw}
+        \endpgfscope
 }
 
 %% variable american inductor
@@ -1668,6 +1767,27 @@
 		\pgfusepath{draw,fill} 
 }
 
+%% Generic sensor, filled - used as inductive sensor by some (double bleah)
+
+\pgfcircdeclarebipole{{% anchor for labelling the type of dependency
+    \anchor{label}{%
+        \southwest
+        \pgf@x=0.4\pgf@x
+        \pgf@y=2\pgf@y
+    }%
+}}{\ctikzvalof{bipoles/fullgeneric/height}}{sfullgeneric}{\ctikzvalof{bipoles/fullgeneric/height}}{\ctikzvalof{bipoles/fullgeneric/width}}{
+
+		\pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+		\pgfusepath{draw,fill} 
+		%\pgfscope
+		\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-2\pgf@circ@res@down}}
+		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{2\pgf@circ@res@down}}
+		\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{2\pgf@circ@res@down}}
+		\pgfusepath{draw}
+		%\endpgfscope
+}
+
 
 %% Generic asymmetric bipole 
 
@@ -1771,15 +1891,21 @@
 
 
 %% Thermistor
-\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/thermistor/height}}{thermistor}{\ctikzvalof{bipoles/thermistor/height}}{\ctikzvalof{bipoles/thermistor/width}}{
+\pgfcircdeclarebipole{{% anchor for labelling the type of dependency
+    \anchor{label}{%
+        \southwest
+        \pgf@x=0.4\pgf@x
+        \pgf@y=1.2\pgf@y
+    }%
+}}{\ctikzvalof{bipoles/thermistor/height}}{thermistor}{\ctikzvalof{bipoles/thermistor/height}}{\ctikzvalof{bipoles/thermistor/width}}{
 		\pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thermistor/main}\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{-\pgfkeysvalueof{/tikz/circuitikz/bipoles/thermistor/main}\pgf@circ@res@up}}
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
 		\pgfusepath{draw}
 		
 		%\pgfscope
 		\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-\pgf@circ@res@down}}
-		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
-		\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{1.2\pgf@circ@res@down}}
+		\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{1.2\pgf@circ@res@down}}
 		\pgfusepath{draw}
 		%\endpgfscope
 }
@@ -3478,7 +3604,12 @@
 }
 
 \pgfcircdeclarebipole
-{}
+{% anchor for labelling the type of dependency
+    \anchor{label}{%
+        \southwest
+        \pgf@x=0.4\pgf@x
+    }%
+}
 {\ctikzvalof{bipoles/resistivesens/height}}
 {resistivesens}
 {\ctikzvalof{bipoles/resistivesens/height}}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -636,6 +636,10 @@
 \compattikzset{isourceN/.style= {\comnpatname noise current source= #1}}
 \compattikzset{nI/.style= {\comnpatname noise current source= #1}}
 
+% resistive sensor american style
+\def\pgf@circ@resistivesens@path#1{\pgf@circ@bipole@path{resistivesens}{#1}}
+\compattikzset{resistive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@resistivesens@path, l=#1}}
+\compattikzset{sR/.style= {\comnpatname resistive sensor= #1}}
 
 \compattikzset{Mr/.style = {\comnpatname memristor}}
 

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -151,12 +151,14 @@
 %% Path definitions
 \def\pgf@circ@resistor@path#1{\ifpgf@circuit@europeanresistor\pgf@circ@bipole@path{generic}{#1}\else\pgf@circ@bipole@path{resistor}{#1}\fi}
 \def\pgf@circ@vresistor@path#1{\ifpgf@circuit@europeanresistor\pgf@circ@bipole@path{tgeneric}{#1}\else\pgf@circ@bipole@path{vresistor}{#1}\fi}
+\def\pgf@circ@sresistor@path#1{\ifpgf@circuit@europeanresistor\pgf@circ@bipole@path{thermistor}{#1}\else\pgf@circ@bipole@path{resistivesens}{#1}\fi}
 \def\pgf@circ@potentiometer@path#1{\ifpgf@circuit@europeanresistor\pgf@circ@bipole@path{genericpotentiometer}{#1}\else\pgf@circ@bipole@path{potentiometer}{#1}\fi}
 \def\pgf@circ@thermistor@path#1{\pgf@circ@bipole@path{thermistor}{#1}}
 \def\pgf@circ@thermistorptc@path#1{\pgf@circ@bipole@path{thermistorptc}{#1}}
 \def\pgf@circ@thermistorntc@path#1{\pgf@circ@bipole@path{thermistorntc}{#1}}
 \def\pgf@circ@varistor@path#1{\pgf@circ@bipole@path{varistor}{#1}}
 \def\pgf@circ@capacitor@path#1{\pgf@circ@bipole@path{capacitor}{#1}}
+\def\pgf@circ@capacitivesens@path#1{\pgf@circ@bipole@path{capacitivesens}{#1}}
 \def\pgf@circ@ecapacitor@path#1{\pgf@circ@bipole@path{ecapacitor}{#1}}
 \def\pgf@circ@polarcapacitor@path#1{\pgf@circ@bipole@path{polarcapacitor}{#1}}
 \def\pgf@circ@vcapacitor@path#1{\pgf@circ@bipole@path{vcapacitor}{#1}}
@@ -200,9 +202,28 @@
 		\fi%
 	\fi%
 }
+\def\pgf@circ@inductivesens@path#1{%
+	\pgfextra{
+		\edef\pgf@circ@temp{\ctikzvalof{inductor}}%
+		\def\pgf@temp{european}%
+	}
+	\ifx\pgf@temp\pgf@circ@temp%
+		\pgf@circ@europeaninductivesens@path{#1}%
+	\else%
+		\pgfextra{	\def\pgf@temp{cute} }%
+		\ifx\pgf@temp\pgf@circ@temp%
+			\pgf@circ@cuteinductivesens@path{#1}%
+		\else%
+			\pgf@circ@americaninductivesens@path{#1}%
+		\fi%
+	\fi%
+}
 \def\pgf@circ@veuropeaninductor@path#1{\pgf@circ@bipole@path{tfullgeneric}{#1}}
 \def\pgf@circ@vamericaninductor@path#1{\pgf@circ@bipole@path{vamericaninductor}{#1}}
 \def\pgf@circ@vcuteinductor@path#1{\pgf@circ@bipole@path{vcuteinductor}{#1}}
+\def\pgf@circ@europeaninductivesens@path#1{\pgf@circ@bipole@path{sfullgeneric}{#1}}
+\def\pgf@circ@americaninductivesens@path#1{\pgf@circ@bipole@path{samericaninductor}{#1}}
+\def\pgf@circ@cuteinductivesens@path#1{\pgf@circ@bipole@path{scuteinductor}{#1}}
 \def\pgf@circ@lamp@path#1{\pgf@circ@bipole@path{lamp}{#1}}
 \def\pgf@circ@esource@path#1{\pgf@circ@bipole@path{esource}{#1}}
 \def\pgf@circ@pvsource@path#1{\pgf@circ@bipole@path{pvsource}{#1}}
@@ -638,8 +659,19 @@
 
 % resistive sensor american style
 \def\pgf@circ@resistivesens@path#1{\pgf@circ@bipole@path{resistivesens}{#1}}
-\compattikzset{resistive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@resistivesens@path, l=#1}}
+\compattikzset{american resistive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@resistivesens@path, l=#1}}
+\compattikzset{european resisitive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@thermistorntc@path, l=#1}}
+\compattikzset{resistive sensor/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@sresistor@path, l=#1}}
 \compattikzset{sR/.style= {\comnpatname resistive sensor= #1}}
+
+\compattikzset{capacitive sensor/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@capacitivesens@path, l=#1}}
+\compattikzset{sC/.style= {\comnpatname capacitive sensor= #1}}
+
+\compattikzset{cute inductive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cuteinductivesens@path, l=#1}}
+\compattikzset{european inductive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@europeaninductivesens@path, l=#1}}
+\compattikzset{american inductive sensor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@americaninductivesens@path, l=#1}}
+\compattikzset{inductive sensor/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@inductivesens@path, l=#1}}
+\compattikzset{sL/.style= {\comnpatname inductive sensor= #1}}
 
 \compattikzset{Mr/.style = {\comnpatname memristor}}
 


### PR DESCRIPTION
This pull request supersede #124 and should fix #66 

Use `resistive sensor` or `sR`:

![image](https://user-images.githubusercontent.com/6414907/47969459-2e29f880-e078-11e8-9810-d9834e13fbd9.png)

Now you have also: 
![image](https://user-images.githubusercontent.com/6414907/49168889-d0b45f00-f338-11e8-8aaf-6289e35b5be9.png)
![image](https://user-images.githubusercontent.com/6414907/49168905-dca02100-f338-11e8-828c-2cf34c2c43ca.png)
![image](https://user-images.githubusercontent.com/6414907/49168920-e3c72f00-f338-11e8-8b79-bef9c947e2aa.png)
![image](https://user-images.githubusercontent.com/6414907/49168932-ed509700-f338-11e8-8507-ed2c35891971.png)

...and the european inductive/resistive sensor version also (see the manual). 

Also, it adds an anchor to ease the positioning of a label for the type of dependency:

![image](https://user-images.githubusercontent.com/6414907/49168992-0f4a1980-f339-11e8-804a-6f46d4fe00ea.png)
