### PR TITLE
Fix the style "stroked" of the bodydiode

### DIFF
--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1181,6 +1181,12 @@
 				\pgfnode{emptydiodeshape}{center}{}{pgf@bodydiode}{\pgfusepath{fill}}
 			\fi
 		\endpgfscope
+                % Draw stroke line
+                \ifpgf@circuit@strokediode
+                    \pgfpathmoveto{\pgfpointanchor{pgf@bodydiode}{west}}
+                    \pgfpathlineto{\pgfpointanchor{pgf@bodydiode}{east}}
+                    \pgfusepath{stroke}
+                \fi
 		%Draw upper connection to body diode
 		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}
 						{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/bodydiode conn}\pgf@circ@res@up}}


### PR DESCRIPTION
This should fix issue #102. 
I would have liked to use anchors `strokepathstart` and `strokepathend` for the emptydiode, but it seems that they are inaccesible. I checked it and it seems to work. 