### PR TITLE
New voltage directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Make the position of voltage symbols adjustable
     - Make the position of arrows in FETs and  BJTs adjustable
     - Added the bulb symbol
+    - Added options for solving the voltage direction problems. 
 
 * Version 0.8.3 (2017-05-28) 
 	- Removed unwanted lines at to-paths if the starting point is a node without a explicit anchor.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -15,7 +15,11 @@
 	%\setmainfont{Gentium Book Basic} 
 }
 
-\usepackage[siunitx]{circuitikz} %do not split this line in more lines, otherwise "make git-manual" will show the wrong version
+%do not split this line in more lines, otherwise "make git-manual" will show the wrong version
+\usepackage[siunitx, RPvoltages]{circuitikz}
+
+% Let this being the same as the chosen voltage direction for coherence
+\def\chosenvoltoption{RPvoltages}
 
 \usepackage{ifxetex,ifluatex}
 \ifxetex
@@ -147,6 +151,7 @@ The easiest way to contact the authors is via the official Github repository: \u
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+\item Since v0.8.4: voltage and current directions/sign (plus and minus signs in case of \texttt{american voltages} and arrows in case of \texttt{european voltages} have been rationalized with a couple of new options (see details in section~\ref{curr-and-volt}. The default case is still the same as v0.8.2.
 \item Since v0.8.2: voltage and current label directions(v<= / i<=) do NOT change the orientation of the drawn source shape anymore. Use the "invert" option to rotate the shape of the source. Furthermore, from this version on, the current label(i=) at current sources can be used independent of the regular label(l=).
 \item Since v0.7?: The label behaviour at mirrored bipoles has changes, this fixes the voltage drawing, but perhaps you have to adjust your label positions.
 \item Since v0.5.1: The parts pfet,pigfete,pigfetebulk and pigfetd are now mirrored by default. Please adjust your yscale-option to correct this.
@@ -221,7 +226,14 @@ Feel free to load the package with your own cultural options:
 	\item \texttt{rotatelabels}: labels on bipoles are always printed aligned along the bipole;
 	\item \texttt{smartlabels}: labels on bipoles are rotated along the bipoles, unless the rotation is very close to multiples of 90°;
 	\item \texttt{compatibility}: makes it possibile to load \Circuitikz\ and \TikZ\ circuit library together.
-	\item \texttt{oldvoltagedirection}: Use old(erronous) way of voltage direction having a difference between european and american direction
+        \item Voltage directions: until v0.8.3, there was an error in the coherence between american and european voltages styles (see section~\ref{curr-and-volt} for the batteries. This has been fixed, but to guarantee backward compatibility and nasty surprises, the fix is available with new options:
+            \begin{itemize}
+                \item \texttt{oldvoltagedirection}: Use old way of voltage direction having a difference between european and american direction, with wrong default labelling for batteries;
+                \item \texttt{nooldvoltagedirection}: The standard from 0.5 onward, utilize the (German?) standard of voltage arrows in the  direction of electric fields (without fixing batteries);
+                \item \texttt{RPvoltages} (meaning Rising Potential voltages): the arrow is in direction of rising potential, like in \texttt{oldvoltagedirections}, but batteries and current sources are fixed to follow the passive/active standard;
+                \item \texttt{EFvoltages} (meaning Electric Field voltages): the arrow is in direction of the electric field, like in \texttt{nooldvoltagedirections}, but batteries are fixed;
+            \end{itemize}
+            If none of these option are given, the package will default to \texttt{nooldvoltagedirections}, but will give a warning. The behavior is also selectable circuit by circuit with the \texttt{voltage dir} style. 
 	\item \texttt{betterproportions}\footnote{May change in the future!}: nicer proportions of transistors in comparision to resistors;
 \end{itemize}	
 
@@ -978,14 +990,91 @@ You also can use stacked (two lines) labels.  The example should be self-explana
 \end{circuitikz}
 \end{LTXexample}
 
-\subsection{Currents}\label{currents}
-The counting direction of currents and voltages have changed with version 0.5, for compability reasons there is a option to use the olddirections(see options). For the new scheme, the following rules apply:
+\subsection{Currents and voltages}\label{curr-and-volt}
+
+The default direction/sign for currents and voltages in the components is, unfortunately, not standard, and can change across country and sometime across different authors.
+This unfortunate situation created a bit of confusion in \texttt{circuitikz} across the versions, with several incompatible changes starting from version 0.5.
+From version 0.8.4 onward, the maintainers agreed a new policy for the directions of bipoles's voltages and currents, depending on 4 different possible options:
 \begin{itemize}
-\item \textbf{Normal bipoles:} currents and voltages are counted positiv in drawing direction.
-\item \textbf{Current Sources:} current is counted positiv in drawing direction, voltage in opposite direction
-\item \textbf{Voltage Sources:} voltage is counted positiv in drawing direction, current in opposite direction
+    \item \texttt{oldvoltagedirection}, or the key style \texttt{voltage dir=old}: Use old way of voltage direction having a difference between european and american direction, with wrong default labelling for batteries (it was the default before version 0.5);
+    \item \texttt{nooldvoltagedirection}, or the key style \texttt{voltage dir=noold}: The standard from version 0.5 onward, utilize the (German?) standard of voltage arrows in the  direction of electric fields (without fixing batteries);
+    \item \texttt{RPvoltages} (meaning Rising Potential voltages), or the key style \texttt{voltage dir=RP}: the arrow is in direction of rising potential, like in \texttt{oldvoltagedirections}, but batteries and current sources are fixed so that they follow the passive/active standard: the default direction of \texttt{v} and \texttt{i} are chosen so that, when both values are positive:
+        \begin{itemize}
+            \item in passive component, the element is \emph{dissipating power};
+            \item in active components (generators), the element is \emph{generating power}.
+        \end{itemize}
+    \item \texttt{EFvoltages} (meaning Electric Field voltages), or the key style \texttt{voltage dir=EF}: the arrow is in direction of the electric field, like in \texttt{nooldvoltagedirections}, but batteries are fixed;
 \end{itemize}
-With this convention, the power at loads is positive and negative at sources.
+
+The standard direction of currents, flows and voltages are changed by these options; notice that the default drops in case of passive and active elements is normally different. Take care that in the case of \texttt{noold} and \texttt{EFvoltages} also the currents can switch directions. It is much easier to understand the several behaviors by looking at the following examples, that have been generated by the code:
+
+\begin{lstlisting}
+\foreach\element in {R, C, D, battery2, V, I, sV, cV, cI}{%
+    \noindent\ttfamily
+    \begin{tabular}{p{2cm}}
+        \element \\ american \\[15pt]
+        \element \\ european \\
+    \end{tabular}
+    \foreach\mode in {old, noold, RP, EF} {
+        \begin{tabular}{@{}l@{}}
+            \multicolumn{1}{c}{voltage dir} \\
+            \multicolumn{1}{c}{dir=\mode} \\[4pt]
+            \begin{tikzpicture}[
+                american, voltage dir=\mode,
+                ]
+                \draw (0,0) to[\element,  *-o, v=$v_1$, i=$i_1$, ] (2.5,0);
+            \end{tikzpicture}\\
+            \begin{tikzpicture}[
+                european, voltage dir=\mode,
+                ]
+                \draw (0,0) to[\element,  *-o, v=$v_1$, i=$i_1$, ] (2.5,0);
+            \end{tikzpicture}
+        \end{tabular}
+        \medskip
+    }
+    \par
+}
+\end{lstlisting}
+
+
+\foreach\element in {R, C, D, battery2, V, I,  sV, cV, cI}{%
+    \noindent\ttfamily
+    \begin{tabular}{p{2cm}}
+        \element \\ american \\[15pt]
+        \element \\ european \\
+    \end{tabular}
+    \foreach\mode in {old, noold, RP, EF} {
+        \begin{tabular}{@{}l@{}}
+            \multicolumn{1}{c}{voltage dir} \\
+            \multicolumn{1}{c}{dir=\mode} \\[4pt]
+            \begin{tikzpicture}[
+                american, voltage dir=\mode,
+                ]
+                \draw (0,0) to[\element,  *-o, v=$v_1$, i=$i_1$, ] (2.5,0);
+            \end{tikzpicture}\\
+            \begin{tikzpicture}[
+                european, voltage dir=\mode,
+                ]
+                \draw (0,0) to[\element,  *-o, v=$v_1$, i=$i_1$, ] (2.5,0);
+            \end{tikzpicture}
+        \end{tabular}
+        \medskip
+    }
+    \par
+}
+
+Obviously, you normally use just one between current and flows, but anyway you can
+change direction of the voltages,
+currents and flows using the complete keys \verb|i_>|, \verb|i^<|, \verb|i>_|, \verb|i>^|,
+as shown in the following examples.
+
+This manual has been typeset with the option \texttt{\chosenvoltoption}. 
+
+
+\subsection{Currents}
+
+Inline (along the wire) currents are selected with \verb|i_>|, \verb|i^<|, \verb|i>_|, \verb|i>^|, and various simplification; the default position and direction is obtained with the key \verb|i=...|.
+
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -1145,7 +1234,7 @@ As an alternative for the current arrows, you can also use the following flows. 
 \end{LTXexample}
 
 \subsection{Voltages}
-See introduction note at Currents (chapter \ref{currents}, page \pageref{currents})!
+See introduction note at Currents (chapter \ref{curr-and-volt}, page \pageref{curr-and-volt})!
 
 \subsubsection{European style} The default, with arrows. Use option \texttt{europeanvoltage} or style \verb![european voltages]!.
 

--- a/doc/compatibility.tex
+++ b/doc/compatibility.tex
@@ -4,7 +4,7 @@
 \usetikzlibrary{circuits.ee.IEC}
 \usetikzlibrary{positioning}
 
-\usepackage[compatibility]{circuitikz}
+\usepackage[compatibility, RPvoltages]{circuitikz}
 \ctikzset{bipoles/length=.9cm}
 
 \begin{document}

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -233,10 +233,26 @@
 
 \DeclareOption{oldvoltagedirection}{
 	\pgf@circ@oldvoltagedirectiontrue
+        \pgf@circ@explicitvdirtrue
+        \pgf@circ@fixbatteriesfalse
 }
 \DeclareOption{nooldvoltagedirection}{
 	\pgf@circ@oldvoltagedirectionfalse
+        \pgf@circ@explicitvdirtrue
+        \pgf@circ@fixbatteriesfalse
 }
+
+\DeclareOption{RPvoltages}{
+	\pgf@circ@oldvoltagedirectiontrue
+        \pgf@circ@explicitvdirtrue
+        \pgf@circ@fixbatteriestrue
+}
+\DeclareOption{EFvoltages}{
+	\pgf@circ@oldvoltagedirectionfalse
+        \pgf@circ@explicitvdirtrue
+        \pgf@circ@fixbatteriestrue
+}
+
 
 \DeclareOption{betterproportions}{
 	\ctikzset{monopoles/ground/width/.initial=.15}
@@ -317,7 +333,8 @@
 \input pgfcirccurrent.tex
 \input pgfcircflow.tex
 
-\ExecuteOptions{nofetbodydiode,nofetsolderdot,nooldvoltagedirection,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility}
+% notice that the default is nooldvoltagedirections; it's not explicitly set to allow for the warning
+\ExecuteOptions{nofetbodydiode,nofetsolderdot,europeancurrents,europeanvoltages,americanports,americanresistors,cuteinductors,europeangfsurgearrester,nosiunitx,noarrowmos,smartlabels,nocompatibility}
 
 \ProcessOptions\relax
 
@@ -327,6 +344,16 @@
     \RequirePackage{xstring}[2009/03/13]
 	%\expandafter\let\csname angstrom\endcsname\relax
 	\RequirePackage{siunitx}
+\fi
+
+\ifpgf@circ@explicitvdir\else
+    \PackageWarningNoLine{circuitikz}{%
+        You did not specify one of the voltage directions:\MessageBreak
+        \space\space    oldvoltagedirections, nooldvoltagedirections, \MessageBreak 
+        \space\space    RPvoltages or EFvoltages \MessageBreak
+        Default directions may have changed, \MessageBreak 
+        please check the manual%
+    }
 \fi
 
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -30,7 +30,17 @@
 
 \newif\ifpgf@circ@siunitx
 \newif\ifpgf@circuit@compat
-\newif\ifpgf@circ@oldvoltagedirection
+\newif\ifpgf@circ@oldvoltagedirection % default false
+\newif\ifpgf@circ@explicitvdir
+\newif\ifpgf@circ@fixbatteries
+
+\ctikzset{voltage dir/.is choice}
+\ctikzset{voltage dir/old/.code={\pgf@circ@oldvoltagedirectiontrue\pgf@circ@fixbatteriesfalse}}
+\ctikzset{voltage dir/noold/.code={\pgf@circ@oldvoltagedirectionfalse\pgf@circ@fixbatteriesfalse}}
+\ctikzset{voltage dir/RP/.code={\pgf@circ@oldvoltagedirectiontrue\pgf@circ@fixbatteriestrue}}
+\ctikzset{voltage dir/EF/.code={\pgf@circ@oldvoltagedirectionfalse\pgf@circ@fixbatteriestrue}}
+\tikzset{voltage dir/.style={circuitikz/voltage dir=#1}}
+
 
 % Option ">" for twoports
 \newif\ifpgf@circuit@inputarrow

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -227,8 +227,10 @@
 \ctikzset{bipoles/spst/depth/.initial=.2}
 \ctikzset{bipoles/nos/height/.initial=.3}
 \ctikzset{bipoles/nos/width/.initial=.35}
+\ctikzset{bipoles/nos/depth/.initial=.2}
 \ctikzset{bipoles/ncs/height/.initial=.35}
 \ctikzset{bipoles/ncs/width/.initial=.35}
+\ctikzset{bipoles/ncs/depth/.initial=.2}
 \ctikzset{bipoles/generic/height/.initial=.30}
 \ctikzset{bipoles/generic/width/.initial=.80}
 \ctikzset{bipoles/european gas filled surge arrester/height/.initial=.30}
@@ -291,7 +293,7 @@
 \ctikzset{bipoles/thermocouple/height 2/.initial=.60}
 \ctikzset{bipoles/thermocouple/width/.initial=.140}
 \ctikzset{bipoles/pushbutton/height/.initial=.5}
-\ctikzset{bipoles/pushbutton/height 2/.initial=.0}
+\ctikzset{bipoles/pushbutton/height 2/.initial=.2}
 \ctikzset{bipoles/pushbutton/width/.initial=.50}
 
 \ctikzset{bipoles/twoport/width/.initial=.7}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -264,8 +264,8 @@
 \ctikzset{bipoles/open/width/.initial=.3} %necessary for curly voltages
 \ctikzset{bipoles/open/voltage/straight label distance/.initial=0}
 \ctikzset{bipoles/open/voltage/distance from node/.initial=.2}
-\ctikzset{bipoles/short/height/.initial=0} %dummy height for voltage positioning
-\ctikzset{bipoles/short/width/.initial=0} %dummy width for voltage positioning
+\ctikzset{bipoles/short/height/.initial=0.3} %dummy height for voltage positioning
+\ctikzset{bipoles/short/width/.initial=0.3} %dummy width for voltage positioning
 %\ctikzset{bipoles/short/voltage/straight label distance/.initial=.2}
 %\ctikzset{bipoles/short/voltage/distance from node/.initial=.5}
 \ctikzset{bipoles/ammeter/height/.initial=.60}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -340,18 +340,32 @@
 		\divide \pgf@circ@res@step by 6
 
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
-		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
 
-		\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@step}{.5\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{-\pgf@circ@res@step}{.5\pgf@circ@res@down}}
+                \ifpgf@circ@fixbatteries
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{.5\pgf@circ@res@down}}
 
-		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@down}}
+                    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@step}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{-\pgf@circ@res@step}{\pgf@circ@res@down}}
 
-		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{.5\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{.5\pgf@circ@res@down}}
 
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+                \else
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+
+                    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@step}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{-\pgf@circ@res@step}{.5\pgf@circ@res@down}}
+
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@down}}
+
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+                \fi
 		\pgfusepath{draw}
 }
 
@@ -366,11 +380,19 @@
 		\pgfusepath{draw}
 
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
-		\pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+                \ifpgf@circ@fixbatteries
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{\pgf@circ@res@down}}
 
-		\pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@down}}
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{.5\pgf@circ@res@down}}
+                \else
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@down}}
+                \fi
 		\pgfusepath{draw}
 }
 
@@ -384,12 +406,21 @@
 		\pgfusepath{draw}
 
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
-		\pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@down}}
-		\pgfusepath{draw}
-		\pgfsetlinewidth{3\pgflinewidth}
-		\pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@up}}
-		\pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+                \ifpgf@circ@fixbatteries
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{\pgf@circ@res@down}}
+                    \pgfusepath{draw}
+                    \pgfsetlinewidth{3\pgflinewidth}
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{.5\pgf@circ@res@down}}
+                \else
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@left}{\pgf@circ@res@down}}
+                    \pgfusepath{draw}
+                    \pgfsetlinewidth{3\pgflinewidth}
+                    \pgfpathmoveto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@up}}
+                    \pgfpathlineto{\pgfpoint{.33\pgf@circ@res@right}{.5\pgf@circ@res@down}}
+                \fi
 		\pgfusepath{draw}
 }
 

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1747,7 +1747,7 @@
 
 %% Short circuit
 
-\pgfcircdeclarebipole{}{0}{short}{0}{0}{ }
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/short/height}}{short}{\ctikzvalof{bipoles/short/height}}{\ctikzvalof{bipoles/short/width}}{ }
 
 %% Open circuit
 

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1658,7 +1658,7 @@
 }
 
 %% Normal open Switch
-\pgfcircdeclarebipole{}{0}{nos}{\ctikzvalof{bipoles/nos/height}}{\ctikzvalof{bipoles/nos/width}}{
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/nos/depth}}{nos}{\ctikzvalof{bipoles/nos/height}}{\ctikzvalof{bipoles/nos/width}}{
 
 	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
 	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
@@ -1668,7 +1668,7 @@
 }
 
 %% Normal closed Switch
-\pgfcircdeclarebipole{}{0}{ncs}{\ctikzvalof{bipoles/ncs/height}}{\ctikzvalof{bipoles/ncs/width}}{
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/ncs/depth}}{ncs}{\ctikzvalof{bipoles/ncs/height}}{\ctikzvalof{bipoles/ncs/width}}{
 	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
 	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
 	\pgfpathlineto{\pgfpoint{.9\pgf@circ@res@right}{\pgf@circ@res@up}}

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -246,11 +246,20 @@
 	\else% american voltage
 		\ifpgf@circuit@bipole@voltageoutsideofsymbol
 		% if it is a battery, must put + and -
+
+                    \ifpgf@circ@fixbatteries
+			\ifpgf@circuit@bipole@voltage@backward
+				(pgfcirc@Vfrom)  node {$+$}  (pgfcirc@Vto) node {$-$}
+			\else
+				(pgfcirc@Vfrom)  node {$-$}  (pgfcirc@Vto) node {$+$}
+			\fi
+                    \else
 			\ifpgf@circuit@bipole@voltage@backward
 				(pgfcirc@Vfrom)  node {$-$}  (pgfcirc@Vto) node {$+$}
 			\else
 				(pgfcirc@Vfrom)  node {$+$}  (pgfcirc@Vto) node {$-$}
 			\fi
+                    \fi
 		\fi
 	\fi
 }

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -59,7 +59,12 @@
 					\circuitikzbasekey/bipole/voltage/direction=forward}
 				\fi
 			\fi
-			\ifpgf@circ@oldvoltagedirection\else
+			\ifpgf@circ@oldvoltagedirection
+                            \ifpgf@circuit@bipole@iscurrent\ifpgf@circ@fixbatteries
+                                \pgfkeys{\circuitikzbasekey/bipole/voltage/position=below,
+					\circuitikzbasekey/bipole/voltage/direction=forward}
+                        \fi\fi
+                        \else
 			\ifpgf@circuit@bipole@iscurrent
 			\ifpgf@circuit@bipole@current@backward
 					\pgfkeys{\circuitikzbasekey/bipole/voltage/position=below,


### PR DESCRIPTION
This superseded #132, and should fix #101. I rebased it and I think it's good to merge; there is no change of default behavior (minus a warning). The manual is now quite clear and explicit; see below. 

I would like to merge this sooner than later, if the other maintainers agree. I have not bumped the version number, but I would like to solve / close most of the issues and then do a 0.8.4 or 0.9, and push it to CTAN. @mredaelli @der-stefan @sistlind 

![image](https://user-images.githubusercontent.com/6414907/50425876-8bc01180-087f-11e9-9bc7-76e10ca092bb.png) 
![image](https://user-images.githubusercontent.com/6414907/50425885-b611cf00-087f-11e9-9de7-f2193a24a15a.png)

...and then there are severl examples, one excerpt is: 

![image](https://user-images.githubusercontent.com/6414907/50425890-e78a9a80-087f-11e9-9b63-adcadb98852a.png)
![image](https://user-images.githubusercontent.com/6414907/50425894-fffab500-087f-11e9-84c4-81b19d528b6a.png)
