### PR TITLE
Fix147 by reverting the "fix `short` voltages" commit

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -264,8 +264,8 @@
 \ctikzset{bipoles/open/width/.initial=.3} %necessary for curly voltages
 \ctikzset{bipoles/open/voltage/straight label distance/.initial=0}
 \ctikzset{bipoles/open/voltage/distance from node/.initial=.2}
-\ctikzset{bipoles/short/height/.initial=0.3} %dummy height for voltage positioning
-\ctikzset{bipoles/short/width/.initial=0.3} %dummy width for voltage positioning
+\ctikzset{bipoles/short/height/.initial=0} %dummy height for voltage positioning
+\ctikzset{bipoles/short/width/.initial=0} %dummy width for voltage positioning
 %\ctikzset{bipoles/short/voltage/straight label distance/.initial=.2}
 %\ctikzset{bipoles/short/voltage/distance from node/.initial=.5}
 \ctikzset{bipoles/ammeter/height/.initial=.60}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1747,6 +1747,8 @@
 
 %% Short circuit
 
+%%% NOTICE that the short is really NOT drawn; we trust the fact that its
+%%% natural length is zero.
 \pgfcircdeclarebipole{}{0}{short}{0}{0}{ }
 
 %% Open circuit

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1747,7 +1747,7 @@
 
 %% Short circuit
 
-\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/short/height}}{short}{\ctikzvalof{bipoles/short/height}}{\ctikzvalof{bipoles/short/width}}{ }
+\pgfcircdeclarebipole{}{0}{short}{0}{0}{ }
 
 %% Open circuit
 


### PR DESCRIPTION
 Revert "Correct voltages for short and open"

The short "component" was not drawn because it was assumed its
size is always 0. Changing the minimum size will create gaps
instead of short circuits. This leaves the voltage positions for
shorts in bad shapes, but the fix has to be done in another place.

This reverts commit 4495860.