### PR TITLE
Fix the position of text in amplifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Added special anchors for transformers (and fixed the wrong center anchor)
     - Changed the logical port implementation to multiple inputs (thanks to John Kormylo)
     - Changed labels spacing so that they are independent on scale factor
+    - Fixed the position of text labels in amplifiers
   
 * Version 0.8.3 (2017-05-28) 
 	- Removed unwanted lines at to-paths if the starting point is a node without a explicit anchor.

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2317,6 +2317,8 @@
 		\pgf@x=-\pgf@x
 	  }
 	  
+          \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
 	  \backgroundpath{			
 			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}	
 			
@@ -2414,6 +2416,8 @@
 		\pgf@x=-\pgf@x
 	  }
 	  
+          \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
 	  \backgroundpath{			
 			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}	
 			

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -586,6 +586,8 @@
         \left
         \pgf@x=-\pgf@x
     }
+    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
     % let's start drawing the component
     \backgroundpath{
         \pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -2296,6 +2296,8 @@
 		  	\pgf@x=-\pgf@x
 		  }  
 	  
+           \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
 	  \backgroundpath{			
 			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}	
 			
@@ -2425,6 +2427,8 @@
 	  	\left
 		\pgf@x=-\pgf@x
 	}
+        \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
 	\backgroundpath{			
 			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}	
 			\northwest
@@ -2557,6 +2561,10 @@
 		  	\pgf@x=-\pgf@x
 		  }  
 	  
+                  \anchor{text}{\northwest
+                      \pgf@x=\pgfkeysvalueof{/tikz/circuitikz/tripoles/op amp/port width}\pgf@x
+                \pgfpoint{-.5\wd\pgfnodeparttextbox+.25\pgf@x}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
 	  \backgroundpath{			
 			\pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}	
 						
@@ -2729,6 +2737,8 @@
         \left
         \pgf@x=-\pgf@x
     }
+  \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
     % let's start drawing the component
     \backgroundpath{
         \pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}
@@ -2934,6 +2944,8 @@
         \left
         \pgf@x=-\pgf@x
     }
+  \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+
     % drawing of the component
     \backgroundpath{
         \pgfsetcolor{\pgfkeysvalueof{/tikz/circuitikz/color}}


### PR DESCRIPTION
It should fix #159. Resulting text for `node [...]{OP37}`: 

![image](https://user-images.githubusercontent.com/6414907/53579165-5be00380-3b79-11e9-9d0b-24b126eb3190.png)
