### PR TITLE
Remove the dependency on deprecated "arrows" library.

### DIFF
--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -19,7 +19,13 @@
 %% Version 3.0 of pgf/TikZ is required
 \RequirePackage{tikz}
 \usetikzlibrary{calc}
-\usepgflibrary{arrows}
+%
+% "arrows" library is deprecated, and behave badly with
+% arrows on short paths. Change to the new arrows.meta
+% In pfgcirc.define, we will add the old definition of
+% latex' which we have lost in the transition
+%
+\usetikzlibrary{arrows.meta, bending}
 
 
 % The options are listed in the manual in this order

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -15,6 +15,45 @@
 \newdimen\pgf@circ@res@temp
 % inital thickness
 \newdimen \pgfstartlinewidth
+
+% arrow tips, ported over old arrows library (deprecated)
+% see https://tex.stackexchange.com/questions/234084/latex-arrow-tip-with-arrows-meta-library
+% this was the original definition of latex' tips, renamed to avoid clashes
+%
+\pgfarrowsdeclare{latexslim}{latexslim}
+{
+  \pgfutil@tempdima=0.28pt%
+  \advance\pgfutil@tempdima by.3\pgflinewidth%
+  \pgfarrowsleftextend{+-4\pgfutil@tempdima}
+  \pgfarrowsrightextend{+6\pgfutil@tempdima}
+}
+{
+  \pgfutil@tempdima=0.28pt%
+  \advance\pgfutil@tempdima by.3\pgflinewidth%
+  \pgfpathmoveto{\pgfqpoint{6\pgfutil@tempdima}{0\pgfutil@tempdima}}
+  \pgfpathcurveto
+  {\pgfqpoint{3.5\pgfutil@tempdima}{.5\pgfutil@tempdima}}
+  {\pgfqpoint{-1\pgfutil@tempdima}{1.5\pgfutil@tempdima}}
+  {\pgfqpoint{-4\pgfutil@tempdima}{3.75\pgfutil@tempdima}}
+  \pgfpathcurveto
+  {\pgfqpoint{-1.5\pgfutil@tempdima}{1\pgfutil@tempdima}}
+  {\pgfqpoint{-1.5\pgfutil@tempdima}{-1\pgfutil@tempdima}}
+  {\pgfqpoint{-4\pgfutil@tempdima}{-3.75\pgfutil@tempdima}}
+  \pgfpathcurveto
+  {\pgfqpoint{-1\pgfutil@tempdima}{-1.5\pgfutil@tempdima}}
+  {\pgfqpoint{3.5\pgfutil@tempdima}{-.5\pgfutil@tempdima}}
+  {\pgfqpoint{6\pgfutil@tempdima}{0\pgfutil@tempdima}}
+  \pgfpathclose
+  \pgfusepathqfill
+}
+
+\pgfarrowsdeclarereversed{latexslim reversed}{latexslim reversed}{latexslim}{latexslim}
+
+
+
+
+
+
 %% Keys
 
 \long\def\pgf@circ@comment#1{}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -230,7 +230,7 @@
 	\pgfusepath{draw}
 	
 	\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@other}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -539,7 +539,7 @@
 		{(\ctikzvalof{bipoles/vcuteinductor/width}*\pgf@circ@Rlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/vcuteinductor/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/vcuteinductor/coils}/2}
 
 	\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{.4\pgf@circ@res@right}{\pgf@circ@res@up}}
 		\pgfusepath{draw}
@@ -633,7 +633,7 @@
 	\pgfusepath{stroke}
 
 	\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@left}{\pgf@circ@res@up}}
 		\pgfusepath{draw}
@@ -1314,7 +1314,7 @@
 		\pgfusepath{draw}
 
 			\pgfsetlinewidth{\pgfstartlinewidth}
-			\pgfsetarrowsend{latex'}
+			\pgfsetarrowsend{latexslim}
 			\pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
 			\pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
 			\pgfusepath{draw}
@@ -1342,7 +1342,7 @@
 		\pgfusepath{draw}
 
 			\pgfsetlinewidth{\pgfstartlinewidth}
-			\pgfsetarrowsstart{latex'}
+			\pgfsetarrowsstart{latexslim}
 			\pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
 			\pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
 			\pgfusepath{draw}
@@ -1492,7 +1492,7 @@
 		\pgfusepath{draw}
 
 			\pgfsetlinewidth{\pgfstartlinewidth}
-			\pgfsetarrowsend{latex'}
+			\pgfsetarrowsend{latexslim}
 			\pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
 			\pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
 			\pgfusepath{draw}
@@ -1519,7 +1519,7 @@
 		\pgfusepath{draw}
 
 			\pgfsetlinewidth{\pgfstartlinewidth}
-			\pgfsetarrowsstart{latex'}
+			\pgfsetarrowsstart{latexslim}
 			\pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
 			\pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
 			\pgfusepath{draw}
@@ -1633,12 +1633,14 @@
 	\pgfpathlineto{\pgfpoint{.6\pgf@circ@res@right}{\pgf@circ@res@up}}
 	\pgfusepath{draw}
 	
-	\pgfsetarrowsstart{latex'}
-	\pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@right}{\pgf@circ@res@down}}
-	\pgfpathlineto{\pgfpoint{.2\pgf@circ@res@right}{0\pgf@circ@res@down}}
-	\pgfpatharcto{1.2\pgf@circ@res@right}{1.2\pgf@circ@res@right}{0}{0}{1}{\pgfpoint{.9\pgf@circ@res@left}{.9\pgf@circ@res@up}}
+        \pgfscope
+        \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpointpolar{90}{1.2\pgf@circ@res@right}}
+	\pgfpatharc{90}{-20}{1.2\pgf@circ@res@right}
+	\pgfsetarrowsend{latexslim}
 	\pgfsetbeveljoin
 	\pgfusepath{draw}
+        \endpgfscope
 }
 
 %% Opening SPST
@@ -1649,12 +1651,14 @@
 	\pgfpathlineto{\pgfpoint{.6\pgf@circ@res@right}{\pgf@circ@res@up}}
 	\pgfusepath{draw}
 	
-	\pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
-	\pgfpatharcto{1.1\pgf@circ@res@right}{1.1\pgf@circ@res@right}{0}{0}{1}{\pgfpoint{.7\pgf@circ@res@left}{.9\pgf@circ@res@up}}
-	\pgfpathlineto{\pgfpoint{1.2\pgf@circ@res@left}{1\pgf@circ@res@up}}
-	\pgfsetarrowsend{latex'}
+        \pgfscope
+        \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpointpolar{-10}{1.2\pgf@circ@res@right}}
+	\pgfpatharc{-10}{90}{1.2\pgf@circ@res@right}
+	\pgfsetarrowsend{latexslim}
 	\pgfsetbeveljoin
 	\pgfusepath{draw}
+        \endpgfscope
 }
 
 %% Normal open Switch
@@ -1911,7 +1915,7 @@
 		\pgfusepath{draw}
 		
 		\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -1926,7 +1930,7 @@
 		\pgfusepath{draw}
 		
 		\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.7\pgf@circ@res@right}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{.3\pgf@circ@res@right}{-1.2\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -1973,7 +1977,7 @@
 		
 		\pgfsetlinewidth{\pgfstartlinewidth}
 		\pgftext[top,x=.85\pgf@circ@res@left,y=.75\pgf@circ@res@down]{\tiny$\vartheta$}
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.62\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{.62\pgf@circ@res@left}{.7\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -1995,7 +1999,7 @@
 		
 		\pgfsetlinewidth{\pgfstartlinewidth}
 		\pgftext[top,x=.85\pgf@circ@res@left,y=.75\pgf@circ@res@down]{\tiny$\vartheta$}
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.62\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfpathlineto{\pgfpoint{.62\pgf@circ@res@left}{.7\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -2048,7 +2052,7 @@
 		\pgfusepath{draw,fill}
 		
 		\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -2076,7 +2080,7 @@
 		\pgfusepath{draw}
 		
 		\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
 		\pgfusepath{draw}
@@ -3528,7 +3532,7 @@
 		\pgfusepath{draw} 
 		
 		\pgfscope
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
 		\pgfpathlineto{\pgfpoint{\pgfkeysvalueof{/tikz/circuitikz/bipoles/european gas filled surge arrester/inside}\pgf@circ@res@left}{0pt}}
 		\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}	

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1196,7 +1196,7 @@
 	
 		\ifpgf@circuit@bpt@drawphoto
 					\pgfscope
-					\pgfsetarrowsstart{latex'}
+					\pgfsetarrowsstart{latexslim}
 					\pgfpathmoveto{\pgfpointadd{\pgfpoint
 										{\pgfkeysvalueof{/tikz/circuitikz/tripoles/#1/base width}\pgf@circ@res@left}
 										{\pgf@circ@res@up+\pgf@circ@res@down}}
@@ -3058,7 +3058,7 @@
 
 \pgfscope
 	%\pgfsetlinewidth{\pgfstartlinewidth}
-	\pgfsetarrowsend{latex'}
+	\pgfsetarrowsend{latexslim}
 	\pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
 	\pgfpathlineto{\pgfpoint{0pt}{-\pgf@circ@res@down}}
 	\pgfusepath{draw}
@@ -3088,7 +3088,7 @@
 		
 		\pgfscope
 		%\pgfsetlinewidth{\pgfstartlinewidth}
-		\pgfsetarrowsend{latex'}
+		\pgfsetarrowsend{latexslim}
 		\pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
 		\pgfpathlineto{\pgfpoint{0pt}{-\pgf@circ@res@down}}
 		\pgfusepath{draw}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -6,7 +6,7 @@
 
 \startmodule[circuitikz]
 \usetikzlibrary[calc]
-\usetikzlibrary[arrows]
+\usetikzlibrary[arrows.meta, bending]
 
 \unprotect
 


### PR DESCRIPTION
We use the new arrows.meta which, with the bending library, correct
a bad behavior of arrows on small curved paths.
Removed workarounds used for short circular path.