### PR TITLE
Add crossing support shapes

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -806,7 +806,14 @@ Transformers with core are also available:
 	\circuititem{buffer}{Buffer}{}
 \end{itemize}
 
-\subsection{Support shapes}
+\subsection{Support shapes and bipoles}
+
+Path style:
+\begin{itemize}
+\circuititembip{crossing}{Jumper style non-contact crossing}{xing}
+\end{itemize}
+
+\noindent Node style:
 
 \begin{itemize}
 	\circuititem{currarrow}{Arrows (current and voltage)}{}
@@ -814,9 +821,68 @@ Transformers with core are also available:
 	\circuititem{circ}{Connected terminal}{}
 	\circuititem{ocirc}{Unconnected terminal}{}
 	\circuititem{diamondpole}{Diamond-style terminal}{}
+	\circuititem{jump crossing}{Jumper-style crossing node}{}
+	\circuititem{plain crossing}{Plain style crossing node}{}
 \end{itemize}
 
+\subsubsection{Terminal shapes}
+Since version 0.8.4, \texttt{circ}, \texttt{ocirc} , and \texttt{diamondpole} have all the standard geographical anchors, so you can do things like these:
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[american,]
+    \draw (0,-1) node[draw](R){R};
+    \draw (R.east) node[ocirc, right]{};
+\end{circuitikz}
+\end{LTXexample}
+
+
+\subsubsection{Crossings}
+
+All circuit-drawing standards agree that to show a crossing without electric contact, a simple crossing of the wires suffices; the electrical contact must be explicitly marked with a filled dot.
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[]
+\draw(1,-1) to[short] (1,1)
+    (0,0) to[short] (2,0);
+\draw(4,-1) to[short] (4,1)
+    (3,0) to[short] (5,0)
+    (4,0) node[circ]{};
+\end{circuitikz}
+\end{LTXexample}
+
+However, sometime it is advisable to mark the non-contact situation more explicitly. To this end, you can use a path-style component called \texttt{crossing}:
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[]
+\draw(1,-1) to[short] (1,1) (0,0) to[crossing] (2,0);
+\draw(4,-1) to[short] (4,1) (3,0) to[short] (5,0)
+    (4,0) node[circ]{};
+\end{circuitikz}
+\end{LTXexample}
+
+That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometime a bit of trials and errors are needed to position it.
+
+For a more powerful (and elegant) way you can use the crossing nodes:
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[]
+    \node at (1,1)[jump crossing](X){};
+    \draw (X.west) -- ++(-1,0);
+    \draw (X.east) to[R] ++(2,0);
+    \draw (X.north) node[vcc]{};
+    \draw (X.south) to[C] ++(0,-1.5);
+\end{circuitikz}
+\end{LTXexample}
+
+Notice that the \texttt{plain crossing} and the \texttt{jump crossing} have a small gap in the straight wire, to enhance the effect of crossing (as a kind of shadow).
+
+The size of the crossing elements can be changed with the key \texttt{bipoles/crossing/size} (default 0.2).
+
+
+\subsubsection{Arrows size}
+
 You can use the parameter  \texttt{current arrow scale} to change the size of the arrows in various components and indicators; the normal value is 16, higher numbers give smaller arrows and so on.  You need to use  \texttt{circuitikz/current arrow scale} if you use it into a node.
+
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
     \draw (0,0) to[R, i=f] ++(2,0) node[npn, anchor=B]{};

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -360,6 +360,8 @@
 \ctikzset{bipoles/resistivesens/height/.initial=.6}
 \ctikzset{bipoles/resistivesens/width/.initial=.8}
 
+% crossing wires
+\ctikzset{bipoles/crossing/size/.initial=.2}
 
 \newif\ifpgf@circuit@trans@depletiontype
 \pgf@circuit@trans@depletiontypefalse

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -3785,3 +3785,22 @@
         \pgfusepath{draw}
     \endpgfscope
 }
+
+%% crossing bipole (but see also nodes)
+\pgfcircdeclarebipole
+    {}
+    {\ctikzvalof{bipoles/crossing/size}}
+    {crossing}
+    {\ctikzvalof{bipoles/crossing/size}}
+    {\ctikzvalof{bipoles/crossing/size}}{
+        \pgfscope
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+        \pgfpathlineto{\pgfpoint{0.4\pgf@circ@res@left}{\pgf@circ@res@zero}}
+        \pgfpatharc{0}{-180}{0.4*\pgf@circ@res@left}
+        \pgfsetbeveljoin
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@zero}}
+        \pgfusepath{draw}
+        \endpgfscope
+    }
+
+% end of pgfcircbipoles.tex

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -715,6 +715,10 @@
 \compattikzset{vdd/.style = {\comnpatname vcc = #1}}
 \compattikzset{vss/.style = {\comnpatname vee = #1}}
 
+% activate the to-style crossing
+\def\pgf@circ@crossing@path#1{\pgf@circ@bipole@path{crossing}{#1}}
+\compattikzset{crossing/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@crossing@path, l=#1}}
+\compattikzset{xing/.style= {\comnpatname crossing= #1}}
 
 % Transistor like bipoles
 

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -50,6 +50,23 @@
 	\anchor{center}{
 		\pgfpointorigin
 	}
+        \savedanchor\northwest{%
+            \pgf@y=\pgfkeysvalueof{/tikz/circuitikz/nodes width}\pgf@circ@Rlen
+            \pgf@x=-\pgf@y
+        }
+        \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
+        \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{west}{ \northwest \pgf@y=0pt }
+        \anchor{w}{ \northwest \pgf@y=0pt }
+        \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{north}{ \northwest \pgf@x=0pt }
+        \anchor{n}{ \northwest \pgf@x=0pt }
+        \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
+        \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
+        \anchor{north west}{ \northwest }
+        \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
 	\anchorborder{
 		\pgf@circ@res@left=\pgf@x
 		\pgf@circ@res@up=\pgf@y
@@ -73,6 +90,23 @@
 	\anchor{center}{
 		\pgfpointorigin
 	}
+        \savedanchor\northwest{%
+            \pgf@y=\pgfkeysvalueof{/tikz/circuitikz/nodes width}\pgf@circ@Rlen
+            \pgf@x=-\pgf@y
+        }
+        \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
+        \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{west}{ \northwest \pgf@y=0pt }
+        \anchor{w}{ \northwest \pgf@y=0pt }
+        \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{north}{ \northwest \pgf@x=0pt }
+        \anchor{n}{ \northwest \pgf@x=0pt }
+        \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
+        \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
+        \anchor{north west}{ \northwest }
+        \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
 	\anchorborder{
 		\pgf@circ@res@left=\pgf@x
 		\pgf@circ@res@up=\pgf@y
@@ -98,6 +132,23 @@
 	\anchor{center}{
 		\pgfpointorigin
 	}
+        \savedanchor\northwest{%
+            \pgf@y=\pgfkeysvalueof{/tikz/circuitikz/nodes width}\pgf@circ@Rlen
+            \pgf@x=-\pgf@y
+        }
+        \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
+        \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+        \anchor{west}{ \northwest \pgf@y=0pt }
+        \anchor{w}{ \northwest \pgf@y=0pt }
+        \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+        \anchor{north}{ \northwest \pgf@x=0pt }
+        \anchor{n}{ \northwest \pgf@x=0pt }
+        \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
+        \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
+        \anchor{north west}{ \northwest }
+        \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
 	\anchorborder{
 		\pgf@circ@res@left=\pgf@x
 		\pgf@circ@res@up=\pgf@y
@@ -243,6 +294,89 @@
 		\endpgfscope
 	}
 
+}
+
+
+% full nodes for wire crossing
+
+\pgfdeclareshape{jump crossing}
+{
+    \savedanchor\northwest{%
+        \pgf@y=\ctikzvalof{bipoles/crossing/size}\pgf@circ@Rlen
+        \pgf@y=.5\pgf@y
+        \pgf@x=-\pgf@y
+    }
+    \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
+    \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+    \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+    \anchor{west}{ \northwest \pgf@y=0pt }
+    \anchor{w}{ \northwest \pgf@y=0pt }
+    \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+    \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+    \anchor{north}{ \northwest \pgf@x=0pt }
+    \anchor{n}{ \northwest \pgf@x=0pt }
+    \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
+    \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
+    \anchor{north west}{ \northwest }
+    \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
+    \behindbackgroundpath{
+        \northwest
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@right = -\pgf@x
+        \pgf@circ@res@left = \pgf@x
+        % horizontal jumper
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathlineto{\pgfpoint{0.4\pgf@circ@res@left}{0pt}}
+        \pgfpatharc{0}{-180}{0.4*\pgf@circ@res@left}
+        \pgfsetbeveljoin
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+        % vertical, broken path
+        \pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0pt}{0.5\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0pt}{0.3\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down}}
+        \pgfusepath{draw}
+
+    }
+}
+\pgfdeclareshape{plain crossing}
+{
+    \savedanchor\northwest{%
+        \pgf@y=\ctikzvalof{bipoles/crossing/size}\pgf@circ@Rlen
+        \pgf@y=.5\pgf@y
+        \pgf@x=-\pgf@y
+    }
+    \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
+    \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+    \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
+    \anchor{west}{ \northwest \pgf@y=0pt }
+    \anchor{w}{ \northwest \pgf@y=0pt }
+    \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+    \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
+    \anchor{north}{ \northwest \pgf@x=0pt }
+    \anchor{n}{ \northwest \pgf@x=0pt }
+    \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
+    \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
+    \anchor{north west}{ \northwest }
+    \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
+    \behindbackgroundpath{
+        \northwest
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@right = -\pgf@x
+        \pgf@circ@res@left = \pgf@x
+        % horizontal jumper
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+        % vertical, broken path
+        \pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0pt}{0.1\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0pt}{0.1\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down}}
+        \pgfusepath{draw}
+
+    }
 }
 
 \endinput


### PR DESCRIPTION
Moreover, I added the standard anchors to circ, ocirc and diamondpole so
that the keys left, right etc. work with them.
Meanwhile, reorganize the related manual part.

![image](https://user-images.githubusercontent.com/6414907/54223731-6ba40400-44f8-11e9-859c-2f8870537565.png)
