### PR TITLE
Fix a typo in the new node description macro

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -103,7 +103,7 @@
             }
         \end{circuitikz}%
         }{%
-        {#3, type: node\IfBooleanT{#1}{, fillable}%
+        {#4, type: node\IfBooleanT{#1}{, fillable}%
     } (\texttt{node[#3]\{#5\}}) \index{#3} }
 }
 % description of a path-style component:


### PR DESCRIPTION
The real description was not printed any more