### PR TITLE
[WIP] Fixing typos in the manual

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,5 +1,5 @@
-circuitikzmanual.*
-compatibility.*
-circuitikz-context.*
-!*.tex
-changelog.tex
+# circuitikzmanual.*
+# compatibility.*
+# circuitikz-context.*
+# !*.tex
+# changelog.tex

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,5 +1,5 @@
-# circuitikzmanual.*
-# compatibility.*
-# circuitikz-context.*
-# !*.tex
-# changelog.tex
+circuitikzmanual.*
+compatibility.*
+circuitikz-context.*
+!*.tex
+changelog.tex

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -204,7 +204,7 @@ You can check the used version at your local installation using the macro \verb!
     \item After v0.8.4: voltage and current directions/sign (plus and minus signs in case of \texttt{american voltages} and arrows in case of \texttt{european voltages} have been rationalized with a couple of new options (see details in section~\ref{curr-and-volt}. The default case is still the same as v0.8.4.
     \item Since v0.8.2: voltage and current label directions(v<= / i<=) do NOT change the orientation of the drawn source shape anymore. Use the "invert" option to rotate the shape of the source. Furthermore, from this version on, the current label(i=) at current sources can be used independent of the regular label(l=).
     \item Since v0.7?: The label behaviour at mirrored bipoles has changes, this fixes the voltage drawing, but perhaps you have to adjust your label positions.
-    \item Since v0.5.1: The parts pfet,pigfete,pigfetebulk and pigfetd are now mirrored by default. Please adjust your yscale-option to correct this.
+    \item Since v0.5.1: The parts pfet, pigfete, pigfetebulk and pigfetd are now mirrored by default. Please adjust your yscale-option to correct this.
     \item Since v0.5: New voltage counting direction, here exists an option to use the old behaviour
 \end{itemize}
 For older projects, you can use an older version locally using the git-version and picking the correct commit from the repository (branch gh-pages).
@@ -353,7 +353,7 @@ You can use a single path or multiple path when drawing your circuit, it's just 
 \end{circuitikz}
 \end{LTXexample}
 
-One of the problems with this circuit is that we would like to have the current in a different position, such as for example on the upper side of the resistors, so that the Kirchoff's Current Law at the node is better shown to students. No problem; as you can see in section~\ref{curr-and-volt} you can use the position specifier \verb|<>^_}| after the key \texttt{i}:
+One of the problems with this circuit is that we would like to have the current in a different position, such as for example on the upper side of the resistors, so that Kirchoff's Current Law at the node is better shown to students. No problem; as you can see in section~\ref{curr-and-volt} you can use the position specifier \verb|<>^_}| after the key \texttt{i}:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american]
@@ -450,7 +450,7 @@ So let's start with the first stage transistor; given that my preferred way of d
 \end{circuitikz}
 \end{LTXexample}
 
-Another thing I like to modify with respect to the standard is the position of the arrows in transistors, which are normally midway the symbol. Issuing the following settings will moe the arrows to the end or start  of the corresponding pin.
+Another thing I like to modify with respect to the standard is the position of the arrows in transistors, which are normally midway the symbol. Issuing the following settings will move the arrows to the end or start  of the corresponding pin.
 
 \ctikzset{tripoles/mos style/arrows,
 tripoles/npn/arrow pos=0.8,
@@ -672,7 +672,7 @@ All can be varied using the \verb!\ctikzset! command, anywhere in the code.
 
 \paragraph{Components size}
 Perhaps the most important parameter is \texttt{bipoles/length}  (default \SI{1.4}{cm}), which
-can be interpreted as the length of a resistor (including reasonable connections): all other lenghts are relative to this value. For instance:
+can be interpreted as the length of a resistor (including reasonable connections): all other lengths are relative to this value. For instance:
 
 \begin{LTXexample}[pos=t,varwidth=true]
 \ctikzset{bipoles/length=1.4cm}
@@ -946,7 +946,7 @@ The anchor is positioned just on the corner of the segmented line crossing the c
     \circuitdescbip[fullbidirectionaldiode]{full bidirectionaldiode}{Full bidirectionaldiode}{biD*}
 \end{groupdesc}
 
-These shapes has no exact node-style counterpart, because the stroke line is build upon the empty variants:
+These shapes have no exact node-style counterpart, because the stroke line is built upon the empty variants:
 
 \begin{groupdesc}
     \circuitdescbip*[emptydiode] {stroke diode}{Stroke diode}{D-}
@@ -959,7 +959,7 @@ These shapes has no exact node-style counterpart, because the stroke line is bui
     \circuitdescbip*[emptyvarcap]{stroke varcap}{Stroke varcap}{VC-}
 \end{groupdesc}
 
-\subsection{Tripole-like diodes}\label{sec:othertrip} The following tripoles are entered with the usual command of the form
+\subsection{Tripole-like diodes}\label{sec:othertrip} The following tripoles are entered with the usual command, of the form
 \begin{groupdesc}
     \circuitdescbip*[emptytriac]{triac}{Standard triac (shape depends on package option)}{Tr}( G/0/0.3 )
     \circuitdescbip*[emptytriac]{empty triac}{Empty triac}{Tro}( gate/0/0.3 )
@@ -972,7 +972,7 @@ These shapes has no exact node-style counterpart, because the stroke line is bui
 
 \subsubsection{Triacs anchors}
 
-When inserting a thrystor, a triac or a potentiometer, one needs to refer to the third node--gate (\texttt{gate} or \texttt{G}) for the former two; wiper (\texttt{wiper} or \texttt{W}) for the latter one. This is done by giving a name to the bipole:
+When inserting a thrystor, a triac or a potentiometer, one needs to refer to the third node-gate (\texttt{gate} or \texttt{G}) for the former two; wiper (\texttt{wiper} or \texttt{W}) for the latter one. This is done by giving a name to the bipole:
 \label{bipole-naming}
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
@@ -984,7 +984,7 @@ When inserting a thrystor, a triac or a potentiometer, one needs to refer to the
 
 
 \begin{framed}
-The package options \texttt{fulldiode}, \texttt{strokediode}, and \texttt{emptydiode} (and the styles \texttt{[full diodes]}, \texttt{[stroke diodes]}, and \texttt{[empty diodes]}) define which shape will be used by abbreviated commands such that \texttt{D}, \texttt{sD}, \texttt{zD}, \texttt{zzD}, \texttt{tD}, \texttt{pD}, \texttt{leD}, \texttt{VC}, \texttt{Ty},\texttt{Tr}(no stroke symbol available!).
+The package options \texttt{fulldiode}, \texttt{strokediode}, and \texttt{emptydiode} (and the styles \texttt{[full diodes]}, \texttt{[stroke diodes]}, and \texttt{[empty diodes]}) define which shape will be used by abbreviated commands such that \texttt{D}, \texttt{sD}, \texttt{zD}, \texttt{zzD}, \texttt{tD}, \texttt{pD}, \texttt{leD}, \texttt{VC}, \texttt{Ty},\texttt{Tr} (no stroke symbol available!).
 \end{framed}
 
 
@@ -1326,8 +1326,8 @@ Since inputs and outputs can vary, input arrows can be placed as nodes. Note tha
 \end{LTXexample}
 
 
-\paragraph{Labels and custom twoport boxes}
-Some twoports have the option to place a normal label (\texttt{l=}) and a inner label (\texttt{t=}).
+\paragraph{Labels and custom two-port boxes}
+Some two-ports have the option to place a normal label (\texttt{l=}) and a inner label (\texttt{t=}).
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
   \ctikzset{bipoles/amp/width=0.9}
@@ -1376,7 +1376,7 @@ To show that a device is optional, you can dash it. The inner symbol will be kep
     \circuitdesc{Lpigbt}{\scshape Lpigbt}{}
 \end{groupdesc}
 
-For all transistors a bodydiode (or freewheeling diode) can automatically be drawn. Just use the global option bodydiode, or for single transistors, the tikz-option bodydiode:
+For all transistors a body diode (or freewheeling diode) can automatically be drawn. Just use the global option bodydiode, or for single transistors, the tikz-option bodydiode:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -1646,7 +1646,7 @@ The internal part of the motor and generator are, by default, filled white (to a
 \draw[thick,->>](motor.center)--++(1.5,0)node[midway,above]{$\omega$};
 \end{circuitikz}
 \end{LTXexample}
-The symbols can also be used along a path, using the transistor-path-syntax(T in front of the shape name, see section \ref{sec:transasbip}). Don´t forget to use parameter $n$ to name the node and get acces to the anchors:
+The symbols can also be used along a path, using the transistor-path-syntax(T in front of the shape name, see section \ref{sec:transasbip}). Don´t forget to use parameter $n$ to name the node and get access to the anchors:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
 \draw (0,0) to [Telmech=M,n=motor] ++(0,-3) to [Telmech=M] ++(3,0) to [Telmech=G,n=generator] ++(0,3) to [R] (0,0);
@@ -1720,7 +1720,7 @@ The set of anchors, to which the standard ``geographical'' \texttt{north}, \text
 \end{circuitikz}
 \end{quote}
 
-Alse the standard ``geographical'' \texttt{north}, \texttt{north east}, etc. are defined.
+Also, the standard ``geographical'' \texttt{north}, \texttt{north east}, etc. are defined.
 A couple of examples follow:
 
 \begin{LTXexample}[varwidth=true]
@@ -1869,7 +1869,7 @@ All these amplifier have the possibility to flip input and output (if needed) po
 ;\end{circuitikz}
 \end{LTXexample}
 
-When you use the \texttt{noinv input/output ...} keys the anchors (\texttt{+}, \texttt{-}, \texttt{out +}, \texttt{out -}) will change with the effective position of the terminals. You have also the anchors \texttt{in up}, \texttt{in down}, \texttt{out up}, \texttt{out down} that will not change with the positive or negatie sign.
+When you use the \texttt{noinv input/output ...} keys the anchors (\texttt{+}, \texttt{-}, \texttt{out +}, \texttt{out -}) will change with the effective position of the terminals. You have also the anchors \texttt{in up}, \texttt{in down}, \texttt{out up}, \texttt{out down} that will not change with the positive or negative sign.
 
 
 
@@ -2301,7 +2301,7 @@ The line thickness of the main shape is controlled by \texttt{multipoles/thickne
 Chips have anchors on pins and global anchors for the main shape.
 The pin anchors to be used to connect wires to the chip are called \texttt{pin 1}, \texttt{pin 2} , \dots, with just one space between \texttt{pin} and the number.
 Border pin anchors (\texttt{bpin 1}\dots) are always on the box border, and can be used to add numbers or whatever markings are needed.
-Obviously, in case of \texttt{multipoles/external pins width} equal to cero, border and normal pin anchors will coincide.
+Obviously, in case of \texttt{multipoles/external pins width} equal to zero, border and normal pin anchors will coincide.
 
 Additionally, you have geometrical anchors on the chip ``box'', see the following figure. The nodes are available with the full name (like \texttt{north}) and with the short abbreviations \texttt{n}, \texttt{nw}, \texttt{w}\dots. The \texttt{dot} anchor is useful to add a personalized marker if you use the \texttt{no topmark} key.
 
@@ -2334,7 +2334,7 @@ Additionally, you have geometrical anchors on the chip ``box'', see the followin
 \subsubsection{Chips rotation}
 
 You can rotate chips, and normally the pin numbers are kept straight (option \texttt{straight numbers}, which is the default), but you can rotate them if you like with \texttt{rotated numbers}.
-Notice that the main label has to be (counter-)rotated manually in this case.
+Notice that the main label has to be (counter-) rotated manually in this case.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -2349,7 +2349,7 @@ Notice that the main label has to be (counter-)rotated manually in this case.
 
 \subsubsection{Chip special usage}
 
-You can use the chips to have special, personalized blocks.
+You can use chips to have special, personalized blocks.
 Look at the following example, which is easily put into a macro.
 
 \begin{LTXexample}[varwidth=true]
@@ -2511,7 +2511,7 @@ You also can use stacked (two lines) labels.  The example should be self-explana
 
 The default direction/sign for currents and voltages in the components is, unfortunately, not standard, and can change across country and sometime across different authors.
 This unfortunate situation created a bit of confusion in \texttt{circuitikz} across the versions, with several incompatible changes starting from version 0.5.
-From version 0.8.4 onward, the maintainers agreed a new policy for the directions of bipoles's voltages and currents, depending on 4 different possible options:
+From version 0.8.4 onward, the maintainers agreed a new policy for the directions of bipoles' voltages and currents, depending on 4 different possible options:
 \begin{itemize}
     \item \texttt{oldvoltagedirection}, or the key style \texttt{voltage dir=old}: Use old way of voltage direction having a difference between european and american direction, with wrong default labelling for batteries (it was the default before version 0.5);
     \item \texttt{nooldvoltagedirection}, or the key style \texttt{voltage dir=noold}: The standard from version 0.5 onward, utilize the (German?) standard of voltage arrows in the  direction of electric fields (without fixing batteries);
@@ -2640,7 +2640,7 @@ Inline (along the wire) currents are selected with \verb|i_>|, \verb|i^<|, \verb
 \end{circuitikz}
 \end{LTXexample}
 
-Also
+Also:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -2705,7 +2705,7 @@ Also
 \subsection{Flows}\label{flows}
 As an alternative for the current arrows, you can also use the following flows. They can also be used to indicate thermal or power flows. The syntax is pretty the same as for currents.
 
-\textit{This is a new beta feature since version 0.8.3, therefore, please provide bugreports or hints to optimize this feature regarding placement and appearance! This means, that the appearance may change in the future!}
+\textit{This is a new beta feature since version 0.8.3; therefore, please provide bug reports or hints to optimize this feature regarding placement and appearance! This means that the appearance may change in the future!}
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1606,7 +1606,7 @@ Notes that in the transmission and receiving antennas, the ``waves'' are outside
 
 \subsubsection{Microstrip customization}
 
-The microstrip linear components (\texttt{mstline}, \texttt{mslstub}, \texttt{msport}) height depend from the parameters \texttt{bipoles/mstline/height} (for the three or them, default 0.3). The width are specified in \texttt{bipoles/mstline/width} for the first two and by \texttt{monopoles/msport/width} for the port (defaults: 1.2, 0.5).
+The microstrip linear components' (\texttt{mstline}, \texttt{mslstub}, \texttt{msport}) heights depend on the parameters \texttt{bipoles/mstline/height} (for the three of them, default 0.3). The widths are specified in \texttt{bipoles/mstline/width} for the first two and by \texttt{monopoles/msport/width} for the port (defaults: 1.2, 0.5).
 
 For the length parameter of the transmission line there is a shortcut in the form of the direct parameter \texttt{mstlinelen}.
 
@@ -1930,7 +1930,7 @@ However, sometime it is advisable to mark the non-contact situation more explici
 \end{circuitikz}
 \end{LTXexample}
 
-That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometime a bit of trials and errors are needed to position it.
+That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometime a bit of trial and error is needed to position it.
 
 For a more powerful (and elegant) way you can use the crossing nodes:
 
@@ -1981,7 +1981,7 @@ These are all of the to-style type:
     \circuitdescbip[toggleswitch]{toggle switch}{Toggle switch}{}
 \end{groupdesc}
 
-While this is a node-style component
+while this is a node-style component:
 
 \begin{groupdesc}
 	\circuitdesc{spdt}{spdt}{}( in/180/0.2, out 1/0/0.2, out 2/0/0.2 )
@@ -3215,7 +3215,7 @@ Bipole paths can also mirrored and inverted (or reverted) to change the drawing 
 \end{circuitikz}
 \end{LTXexample}
 
-Placing labels, currents and voltages works also, please note, that mirroring and inverting does not incfluence the positioning of labels and voltages. Labels are by default above/right of the bipole and voltages below/left, respectively.
+Placing labels, currents and voltages works also, please note, that mirroring and inverting does not influence the positioning of labels and voltages. Labels are by default above/right of the bipole and voltages below/left, respectively.
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
    \draw (0,0) to[ospst=T, i=$i_1$, v=$v$] (2,0);
@@ -3258,7 +3258,7 @@ Placing labels, currents and voltages works also, please note, that mirroring an
 \subsection{Line joins between Path Components}
 \label{sec:line-joins}
 
-Line joins should be calculated correctly, if the were on the same path and if the path is not closed. For example, the following path is not closed correctly(\textit{--cycle} does not work here!):
+Line joins should be calculated correctly, if the are on the same path and if the path is not closed. For example, the following path is not closed correctly (\textit{--cycle} does not work here!):
 \begin{LTXexample}[varwidth=true]
 	\begin{tikzpicture}[line width=3pt,european]
 	\draw (0,0) to[R]++(2,0)to[R]++(0,2)
@@ -3266,7 +3266,7 @@ Line joins should be calculated correctly, if the were on the same path and if t
 	\draw[red,line width=1pt] circle(2mm);
 	\end{tikzpicture}
 \end{LTXexample}
-To correct the line ending, there are support shapes to fill the missing rectangle. They can be used like the support shapes(*,o,d) using a dot (.) on one or both ends of a component(have a look at the last resistor in this example:
+To correct the line ending, there are support shapes to fill the missing rectangle. They can be used like the support shapes (*,o,d) using a dot (.) on one or both ends of a component (have a look at the last resistor in this example:
 \begin{LTXexample}[varwidth=true]
 	\begin{tikzpicture}[line width=3pt,european]
 	\draw (0,0) to[R]++(2,0)to[R]++(0,2)


### PR DESCRIPTION
Hi,
First of all - thanks for this package!  I've been using it for a couple of weeks now, and I really like the functionality.

I noticed some typos in the manual that I wanted to fix.  I'm not quite done with going through it all yet, and I would like to give it a couple of passes, but this should hopefully fix some of the typos and such.  Minor stuff, but it does help polish it up a bit :)