### PR TITLE
Start new development structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version git (0.9.1, unreleased)
+    - Bumped the version to 0.9.1 so it's clearly different in log from the released one.
+
 * Version 0.9.0 (2019-05-10)
     - Added Romano Giannetti as contributor
     - Added a CONTRIBUTING file

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -9,8 +9,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{0.9.0}
-\def\pgfcircversiondate{2019/05/10}
+\def\pgfcircversion{0.9.1}
+\def\pgfcircversiondate{2019/05/11}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
-\def\pgfcircversion{0.9.0}
-\def\pgfcircversiondate{2019/05/10}
+\def\pgfcircversion{0.9.1}
+\def\pgfcircversiondate{2019/05/11}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
I marked the new version 0.9.1, so that it will be clear if the user is
using a development version and _not_ using the circuitikzgit.sty file,
which is possible if the user has the git repository in their TEXINPUT
path.