### PR TITLE
Add details about using older versions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,38 @@ So I based everything with the very impressive (if somewhat verbose at times) Ti
 The stable version is available on ctan and is included within the major latex distributions(Texlive, Miktex). If you want to test the latest version, have a look at http://circuitikz.github.io/circuitikz/. There you can find the latest git-version as a single file, just copy it to your project or to your local tex tree. 
 
 ## Usage
+### Stable version
 Just place
-````latex
+```latex
   \usepackage{circuitikz}
-````
+```
 or, for ConTeXt, 
-````latex
+```latex
   \usemodule[circuitikz]
-````
+```
 in the preamble and compile away, both with PS and PDF target output.
 
-If you want to use or to try the git version, just append a git the package name:
-````latex
+### Development version
+
+If you want to use the git version, just append a git to the package name:
+```latex
   \usepackage{circuitikzgit}
-````
+```
 or, for ConTeXt,
-````latex
+```latex
   \usemodule[circuitikzgit]
-````
+```
+
+### Older versions
+
+If you want to use older versions of `circuitikz`, just append the version number to the package name, as in `circuitikz-$version`:
+```latex
+  \usepackage{circuitikz-0.8.3}
+```
+or, for ConTeXt,
+```latex
+  \usemodule[circuitikz-0.8.3]
+```
 ## More Information
 More Information can be found in the manual and at the wiki of the project located at https://github.com/circuitikz/circuitikz/wiki.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ or, for ConTeXt,
   \usemodule[circuitikzgit]
 ```
 
-### Older versions
+### Older versions (v0.9.1 onwards)
 
 If you want to use older versions of `circuitikz`, just append the version number to the package name, as in `circuitikz-$version`:
 ```latex


### PR DESCRIPTION
DO NOT MERGE (yet):

This will have to wait till a new version of `circuitikz` is released, which has the old versions bundled with it.