### PR TITLE
Release 0.9.1, official date 16 Jun 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version git (0.9.1, unreleased)
-    - Bumped the version to 0.9.1 so it's clearly different in log from the released one.
+* Version 0.9.1
     - Added old LaTeX versions for 0.8.3, 0.7, 0.6 and 0.4
     - Added the option to have inline transformers and gyrators
     - Added rotary switches
-    - Added more configurable bipole nodes and more shapes
+    - Added more configurable bipole nodes (connectors) and more shapes
     - Added 7-segment displays
     - Added vacuum tubes by J. op den Brouw 
     - Made the open shape of dcisources configurable

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -10,7 +10,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{0.9.1}
-\def\pgfcircversiondate{2019/05/11}
+\def\pgfcircversiondate{2019/06/16}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
 \def\pgfcircversion{0.9.1}
-\def\pgfcircversiondate{2019/05/11}
+\def\pgfcircversiondate{2019/06/16}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
        - Added old LaTeX versions for 0.8.3, 0.7, 0.6 and 0.4
        - Added the option to have inline transformers and gyrators
        - Added rotary switches
        - Added more configurable bipole nodes (connectors) and more shapes
        - Added 7-segment displays
        - Added vacuum tubes by J. op den Brouw
        - Made the open shape of dcisources configurable
        - Made the arrows on vcc and vee configurable
        - Fixed anchors of diamondpole nodes
        - Fixed a bug (#205) about unstable anchors in the chip components
        - Fixed a regression in label placement for some values of scaling
        - Fixed problems with cute switches anchors

    Lot of thanks to J. op den Brouw <J.E.J.opdenBrouw@hhs.nl> and
    to Anshul Singhvi <anshulsinghvi@gmail.com> for the help!