### PR TITLE
Release 0.9.2, official date 21 Jun 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 0.9.2 (unreleased)
+* Version 0.9.2 (2019-06-21)
     - (hopefully) fixed ConTeXt compatibility. Most new functionality is not tested; testers and developers for the ConTeXt side are needed.
     - Added old ConTeXt version for 0.8.3
     - Added tailless ground
 
-* Version 0.9.1
+* Version 0.9.1 (2019-06-16)
     - Added old LaTeX versions for 0.8.3, 0.7, 0.6 and 0.4
     - Added the option to have inline transformers and gyrators
     - Added rotary switches

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ manual: manual-latex manual-context clean
 manual-context: changelog
 	rm -f doc/circuitikz-context.pdf
 	rm -f doc/tmp.pdf
-	cd doc;context circuitikz-context.tex
+	cd doc; TEXINPUTS=.:../tex/: context circuitikz-context.tex
 	#optimize for smaller filesize(faktor 2!)--> no benefit at context!
 	#gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -sOutputFile=doc/tmp.pdf doc/circuitikz-context.pdf
 	#mv doc/tmp.pdf doc/circuitikz-context.pdf

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -9,8 +9,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{0.9.1}
-\def\pgfcircversiondate{2019/06/16}
+\def\pgfcircversion{0.9.2}
+\def\pgfcircversiondate{2019/06/21}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
-\def\pgfcircversion{0.9.1}
-\def\pgfcircversiondate{2019/06/16}
+\def\pgfcircversion{0.9.2}
+\def\pgfcircversiondate{2019/06/21}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
This is basically a bug-fix release for ConTeXt following 0.9.1.
Release 0.9.2 (2019-06-21)

     - (hopefully) fixed ConTeXt compatibility. Most new functionality is not tested;
        testers and developers for the ConTeXt side are needed.
     - Added old ConTeXt version for 0.8.3
     - Added tailless ground

Release 0.9.1:

      - Added old LaTeX versions for 0.8.3, 0.7, 0.6 and 0.4
      - Added the option to have inline transformers and gyrators
      - Added rotary switches
      - Added more configurable bipole nodes (connectors) and more shapes
      - Added 7-segment displays
      - Added vacuum tubes by J. op den Brouw
      - Made the open shape of dcisources configurable
      - Made the arrows on vcc and vee configurable
      - Fixed anchors of diamondpole nodes
      - Fixed a bug (#205) about unstable anchors in the chip components
      - Fixed a regression in label placement for some values of scaling
      - Fixed problems with cute switches anchors