### PR TITLE
Fix problem with coupler2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 0.9.3 (unreleased, starting development 2019-06-23)
     - Bumped version to avoid confusion.
+    - Fixed a (puzzling) problem with coupler2
 
 * Version 0.9.2 (2019-06-21)
     - (hopefully) fixed ConTeXt compatibility. Most new functionality is not tested; testers and developers for the ConTeXt side are needed.

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -464,23 +464,30 @@
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
     \pgfusepath{draw}
 
-    \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@left}{0pt}}
-    \pgfpatharc{0}{90} {0.4\pgf@circ@res@up}
-    \pgfsetarrowsend{latex}
-    \pgfusepath{draw}
-    \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@left}{0pt}}
-    \pgfpatharc{0}{-90} {0.4\pgf@circ@res@up}
-    \pgfsetarrowsend{latex}
-    \pgfusepath{draw}
-
-    \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@right}{0pt}}
-    \pgfpatharc{180}{90} {0.4\pgf@circ@res@up}
-    \pgfsetarrowsend{latex}
-    \pgfusepath{draw}
-    \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@right}{0pt}}
-    \pgfpatharc{-180}{-90} {0.4\pgf@circ@res@up}
-    \pgfsetarrowsend{latex}
-    \pgfusepath{draw}
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@left}{0pt}}
+        \pgfpatharc{0}{90} {0.4\pgf@circ@res@up}
+        \pgfsetarrowsend{latex}
+        \pgfusepath{draw}
+    \endpgfscope
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@left}{0pt}}
+        \pgfpatharc{0}{-90} {0.4\pgf@circ@res@up}
+        \pgfsetarrowsend{latex}
+        \pgfusepath{draw}
+    \endpgfscope
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@right}{0pt}}
+        \pgfpatharc{180}{90} {0.4\pgf@circ@res@up}
+        \pgfsetarrowsend{latex}
+        \pgfusepath{draw}
+    \endpgfscope
+    \pgfscope
+        \pgfpathmoveto{\pgfpoint{0.1\pgf@circ@res@right}{0pt}}
+        \pgfpatharc{-180}{-90} {0.4\pgf@circ@res@up}
+        \pgfsetarrowsend{latex}
+        \pgfusepath{draw}
+    \endpgfscope
 }
 
 % contrib Kristofer M. Monisit


### PR DESCRIPTION
It seems that the arc+arrows mingle with the origin of
the coordinates. Insulate them with \pgfscope.

Fixes #239 