### PR TITLE
Fix the pentode anchors description

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1813,7 +1813,7 @@ Electronic tubes, also known as vacuum tubes, control current flow between elect
 Some pentodes have the suppressor grid internally connected to the control grid, which saves a pin on the tube's housing.
 
 \begin{groupdesc}
-	\circuitdesc*{pentode suppressor to cathode}{Pentode with suppressor grid connected to cathode}{} ( anode/90/0.2, cathode/-90/0.2, control/190/0.2,screen/180/0.2 )
+	\circuitdesc*{pentode suppressor to cathode}{Pentode with suppressor grid connected to cathode}{}( anode/90/0.2, cathode/-90/0.2, control/190/0.2,screen/180/0.2 )
 \end{groupdesc}
 
 Note that the \verb|diodetube| is used as component name to avoid clashes with the semiconductor diode.


### PR DESCRIPTION
There could be no space before an optional argument if it
follows a mandatory argument...