### PR TITLE
Release 0.9.3, official date 13 Jul 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 0.9.3 (unreleased, starting development 2019-06-23)
-    - Bumped version to avoid confusion.
+* Version 0.9.3 (2019-07-13)
     - Added the option to have "dotless" P-MOS (to use with arrowmos option)
     - Fixed a (puzzling) problem with coupler2
     - Fixed a compatibility problem with newer PGF (>3.0.1a)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -10,7 +10,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{0.9.3}
-\def\pgfcircversiondate{2019/06/23}
+\def\pgfcircversiondate{2019/07/13}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
 \def\pgfcircversion{0.9.3}
-\def\pgfcircversiondate{2019/06/23}
+\def\pgfcircversiondate{2019/07/13}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
This is mainly a bugfix release.
     - Added the option to have "dotless" P-MOS (to use with arrowmos option)
       see https://github.com/circuitikz/circuitikz/issues/243
     - Fixed a (puzzling) problem with coupler2
       see https://github.com/circuitikz/circuitikz/issues/239
     - Fixed a compatibility problem with newer PGF (>3.0.1a)
       see https://github.com/circuitikz/circuitikz/issues/243

Thanks to Alessandro Cuttin https://github.com/afcuttin for helping
with bug hunting and fixing.