### PR TITLE
Fixed a bug when using inline gyrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 0.9.4 (unreleased)
     - Bumped the release number to avoid problems
+    - Fixed a bug with "inline" gyrators, now the circle will not overlap
 
 * Version 0.9.3 (2019-07-13)
     - Added the option to have "dotless" P-MOS (to use with arrowmos option)

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -302,11 +302,12 @@
     \pgfusepath{draw}
 
     \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/quadpoles/thickness}\pgflinewidth}
-    \pgfpathmoveto{\pgfpoint{\stretto\pgf@circ@res@left}{.7*\stretto\pgf@circ@res@down}}
-    \pgfpatharc{90}{270}{.7*\stretto\pgf@circ@res@down}
+    \pgfmathsetlength{\pgf@circ@res@other}{min(.7*\stretto*\pgf@circ@res@up, .8*\pgf@circ@res@right)} % radius
+    \pgfpathmoveto{\pgfpoint{\stretto\pgf@circ@res@left}{-\pgf@circ@res@other}}
+    \pgfpatharc{-90}{90}{\pgf@circ@res@other}
 
-    \pgfpathmoveto{\pgfpoint{\stretto\pgf@circ@res@right}{.7*\stretto\pgf@circ@res@up}}
-    \pgfpatharc{-90}{90}{.7*\stretto\pgf@circ@res@down}
+    \pgfpathmoveto{\pgfpoint{\stretto\pgf@circ@res@right}{\pgf@circ@res@other}}
+    \pgfpatharc{90}{270}{\pgf@circ@res@other}
     \pgfusepath{draw}
 
 }{}


### PR DESCRIPTION
No one noticed, so... "inline" gyrators had overlapping semicircles. Now it's fixed. 