### PR TITLE
Minimum fix for poles on transistor paths.

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2306,7 +2306,9 @@ Access to the gate and/or base nodes can be gained by naming the transistors wit
 ;\end{circuitikz}
 \end{LTXexample}
 
-The \texttt{name} property is available also for bipoles, although this is useful mostly for triac, potentiometer and thyristor (see~\ref{sec:othertrip}).
+Transistor paths have the possibility to use the poles syntax (see section~\ref{sec:bipole-nodes}) but they have \textbf{no} voltage, current, flow, annotation options.
+
+The \texttt{name} property is available also for bipoles; this is useful mostly for triac, potentiometer and thyristor (see~\ref{sec:othertrip}).
 
 \subsubsection{Transistors customization}\label{sec:styling-transistors}
 

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -826,6 +826,7 @@
         (\ctikzvalof{bipole/name}start.center) --(\ctikzvalof{bipole/name}.left)
         (\ctikzvalof{bipole/name}.right)  -- (\ctikzvalof{bipole/name}end.center)
     \fi
+    \drawpoles
     \pgfextra{
         \pgfcircresetpath
     }


### PR DESCRIPTION
Fixes #262 

This is not so satisfactory as it would have been PR #269, but it's quite minimal and it works at least to have poles added to the transistor paths. 

The example in #262 compiles to: 

![image](https://user-images.githubusercontent.com/6414907/63714088-4ce4c000-c841-11e9-824f-bc8db32ec378.png)
