### PR TITLE
Fixed voltage label and element position when scale is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Fixed a bug in input anchors of european not ports
     - Fixed "tlinestub" so that it has the same default size than "tline" (TL)
     - Fixed the "transistor arrows at end" feature, added to styling
+    - Changed the behavior of "voltage shift" and voltage label positioning to be more robust
     - Added several new anchors for "elmech" element
     - Several minor fixes in some component drawings to allow fill and thickness styles
     - Add 0.9.3 version snapshots. The styling addition are quite big; they should be backward compatible, but better safe than sorry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
 * Version 0.9.4 (unreleased)
+
+    This release introduces two changes: a big one, which is the styling of the components (please look at the manual for details) and a change to how voltage labels and arrows are positioned. This one should be backward compatible *unless* you used `voltage shift` introduced in 0.9.0, which was broken when using the global `scale` parameter.
+
     - Fixed a bug with "inline" gyrators, now the circle will not overlap
     - Fixed a bug in input anchors of european not ports
     - Fixed "tlinestub" so that it has the same default size than "tline" (TL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The major changes among the different circuitikz versions are listed here. See <
 
     This release introduces two changes: a big one, which is the styling of the components (please look at the manual for details) and a change to how voltage labels and arrows are positioned. This one should be backward compatible *unless* you used `voltage shift` introduced in 0.9.0, which was broken when using the global `scale` parameter.
 
+    The styling additions are quite big, and, although in principle they are backward compatible, you can find corner cases where they are not, especially if you used to change parameters for `pgfcirc.defines.tex`; so a snapshot for the 0.9.3 version is available.
+
     - Fixed a bug with "inline" gyrators, now the circle will not overlap
     - Fixed a bug in input anchors of european not ports
     - Fixed "tlinestub" so that it has the same default size than "tline" (TL)
@@ -12,7 +14,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Changed the behavior of "voltage shift" and voltage label positioning to be more robust
     - Added several new anchors for "elmech" element
     - Several minor fixes in some component drawings to allow fill and thickness styles
-    - Add 0.9.3 version snapshots. The styling addition are quite big; they should be backward compatible, but better safe than sorry.
+    - Add 0.9.3 version snapshots.
     - Added styling of relative size of components (at a global or local level)
     - Added styling for fill color and thickeness
     - Added style files
@@ -33,7 +35,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Added rotary switches
     - Added more configurable bipole nodes (connectors) and more shapes
     - Added 7-segment displays
-    - Added vacuum tubes by J. op den Brouw 
+    - Added vacuum tubes by J. op den Brouw
     - Made the open shape of dcisources configurable
     - Made the arrows on vcc and vee configurable
     - Fixed anchors of diamondpole nodes

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -809,7 +809,8 @@ Several groups of components, on the other hand, have a special \texttt{scale} p
 
 \paragraph{Thickness of the lines}\label{sec:legacy-thickness} (globally)
 
-You can change the thickness of the components lines with the parameter \texttt{bipoles/thickness} (default 2). The number is relative to the thickness of the normal lines leading to the component.
+The best way to alter the thickness of components is using styling, see section~\ref{sec:styling-thickness}. Alternatively, you can use ``legacy'' classes like \texttt{bipole}, \texttt{tripoles} and so on ---
+for example changing the parameter \texttt{bipoles/thickness} (default 2). The number is relative to the thickness of the normal lines leading to the component.
 
 \begin{LTXexample}[varwidth=true]
     \ctikzset{bipoles/thickness=1}
@@ -1024,7 +1025,7 @@ Old textbooks used the two-color style quite extensively, filling with a kind of
 
 \subsubsection{Line thickness}\label{sec:styling-thickness}
 
-You can change the line thickness for any class of component in an independent way. The default standard thickness of components is defined on a loose ``legacy'' category (like \texttt{bipoles}, +\texttt{tripoles} and so on, see section~\ref{sec:legacy-thickness}); to override that you set the key \texttt{\emph{class}/thickness} to any number. The default is \texttt{none}, which means that the old way of selecting thickness is used.
+You can change the line thickness for any class of component in an independent way. The default standard thickness of components is defined on a loose ``legacy'' category (like \texttt{bipoles}, \texttt{tripoles} and so on, see section~\ref{sec:legacy-thickness}); to override that you set the key \texttt{\emph{class}/thickness} to any number. The default is \texttt{none}, which means that the old way of selecting thickness is used.
 
 For example, \emph{amplifiers} have the legacy class of \texttt{tripoles}, as well as transistors and tubes.By default they are drawn with thickness 2 (relative to the base linewidth). To change them to be thicker, you can for example add to the previous style
 
@@ -4873,18 +4874,17 @@ The first step is to check if we can use the definition already existing for sim
 
 We will use them; at this stage you can decide to add other parameters if you need them. (Notice, however, than although flexibility is good, these parameters should be described in the manual, otherwise they're as good as a fixed number in the code).
 
-
 To define the new component we will look into \texttt{pgfcircbipoles.tex} and we will copy, for example, the definition of the damper into our code, just changing the name:
 
 \begin{lstlisting}
 %% mechanical resistor - damper
-\pgfcircdeclarebipole
+\pgfcircdeclarebipolescaled{mechanicals}
 {}                                   % extra anchors
 {\ctikzvalof{bipoles/damper/height}} % depth (under the path line)
 {viscoe}                             % name
 {\ctikzvalof{bipoles/damper/height}} % height (above the path line)
 {\ctikzvalof{bipoles/damper/width}}  % width
-{ % draw the bipole
+{
     \pgfpathrectanglecorners{\pgfpoint{\ctikzvalof{bipoles/damper/length}\pgf@circ@res@right}{\pgf@circ@res@down}}{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
     \pgf@circ@maybefill
 
@@ -4895,7 +4895,7 @@ To define the new component we will look into \texttt{pgfcircbipoles.tex} and we
     \pgfusepath{stroke}
 
     % damper box
-    \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+    \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
@@ -4912,10 +4912,17 @@ To define the new component we will look into \texttt{pgfcircbipoles.tex} and we
         {.8\pgf@circ@res@up}}
     \pgfsetbuttcap
     \pgfusepath{stroke}
+
 }
 \end{lstlisting}
 
-This command will define a shape that is named \texttt{viscoeshape}, with all the correct geographical anchors based on the depth, height and width defined in the parameters of \verb|\pgfcircdeclarebipole|. This is not sufficient for using the element in a \texttt{to[]} path command; you need to ``activate'' it with (this commands are normally in \texttt{pgfcircpath.tex}):
+This command will define a shape that is named \texttt{viscoeshape}, with all the correct geographical anchors based on the depth, height and width defined in the parameters of \verb|\pgfcircdeclarebipole|. Moreover, the element is assigned to the class \texttt{mechanicals} for styling.
+
+To be coherent with the styling, you should use (when needed) the length \verb|\pgf@circ@scaled@Rlen| as the ``basic'' length for drawing, using the fill functions defined at the start of \texttt{pgfcirc.defines.tex} to fill and stroke --- so that the operation will follow the style parameters and, finally, use the macro \verb|\pgf@circ@setlinewidth| to set the line thickness /the first argument is the ``legacy'' class, if you do not want to assign one you can use the pseudo-legacy class \texttt{none}.
+
+The anchors for the bipole (which then set the lengths \verb|\pgf@circ@res@left|) are already scaled for your use. You can use these lenghts (which defines, normally, the geographical anchors of the element) to draw your shapes.
+
+This is not sufficient for using the element in a \texttt{to[]} path command; you need to ``activate'' it with (this commands are normally in \texttt{pgfcircpath.tex}):
 
 \begin{lstlisting}
 \def\pgf@circ@viscoe@path#1{\pgf@circ@bipole@path{viscoe}{#1}}
@@ -4926,7 +4933,7 @@ This command will define a shape that is named \texttt{viscoeshape}, with all th
 And now you can show it with:
 
 \begin{lstlisting}
-\circuitdescbip*{viscoe}{Mechanical viscoelastic element\footnotemark}{}(left/135/0.2, right/45/0.2, center/-90/0.3)
+\circuitdescbip*{viscoe}{Mechanical viscoelastic element}{}(left/135/0.2, right/45/0.2, center/-90/0.3)
 
 \geolrcoord{viscoeshape, fill=yellow}
 
@@ -4950,7 +4957,7 @@ Looking at the implementation of the \texttt{spring} element, a possible impleme
     % spring into the damper
     \pgfscope
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
-        \pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+        \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfsetcornersarced{\pgfpoint{.25\pgf@circ@res@up}{.25\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{.75\pgf@circ@res@left}{.75\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{.5\pgf@circ@res@left}{-.75\pgf@circ@res@up}}
@@ -4975,12 +4982,6 @@ which leads to:
 \end{LTXexample}
 
 As a final note, notice that the \texttt{viscoe} element is already added to the standard package.
-
-Using \verb|\pgfcircdeclarebipole| will set up a component which is not globally scalable; if you want such a thing, you should use the command
-
-\verb|\pgfcircdeclarebipolescaled{resistors}|
-
-(for example), to put the new component in the ``resistors'' scale class, and then use \verb|\pgf@circ@scaled@Rlen|  as the default length in your code.
 
 \subsection{Node-style component}
 
@@ -5030,7 +5031,7 @@ The best way of contributing is forking the project, adding your component in th
         to[L, l=12<\milli\henry>, i=$i_1$,v=b] (4,0) -- (0,0)
   (4,2) { to[D*, *-*, color=red] (2,0) }
   (0,2) to[R, l=1<\kilo\ohm>, *-] (2,2)
-        to[cV, i=1,v=$\SI{.3}{\kilo\ohm} i_1$] (4,2)
+        to[cV, i=1,v=$\SI{.3}{\kilo\ohm}\, i_1$] (4,2)
   (2,0) to[I, i=1<\milli\ampere>, -*] (2,2)
 ;\end{circuitikz}
 \end{LTXexample}
@@ -5166,7 +5167,7 @@ The best way of contributing is forking the project, adding your component in th
 \end{tabular}
 
 % % changelog.tex will be updated by makefile from CHANGELOG.md
-\section{Changelog}
+\section{Changelog and Release Notes}
 \IfFileExists{changelog.tex}
 {\sloppy\input{changelog.tex}}
 {The file changelog.tex was not found, run 'make changelog' at toplevel to generate it with pandoc from CHANGELOG.md}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4192,17 +4192,18 @@ This could be especially useful if you define a style, to use like this:
 \tikz \draw (0,0) to[C, i=$\imath$] (2,0);
 \end{LTXexample}
 
-However, you can override the properties \texttt{voltage/distance from node} (how distant from the initial and final points of the path the arrow starts and ends), \texttt{voltage/bump b} (how high the bump of the arrow is --- how curved it is) and \texttt{voltage/european label distance} (how distant from the bipole the voltage label will be) on a per-component basis, in order to fine-tune the voltages:
+However, you can override the properties \texttt{voltage/distance from node} (how distant from the initial and final points of the path the arrow starts and ends) and \texttt{voltage/bump b} (how high the bump of the arrow is --- how curved it is)\footnote{Prior to 0.9.4 you had also \texttt{voltage/european label distance} (how distant from the bipole the voltage label will be) but this is deprecated, and the european-style label is printed near the bump)} on a per-component basis, in order to fine-tune the voltages:
 
 
 \begin{LTXexample}[varwidth=true]
 \tikz \draw (0,0) to[R, v=1<\volt>] (1.5,0)
        to[C, v=2<\volt>] (3,0); \par
-\ctikzset{bipoles/capacitor/voltage/%
-     distance from node/.initial=.7}
+\ctikzset{bipoles/capacitor/voltage/distance from node/.initial=.7}
 \tikz \draw (0,0) to[R, v=1<\volt>] (1.5,0)
        to[C, v=2<\volt>] (3,0); \par
 \end{LTXexample}
+
+Note the \texttt{.initial}; you have to create such key the first time you use it.
 
 
 \subsection{Nodes (also called poles)}\label{sec:bipole-nodes}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -186,16 +186,18 @@
 
 % Base len for all circuitikz
 \newdimen\pgf@circ@Rlen
-\ctikzset{bipoles/length/.code={\pgf@circ@Rlen = #1}}
+% scaled length for internal use in scalable shapes
+\newdimen\pgf@circ@scaled@Rlen
+\ctikzset{bipoles/length/.code={\pgf@circ@Rlen = #1\pgf@circ@scaled@Rlen=\pgf@circ@Rlen}}
 \pgf@circ@Rlen = 1.4cm
+% by default scale is 1.0
+\pgf@circ@scaled@Rlen=\pgf@circ@Rlen
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% main style definitions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-% scaled length for internal use in scalable shapes
-\newdimen\pgf@circ@scaled@Rlen
 
 % load a style file: search ctikzstyle-NAME.tex in path
 \def\ctikzloadstyle#1{%

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -135,8 +135,8 @@
         \pgfsetlinewidth{\ctikzvalof{#1/thickness}#2}%
     \fi
 }
-% use \pgf@circ@setlinewidth{one}{\pgflinewidth} if there is no legacy case
-\ctikzset{one/thickness/.initial=1.0} % do not touch
+% use \pgf@circ@setlinewidth{none}{\pgflinewidth} if there is no legacy case
+\ctikzset{none/thickness/.initial=1.0} % do not touch
 
 % voltage options
 

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -59,6 +59,7 @@
 
 
 %% Generic bipole path
+%% I am not user what the second argument is needed for
 \def\pgf@circ@bipole@path#1#2{
 
     \pgfextra{
@@ -70,7 +71,7 @@
         \def\pgf@circ@temp{}
         \ifx\pgf@temp\pgf@circ@temp % if it has not a name
             \pgfmathrandominteger{\pgf@circ@rand}{1000}{9999}
-            \ctikzset{bipole/name = #2\pgf@circ@rand} % create it
+            \ctikzset{bipole/name = #1\pgf@circ@rand} % create it (re-usage should not create problem, but...)
         \fi
     }
 

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -100,46 +100,61 @@
 \def\pgf@circ@avplus{\ctikzvalof{voltage/american plus}}
 \def\pgf@circ@avminus{\ctikzvalof{voltage/american minus}}
 
+%%
+\def\setscaledRlenforclass{%
+    \csname pgf@sh@ma@\ctikzvalof{bipole/name}\endcsname
+    \ifdefined\ctikzclass
+        \edef\pgf@temp{/tikz/circuitikz/\ctikzclass/scale}
+        \pgfkeysifdefined{\pgf@temp}
+            {\pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+            {\pgf@circ@scaled@Rlen=\pgf@circ@Rlen}
+    \else
+        \pgf@circ@scaled@Rlen=\pgf@circ@Rlen
+    \fi
+}
+
 %% Output routine for generic bipoles
 
 \def\pgf@circ@drawvoltagegeneric{
     \pgfextra{
+        % \typeout{NAME:\ctikzvalof{bipole/name}}
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}
         \pgfkeysifdefined{\pgf@temp}
         {
             \edef\partheight{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}}
-            \edef\tmpdistfromline{(\partheight\pgf@circ@Rlen)}
+            \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen)}
         }
         {
             \pgfkeysifdefined{/tikz/circuitikz/bipoles/voltage/straight label distance}
             {
                 \edef\partheight{\ctikzvalof{bipoles/voltage/straight label distance}}
-                \edef\tmpdistfromline{(\partheight\pgf@circ@Rlen)}
+                \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen)}
             }
             {%calculate default value from part height
                 \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/height}
                 \pgfkeysifdefined{\pgf@temp}
                 {
                     \edef\partheight{0.5*\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/height}}
-                    \edef\tmpdistfromline{(\partheight\pgf@circ@Rlen+0.2\pgf@circ@Rlen)}
+                    \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen+0.2\pgf@circ@scaled@Rlen)}
                 }
                 {
-                    \edef\tmpdistfromline{(.5\pgf@circ@Rlen)} %fallback to fixed value
+                    \edef\tmpdistfromline{(.5\pgf@circ@scaled@Rlen)} %fallback to fixed value
                 }
             }
         }
+        % \typeout{KIND:\ctikzvalof{bipole/kind}\space RLEN:\the\pgf@circ@Rlen\space SCALED:\the\pgf@circ@scaled@Rlen}
         \ifnum \ctikzvalof{mirror value}=-1
         \ifpgf@circuit@bipole@inverted
             \ifpgf@circuit@bipole@voltage@straight
                 \def\distfromline{\tmpdistfromline}
             \else
-                \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@Rlen}
+                \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
             \fi
             \else
             \ifpgf@circuit@bipole@voltage@straight
                 \def\distfromline{-\tmpdistfromline}
             \else
-                \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@Rlen}
+                \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
             \fi
         \fi
         \else
@@ -147,13 +162,13 @@
                 \ifpgf@circuit@bipole@voltage@straight
                     \def\distfromline{-\tmpdistfromline}
                 \else
-                    \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@Rlen}
+                    \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
                 \fi
                 \else
                 \ifpgf@circuit@bipole@voltage@straight
                     \def\distfromline{\tmpdistfromline}
                 \else
-                    \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@Rlen}
+                    \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
                 \fi
             \fi
         \fi
@@ -171,13 +186,6 @@
             { \edef\bumpb{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}} }
             { \edef\bumpb{\ctikzvalof{voltage/bump b}} }
         \edef\shiftv{\ctikzvalof{voltage/shift}}
-        % \pgfmathsetmacro{\bumpb}{\bumpb + \shiftv} %% adjust the bump for shift
-        % \ifpgf@circuit@bipole@inverted
-        %     \pgfmathsetmacro{\shiftv}{-\shiftv}
-        % \fi
-        % \ifnum \ctikzvalof{mirror value} = -1
-        %     \pgfmathsetmacro{\shiftv}{-\shiftv}
-        % \fi
         \newdimen{\absvshift}
         \pgfmathsetlength{\absvshift}{\shiftv*\distfromline+\distfromline}
         % put this to true to see the voltage label coordinate anchors
@@ -421,6 +429,9 @@
             \fi
         \fi
 
+        % take into account scaling
+        \setscaledRlenforclass
+
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}
         \pgfkeysifdefined{\pgf@temp}
             { \edef\eudist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}} }
@@ -429,8 +440,8 @@
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/height}
         \pgfkeysifdefined{\pgf@temp}
             {\pgfmathsetmacro{\partheightf}{0.5*\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/height}}
-             \edef\partheight{\partheightf\pgf@circ@Rlen}}
-            {\edef\partheight{(.5\pgf@circ@Rlen)}} %fallback to fixed value
+             \edef\partheight{\partheightf\pgf@circ@scaled@Rlen}}
+            {\edef\partheight{(.5\pgf@circ@scaled@Rlen)}} %fallback to fixed value
         \newdimen{\alshift}
         % this is more or less the same of the legacy code; we shift the american label a bit
         % outside the (+) -- (-) line

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -164,41 +164,78 @@
         \fi
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}
         \pgfkeysifdefined{\pgf@temp}
-        { \edef\distacefromnode{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}} }
-        { \edef\distacefromnode{\ctikzvalof{voltage/distance from node}} }
+            { \edef\distacefromnode{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}} }
+            { \edef\distacefromnode{\ctikzvalof{voltage/distance from node}} }
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}
         \pgfkeysifdefined{\pgf@temp}
-        { \edef\bumpb{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}} }
-        { \edef\bumpb{\ctikzvalof{voltage/bump b}} }
+            { \edef\bumpb{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}} }
+            { \edef\bumpb{\ctikzvalof{voltage/bump b}} }
         \edef\shiftv{\ctikzvalof{voltage/shift}}
-        \pgfmathsetmacro{\bumpb}{\bumpb + \shiftv} %% adjust the bump is shift
-        \ifpgf@circuit@bipole@inverted
-            \pgfmathsetmacro{\shiftv}{-\shiftv}
-        \fi
-        \ifnum \ctikzvalof{mirror value} = -1
-            \pgfmathsetmacro{\shiftv}{-\shiftv}
-        \fi
+        % \pgfmathsetmacro{\bumpb}{\bumpb + \shiftv} %% adjust the bump for shift
+        % \ifpgf@circuit@bipole@inverted
+        %     \pgfmathsetmacro{\shiftv}{-\shiftv}
+        % \fi
+        % \ifnum \ctikzvalof{mirror value} = -1
+        %     \pgfmathsetmacro{\shiftv}{-\shiftv}
+        % \fi
+        \newdimen{\absvshift}
+        \pgfmathsetlength{\absvshift}{\shiftv*\distfromline+\distfromline}
+        % put this to true to see the voltage label coordinate anchors
+        \newif\ifpgf@circ@debugv\pgf@circ@debugvfalse
     }
     % %\pgf@circ@Rlen/\ctikzvalof{current arrow scale} is equal to the length of the currarrow
     coordinate (pgfcirc@midtmp) at ($(\tikztostart) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorstartnode)$) %absolute move, minimum space is length of arrowhead
     coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distacefromnode ! (anchorstartnode)$)
-
+    coordinate (pgfcirc@Vfrom@flat) at (pgfcirc@midtmp)
     coordinate (pgfcirc@Vfrom) at ($(pgfcirc@midtmp) ! -\distfromline ! \pgf@circ@voltage@angle:(anchorstartnode)$)
+
     coordinate (pgfcirc@midtmp) at ($(\tikztotarget) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorendnode)$)%absolute move, minimum space is length of arrowhead
     coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distacefromnode ! (anchorendnode)$)
-
+    coordinate (pgfcirc@Vto@flat) at (pgfcirc@midtmp)
     coordinate (pgfcirc@Vto) at ($(pgfcirc@midtmp) ! \distfromline ! \pgf@circ@voltage@angle : (anchorendnode)$)
 
     \ifpgf@circuit@bipole@voltage@below
-        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto) ! \shiftv!90 :  (anchorendnode)$)
-        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom) ! \shiftv!-90 :  (anchorstartnode)$)
-        coordinate (pgfcirc@Vcont1) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-110)$)
-        coordinate (pgfcirc@Vcont2) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-70)$)
+        \ifpgf@circ@debugv
+            node [ocirc, fill=red] at (anchorstartnode) {}
+            node [ocirc, fill=blue] at (anchorendnode) {}
+            node [ocirc, fill=green] at (pgfcirc@Vto) {}
+            node [ocirc, fill=yellow] at (pgfcirc@Vfrom) {}
+            node [odiamondpole, fill=green] at (pgfcirc@Vto@flat) {}
+            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom@flat) {}
+        \fi
+        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! \absvshift!90 :  (anchorendnode)$)
+        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! \absvshift!-90 :  (anchorstartnode)$)
+        coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-110)$)
+        coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-70)$)
+        coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! -\absvshift!90 : (pgfcirc@Vcont2t)$)
+        coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! -\absvshift!-90 : (pgfcirc@Vcont1t)$)
+        \ifpgf@circ@debugv
+            node [odiamondpole, fill=green] at (pgfcirc@Vto) {}
+            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom) {}
+            node [osquarepole, fill=red] at (pgfcirc@Vcont1) {}
+            node [osquarepole, fill=blue] at (pgfcirc@Vcont2) {}
+        \fi
     \else
-        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto) ! -\shiftv!90 :  (anchorendnode)$)
-        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom) ! -\shiftv!-90 :  (anchorstartnode)$)
-        coordinate (pgfcirc@Vcont1) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.110)$)
-        coordinate (pgfcirc@Vcont2) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.70)$)
+        \ifpgf@circ@debugv
+            node [ocirc, fill=red] at (anchorstartnode) {}
+            node [ocirc, fill=blue] at (anchorendnode) {}
+            node [ocirc, fill=green] at (pgfcirc@Vto) {}
+            node [ocirc, fill=yellow] at (pgfcirc@Vfrom) {}
+            node [odiamondpole, fill=green] at (pgfcirc@Vto@flat) {}
+            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom@flat) {}
+        \fi
+        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! -\absvshift!90 :  (anchorendnode)$)
+        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! -\absvshift!-90 :  (anchorstartnode)$)
+        coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.110)$)
+        coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.70)$)
+        coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! \absvshift!90 : (pgfcirc@Vcont2t)$)
+        coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! \absvshift!-90 : (pgfcirc@Vcont1t)$)
+        \ifpgf@circ@debugv
+            node [odiamondpole, fill=green] at (pgfcirc@Vto) {}
+            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom) {}
+            node [osquarepole, fill=red] at (pgfcirc@Vcont1) {}
+            node [osquarepole, fill=blue] at (pgfcirc@Vcont2) {}
+        \fi
     \fi
 
     \ifpgf@circuit@europeanvoltage
@@ -255,7 +292,7 @@
     \pgfextra{
         \edef\shiftv{\ctikzvalof{voltage/shift}}
         \edef\bumpa{\ctikzvalof{voltage/bump a}}
-        \pgfmathsetmacro{\bumpaplus}{\bumpa + \shiftv}
+        \pgfmathsetmacro{\bumpaplus}{\bumpa + 0.5*\shiftv} % coefficient added "by feel". Sorry.
     }
     \ifpgf@circuit@bipole@voltage@below
         coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-120)$)
@@ -264,6 +301,9 @@
         coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.120)$)
         coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.60)$)
     \fi
+    % fix the (unused in this case) Vcont1/2 coords for label placement along the line
+    coordinate (pgfcirc@Vcont1) at (pgfcirc@Vto)
+    coordinate (pgfcirc@Vcont2) at (pgfcirc@Vfrom)
     \ifpgf@circuit@europeanvoltage
         \ifpgf@circuit@bipole@voltage@backward
             (pgfcirc@Vto)  -- node[currarrow, sloped,  allow upside down, pos=1] {} (pgfcirc@Vfrom)
@@ -356,6 +396,15 @@
         \fi
         \fi\fi
 
+        % this must be set *before* changing for mirroring and inverting; in that case
+        % the xscale/yscale parameters take it into account
+        \ifpgf@circuit@bipole@voltage@below
+            \def\pgf@circ@bipole@voltage@label@where{-90}
+        \else
+            \def\pgf@circ@bipole@voltage@label@where{90}
+        \fi
+
+        % magic to counteract the scale and yscale effects (there should be a better way...)
         \ifnum \ctikzvalof{mirror value}=-1
             \ifpgf@circuit@bipole@voltage@below
                 \pgf@circuit@bipole@voltage@belowfalse
@@ -368,26 +417,24 @@
             \ifpgf@circuit@bipole@voltage@below
                 \pgf@circuit@bipole@voltage@belowfalse
             \else
-
                 \pgf@circuit@bipole@voltage@belowtrue
             \fi
         \fi
 
-        \ifpgf@circuit@bipole@voltage@below
-            \def\pgf@circ@bipole@voltage@label@where{-90}
-        \else
-            \def\pgf@circ@bipole@voltage@label@where{90}
-        \fi
-
-
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}
         \pgfkeysifdefined{\pgf@temp}
-        { \edef\eudist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}} }
-        { \edef\eudist{\ctikzvalof{voltage/european label distance}} }
-        \edef\shiftv{\ctikzvalof{voltage/shift}}
-        % adjust the label distance to the shift.
-        \pgfmathsetmacro{\eudistplus}{\eudist+\shiftv}
-
+            { \edef\eudist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}} }
+            { \edef\eudist{\ctikzvalof{voltage/european label distance}} }
+        % find the height of the bipole or use a default value
+        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/height}
+        \pgfkeysifdefined{\pgf@temp}
+            {\pgfmathsetmacro{\partheightf}{0.5*\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/height}}
+             \edef\partheight{\partheightf\pgf@circ@Rlen}}
+            {\edef\partheight{(.5\pgf@circ@Rlen)}} %fallback to fixed value
+        \newdimen{\alshift}
+        % this is more or less the same of the legacy code; we shift the american label a bit
+        % outside the (+) -- (-) line
+        \pgfmathsetlength{\alshift}{(\ctikzvalof{voltage/american label distance}-0.6)*\partheight}
         \pgfsetcornersarced{\pgfpointorigin}% do not use rounded corners!
     }%end pgfextra
 
@@ -397,19 +444,21 @@
         \pgf@circ@drawvoltagegeneric
     \fi
 
-    %	(\ctikzvalof{bipole/name}.\pgf@circ@bipole@voltage@label@where) %Zeile sinnlos!?
     \ifpgf@circuit@bipole@voltage@straight
         coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
         node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt]
         at (Vlab) { \pgf@circ@finallabels{voltage/label} }
     \else
-        coordinate (Vlab) at ($(\ctikzvalof{bipole/name}.center) !
         \ifpgf@circuit@europeanvoltage
-            \eudistplus
+            coordinate (Vlab) at ($(pgfcirc@Vcont1)!0.5!(pgfcirc@Vcont2)$)
         \else
-            \ctikzvalof{voltage/american label distance}
-        \fi !
-        (\ctikzvalof{bipole/name}.\pgf@circ@bipole@voltage@label@where)$)
+            coordinate (Vlab) at ($(pgfcirc@Vfrom)!0.5!(pgfcirc@Vto)$)
+            \ifpgf@circuit@bipole@isvoltage\else
+            % add a bit of space for american labels above their symbols in the normal case. You can avoid that
+            % with voltage/american label distance=0.5 (it's measured from the center of the component, in heights)
+                coordinate (Vlab) at ($(Vlab) ! \alshift ! \pgf@circ@bipole@voltage@label@where :(pgfcirc@Vto)$)
+            \fi
+        \fi
         node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt] at (Vlab) { \pgf@circ@finallabels{voltage/label} }
     \fi
 }%end drawvoltages

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -179,8 +179,8 @@
         \fi
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}
         \pgfkeysifdefined{\pgf@temp}
-            { \edef\distacefromnode{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}} }
-            { \edef\distacefromnode{\ctikzvalof{voltage/distance from node}} }
+            { \edef\distancefromnode{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/distance from node}} }
+            { \edef\distancefromnode{\ctikzvalof{voltage/distance from node}} }
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}
         \pgfkeysifdefined{\pgf@temp}
             { \edef\bumpb{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}} }
@@ -193,12 +193,12 @@
     }
     % %\pgf@circ@Rlen/\ctikzvalof{current arrow scale} is equal to the length of the currarrow
     coordinate (pgfcirc@midtmp) at ($(\tikztostart) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorstartnode)$) %absolute move, minimum space is length of arrowhead
-    coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distacefromnode ! (anchorstartnode)$)
+    coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distancefromnode ! (anchorstartnode)$)
     coordinate (pgfcirc@Vfrom@flat) at (pgfcirc@midtmp)
     coordinate (pgfcirc@Vfrom) at ($(pgfcirc@midtmp) ! -\distfromline ! \pgf@circ@voltage@angle:(anchorstartnode)$)
 
     coordinate (pgfcirc@midtmp) at ($(\tikztotarget) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorendnode)$)%absolute move, minimum space is length of arrowhead
-    coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distacefromnode ! (anchorendnode)$)
+    coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distancefromnode ! (anchorendnode)$)
     coordinate (pgfcirc@Vto@flat) at (pgfcirc@midtmp)
     coordinate (pgfcirc@Vto) at ($(pgfcirc@midtmp) ! \distfromline ! \pgf@circ@voltage@angle : (anchorendnode)$)
 


### PR DESCRIPTION
Voltage (especially european ones) behaved badly when a global scale was
used, and the "voltage shift" parameter more so (Romano's fault).
Changed the positioning of voltages so now they are better behaved, and
"shift" means "shift" --- no effect on the shape of the curve.

In the process the key "voltage/european label distance" has been
deprecated.

Fixes #272 