### PR TITLE
Release 0.9.4, official date 30 Aug 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 0.9.4 (unreleased)
+* Version 0.9.4 (2019-08-30)
 
     This release introduces two changes: a big one, which is the styling of the components (please look at the manual for details) and a change to how voltage labels and arrows are positioned. This one should be backward compatible *unless* you used `voltage shift` introduced in 0.9.0, which was broken when using the global `scale` parameter.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -9,8 +9,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{0.9.4-unreleased}
-\def\pgfcircversiondate{2019/07/13}
+\def\pgfcircversion{0.9.4}
+\def\pgfcircversiondate{2019/08/30}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
-\def\pgfcircversion{0.9.4-unreleased}
-\def\pgfcircversiondate{2019/07/13}
+\def\pgfcircversion{0.9.4}
+\def\pgfcircversiondate{2019/08/30}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
This release introduces two changes: a big one, which is the styling of the components
(please look at the manual for details) and a change to how voltage labels and arrows
are positioned. This one should be backward compatible *unless* you used `voltage shift`
introduced in 0.9.0, which was broken when using the global `scale` parameter.

The styling additions are quite big, and, although in principle they are backwardi
compatible, you can find corner cases where they are not, especially if you used
to change parameters for `pgfcirc.defines.tex`; so a snapshot for the 0.9.3 version
is available.

- Fixed a bug with "inline" gyrators, now the circle will not overlap
- Fixed a bug in input anchors of european not ports
- Fixed "tlinestub" so that it has the same default size than "tline" (TL)
- Fixed the "transistor arrows at end" feature, added to styling
- Changed the behavior of "voltage shift" and voltage label positioning to be more robust
- Added several new anchors for "elmech" element
- Several minor fixes in some component drawings to allow fill and thickness styles
- Add 0.9.3 version snapshots.
- Added styling of relative size of components (at a global or local level)
- Added styling for fill color and thickeness
- Added style files