### PR TITLE
Adding access and styling  to the labels of bipoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Bumped version number
     - Added a "midtap" anchor for coils and exposed the inner coils shapes in the transformers.
     - Added a "curved capacitor" with polarity coherent with "ecapacitor"
+    - Added the possibility to apply style and access the nodes of bipole's text ornaments (labels, annotations, voltages, currents and flows).
 
 * Version 0.9.4 (2019-08-30)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4308,9 +4308,48 @@ However, you can override the properties \texttt{voltage/distance from node} (ho
 
 Note the \texttt{.initial}; you have to create such key the first time you use it.
 
+\subsection{Changing the style of labels and text ornaments}
+
+You can change the style of bipole text ornaments (labels, annotations, voltages etc) by using the appropriate styles or keys.
+The basic style applied to the text are defined in the \texttt{/tikz/circuitikz} key directory and applied to every node that contains the text; you can also change them locally by using the \texttt{tikz} direct keys in local scopes.
+
+For example, you can make all annotations small by using:
+
+\begin{lstlisting}[numbers=none]
+\ctikzset{bipole annotation style/.style={font=\small}}
+\end{lstlisting}
+
+And the change (override) the setting in one specific bipole using:
+
+\begin{lstlisting}[numbers=none]
+...to[bipole annotation style={color=red}, R, a={Red note}]...
+\end{lstlisting}
+
+where the annotation will be in normal font (it has been reset!) and red, or append to the style:
+
+\begin{lstlisting}[numbers=none]
+...to[bipole annotation append style={color=red}, R, a={Red small note}]...
+\end{lstlisting}
+
+\textbf{Caveat:} you have to put the style changing key at the start of the \texttt{to} arguments to have any effect\footnote{No, I do not know why. Hints and fixes are welcome.}.
+
+The available styles and commands are \texttt{bipole label style}, \texttt{bipole annotation style}, \texttt{bipole voltage style}, \texttt{bipole current style}, and \texttt{bipole flow style}. The following example shows a bit of everything.
 
 
-\subsection{Labels in pecial components}
+\begin{LTXexample}[pos=t, basicstyle=\small\ttfamily ]
+\begin{circuitikz}[american]
+    \ctikzset{bipole annotation style/.style={font=\tiny}}
+    \ctikzset{bipole current style/.style={font=\small\sffamily}}
+    \draw (0,0) to [bipole annotation append style={fill=yellow}, R=L1, a=A1] ++(3,0)
+        to [bipole label style={fill=cyan}, R, l2_=L2 and 2L, a^=A2] ++(3,0);
+    \draw (7,0) to [bipole voltage style={color=blue},
+        bipole flow style={fill=green, outer sep=5pt},
+        R=R1, v=V1, i=I1, f>^=F1] ++(3,0)
+    to [bipole current append style={color=red}, R, v<=V2, i^=I2, f>^=F2] ++(3,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\subsection{Labels in special components}
 
 For some components label, current and voltage behave as one would expect:
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1924,7 +1924,6 @@ These are pseudo-arrows used in lot of places in the packages (for transistors, 
 \begin{groupdesc}
     \circuitdesc{currarrow}{Arrows (current and voltage)}{}(center/0/0.2)
     \circuitdesc{inputarrow}{Arrow to draw at its tip, useful for block diagrams.}{}(center/0/0.2)
-    \circuitdesc*{bnc}{BNC connector}{}(left/135/0.6, right/45/0.6, center/-90/0.6, hot/0/0.6, zero/-135/0.6)
 \end{groupdesc}
 
 \subsubsection{Arrows size}\label{sec:currarrow-size}
@@ -3719,6 +3718,7 @@ A couple of examples are shown below.
 \end{LTXexample}
 
 
+
 \section{Labels and similar annotations}
 
 \begin{LTXexample}[varwidth=true]
@@ -4279,7 +4279,9 @@ This could be especially useful if you define a style, to use like this:
     \draw (0,-2) to[R,v_<=$V_S$] ++(2,0);
 \end{circuitikz}
 \end{LTXexample}
-\subsubsection{Global properties of voltages and currents}
+
+
+\subsection{Global properties of voltages and currents}
 
 \begin{LTXexample}[varwidth=true]
 \tikz \draw (0,0) to[R, v=1<\volt>] (2,0); \par
@@ -4307,140 +4309,8 @@ However, you can override the properties \texttt{voltage/distance from node} (ho
 Note the \texttt{.initial}; you have to create such key the first time you use it.
 
 
-\subsection{Nodes (also called poles)}\label{sec:bipole-nodes}
 
-You can add nodes to the bipoles, positioned at the coordinates surrounding the component. The general style to use is \texttt{bipole nodes=\{start\}\{stop\}}, where \texttt{start} and \texttt{stop} are the nodes --- to be chosen between \texttt{none}, \texttt{circ}, \texttt{ocirc}, \texttt{squarepole}, \texttt{osquarepole}, \texttt{diamondpole},  \texttt{odiamondpole} and \texttt{rectfill}\footnote{You can use other shapes too, but at your own risk\dots Moreover, notice that \texttt{none} is not really a node, just a special word used to say ``do not put any node here''.} (see section~\ref{sec:terminals}).
-
-
-\begin{LTXexample}[varwidth=true,
-        basicstyle=\small\ttfamily
-    ]
-\begin{circuitikz}
-    \ctikzset{bipoles/length=.5cm, nodes width=0.1}%small components, big nodes
-    \foreach \a/\p [evaluate=\a as \b using (\a+180)] in
-    {-90/none, -60/circ, -30/ocirc, 0/diamondpole, 30/odiamondpole, 60/squarepole, 90/osquarepole}
-        \draw (0,0) to[R, bipole nodes={none}{\p}] ++(\a:1.5)  node[font=\tiny, anchor=\b]{\p};
-\end{circuitikz}
-\end{LTXexample}
-
-These bipole nodes are added after the path is drawn, as every node in Ti\emph{k}Z --- this is the reason why they are always filled (with the main color the normal nodes, with white the open ones), in order to ``hide'' the wire below. You can override the fill color if you want; but notice that if you draw things in two different paths, you will have ``strange'' results; notice that in the second line of resistors the second wire is starting from the center of the white \texttt{ocirc} of the previous path.
-
-\begin{LTXexample}[varwidth=true,
-        pos=t, basicstyle=\small\ttfamily
-    ]
-\begin{circuitikz}
-    \draw (0,0) to[R, *-o] ++(2,0) to[R, -d] ++(2,0)
-        to[R, bipole nodes={diamondpole}{odiamondpole, fill=red}] ++(2,0);
-    \draw (0,-1) to[R, *-o] ++(2,0) ;
-    \draw (2,-1) to[R, -d] ++(2,0) to[R, bipole nodes={none}{squarepole}] ++(2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-You can define shortcuts for the \texttt{bipole nodes} you use most; for example if you want a shortcut for a bipole with open square node in red in the right side you can:
-
-\begin{LTXexample}[varwidth=true,
-        basicstyle=\small\ttfamily
-    ]
-\begin{circuitikz}
-    \ctikzset{-s/.style = {bipole nodes={none}{osquarepole, fill=red}}}
-    \draw (0,0) to[R, -s] ++(2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-There are several predefined shorthand as the above; in the following pages you can see all of them.
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, o-o] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, -o] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, o-] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, *-*] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, -*] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, *-] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, d-d] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, -d] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, d-] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, o-*] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, *-o] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, o-d] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, d-o] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, *-d] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-\begin{LTXexample}[varwidth=true]
-\begin{circuitikz}
-   \draw (0,0) to[R, d-*] (2,0);
-\end{circuitikz}
-\end{LTXexample}
-
-
-\subsection{Special components}
+\subsection{Labels in pecial components}
 
 For some components label, current and voltage behave as one would expect:
 
@@ -4618,8 +4488,164 @@ If the option {\ttfamily siunitx} is active (and \emph{not} in \ConTeXt), then t
 \end{circuitikz}
 \end{LTXexample}
 
+\subsection{Accessing labels text nodes}
+
+Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{label}s and \texttt{annotation}s was present before, but not documented.} using special node names. So, if you use \texttt{name} to give a name to the bipole node, you can access also the following nodes: \texttt{namelabel} (notice: no space nor any other symbol between \texttt{name} and \texttt{label}!), \texttt{nameannotation}, \texttt{namevoltage}, \texttt{namecurrent} and \texttt{nameflow}.
+
+\begin{LTXexample}[varwidth=true,
+            pos=t, basicstyle=\small\ttfamily
+    ]
+\newcommand{\marknode}[2][45]{%
+    \node[circle, draw, red, inner sep=1pt,
+    pin={[red, font=\tiny]#1:#2}] at (#2.center) {};
+}
+\begin{circuitikz}[ american]
+    \draw (0,0) to [R=L1, a=A1, name=L1] ++(3,0)
+    to [R, l2_=L2 and 2L, a^=A2, name=L2] ++(3,0);
+    \marknode{L1} \marknode{L1label} \marknode[0]{L1annotation}
+    \marknode{L2} \marknode[0]{L2label} \marknode{L2annotation}
+    \draw[blue] (L2label.south west) rectangle (L2label.north east);
+    \draw (6.1,0) to [R=R1, v=V1, i=I1, f>^=F1, name=R1] ++(3,0)
+    to [R, v<=V2, i^=I2, f>^=F2, name=R2] ++(3,0);
+    \marknode[0]{R1voltage} \marknode[0]{R2voltage} \marknode[90]{R1current}
+    \marknode[90]{R2current} \marknode{R1flow} \marknode{R2flow}
+\end{circuitikz}
+\end{LTXexample}
 
 
+\section{Using bipoles in circuits}
+
+\subsection{Nodes (also called poles)}\label{sec:bipole-nodes}
+
+You can add nodes to the bipoles, positioned at the coordinates surrounding the component. The general style to use is \texttt{bipole nodes=\{start\}\{stop\}}, where \texttt{start} and \texttt{stop} are the nodes --- to be chosen between \texttt{none}, \texttt{circ}, \texttt{ocirc}, \texttt{squarepole}, \texttt{osquarepole}, \texttt{diamondpole},  \texttt{odiamondpole} and \texttt{rectfill}\footnote{You can use other shapes too, but at your own risk\dots Moreover, notice that \texttt{none} is not really a node, just a special word used to say ``do not put any node here''.} (see section~\ref{sec:terminals}).
+
+
+\begin{LTXexample}[varwidth=true,
+        basicstyle=\small\ttfamily
+    ]
+\begin{circuitikz}
+    \ctikzset{bipoles/length=.5cm, nodes width=0.1}%small components, big nodes
+    \foreach \a/\p [evaluate=\a as \b using (\a+180)] in
+    {-90/none, -60/circ, -30/ocirc, 0/diamondpole, 30/odiamondpole, 60/squarepole, 90/osquarepole}
+        \draw (0,0) to[R, bipole nodes={none}{\p}] ++(\a:1.5)  node[font=\tiny, anchor=\b]{\p};
+\end{circuitikz}
+\end{LTXexample}
+
+These bipole nodes are added after the path is drawn, as every node in Ti\emph{k}Z --- this is the reason why they are always filled (with the main color the normal nodes, with white the open ones), in order to ``hide'' the wire below. You can override the fill color if you want; but notice that if you draw things in two different paths, you will have ``strange'' results; notice that in the second line of resistors the second wire is starting from the center of the white \texttt{ocirc} of the previous path.
+
+\begin{LTXexample}[varwidth=true,
+        pos=t, basicstyle=\small\ttfamily
+    ]
+\begin{circuitikz}
+    \draw (0,0) to[R, *-o] ++(2,0) to[R, -d] ++(2,0)
+        to[R, bipole nodes={diamondpole}{odiamondpole, fill=red}] ++(2,0);
+    \draw (0,-1) to[R, *-o] ++(2,0) ;
+    \draw (2,-1) to[R, -d] ++(2,0) to[R, bipole nodes={none}{squarepole}] ++(2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+You can define shortcuts for the \texttt{bipole nodes} you use most; for example if you want a shortcut for a bipole with open square node in red in the right side you can:
+
+\begin{LTXexample}[varwidth=true,
+        basicstyle=\small\ttfamily
+    ]
+\begin{circuitikz}
+    \ctikzset{-s/.style = {bipole nodes={none}{osquarepole, fill=red}}}
+    \draw (0,0) to[R, -s] ++(2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+There are several predefined shorthand as the above; in the following pages you can see all of them.
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, o-o] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, -o] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, o-] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, *-*] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, -*] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, *-] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, d-d] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, -d] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, d-] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, o-*] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, *-o] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, o-d] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, d-o] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, *-d] (2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+   \draw (0,0) to[R, d-*] (2,0);
+\end{circuitikz}
+\end{LTXexample}
 \subsection{Mirroring and Inverting}
 Bipole paths can also mirrored and inverted (or reverted) to change the drawing direction.
 

--- a/tex/pgfcirccurrent.tex
+++ b/tex/pgfcirccurrent.tex
@@ -192,7 +192,8 @@
         }
     \fi
     coordinate[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff](Iarrow)
-    (Iarrow.\pgf@circ@bipole@current@label@where) node[anchor=\pgf@circ@dir]{\pgf@circ@finallabels{current/label}}
+    (Iarrow.\pgf@circ@bipole@current@label@where)
+    node[anchor=\pgf@circ@dir](\ctikzvalof{bipole/name}current){\pgf@circ@finallabels{current/label}}
 }
 
 \endinput

--- a/tex/pgfcirccurrent.tex
+++ b/tex/pgfcirccurrent.tex
@@ -10,6 +10,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Current handling
 
+%% styles
+\ctikzset{bipole current style/.style={}}
+\tikzset{bipole current style/.code={
+        \ctikzset{bipole current style/.style={#1}}
+}}
+\tikzset{bipole current append style/.code={
+        \ctikzset{bipole current style/.append style={#1}}
+}}
+
 %% Options
 \ctikzset{i^>/.style = {
         i = #1,
@@ -193,7 +202,8 @@
     \fi
     coordinate[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff](Iarrow)
     (Iarrow.\pgf@circ@bipole@current@label@where)
-    node[anchor=\pgf@circ@dir](\ctikzvalof{bipole/name}current){\pgf@circ@finallabels{current/label}}
+    node[anchor=\pgf@circ@dir, \circuitikzbasekey/bipole current style]
+    (\ctikzvalof{bipole/name}current){\pgf@circ@finallabels{current/label}}
 }
 
 \endinput

--- a/tex/pgfcircflow.tex
+++ b/tex/pgfcircflow.tex
@@ -10,6 +10,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% flow handling
 
+%% styles
+\ctikzset{bipole flow style/.style={}}
+\tikzset{bipole flow style/.code={
+        \ctikzset{bipole flow style/.style={#1}}
+}}
+\tikzset{bipole flow append style/.code={
+        \ctikzset{bipole flow style/.append style={#1}}
+}}
+
 %% Options
 \ctikzset{f^>/.style = {
         f = #1,
@@ -187,8 +196,8 @@
         \fi
     }
     coordinate[flowarrow,pos=\ctikzvalof{flow/distance},rotate=\pgf@circ@ffffff,yshift=\flow@offset](Farrowpos)
-    (Farrowpos.\pgf@circ@bipole@flow@label@where)
-    node[anchor=\pgf@circ@dir](\ctikzvalof{bipole/name}flow){\pgf@circ@finallabels{flow/label}}
+    (Farrowpos.\pgf@circ@bipole@flow@label@where) node[anchor=\pgf@circ@dir, \circuitikzbasekey/bipole flow style]
+    (\ctikzvalof{bipole/name}flow){\pgf@circ@finallabels{flow/label}}
 }
 
 \endinput

--- a/tex/pgfcircflow.tex
+++ b/tex/pgfcircflow.tex
@@ -187,7 +187,8 @@
         \fi
     }
     coordinate[flowarrow,pos=\ctikzvalof{flow/distance},rotate=\pgf@circ@ffffff,yshift=\flow@offset](Farrowpos)
-    (Farrowpos.\pgf@circ@bipole@flow@label@where) node[anchor=\pgf@circ@dir]{ \pgf@circ@finallabels{flow/label}}
+    (Farrowpos.\pgf@circ@bipole@flow@label@where)
+    node[anchor=\pgf@circ@dir](\ctikzvalof{bipole/name}flow){\pgf@circ@finallabels{flow/label}}
 }
 
 \endinput

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -10,6 +10,23 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Bipole label positioning
 
+%% bipole labels and annotation extra style
+
+\ctikzset{bipole label style/.style={}}
+\tikzset{bipole label style/.code={
+        \ctikzset{bipole label style/.style={#1}}
+}}
+\tikzset{bipole label append style/.code={
+        \ctikzset{bipole label style/.append style={#1}}
+}}
+\ctikzset{bipole annotation style/.style={}}
+\tikzset{bipole annotation style/.code={
+        \ctikzset{bipole annotation style/.style={#1}}
+}}
+\tikzset{bipole annotation append style/.code={
+        \ctikzset{bipole annotation style/.append style={#1}}
+}}
+
 %% Options
 \ctikzset{label/.style = { l=#1 } }
 \ctikzset{l/.code = {
@@ -188,7 +205,8 @@
     }
     % reset cm is not working correctly here
     (labelcoor)++(\pgf@circ@labposangle:\the\pgf@circ@res@temp) coordinate(labelcoor)
-    node[anchor=mid, rotate=\pgfcirclabrot](\ctikzvalof{bipole/name}#1){\pgf@circ@finallabels{#1}}
+    node[anchor=mid, rotate=\pgfcirclabrot, \circuitikzbasekey/bipole #1 style]
+    (\ctikzvalof{bipole/name}#1){\pgf@circ@finallabels{#1}}
 }
 
 \def\pgf@circ@drawreglabels#1{
@@ -257,7 +275,7 @@
             \fi
         \fi\fi
     (labelcoor) node[anchor=\pgf@circ@labanctext,
-        inner sep=0.5\pgf@circ@res@temp, outer sep=0pt,
+    inner sep=0.5\pgf@circ@res@temp, outer sep=0pt, \circuitikzbasekey/bipole #1 style,
         ](\ctikzvalof{bipole/name}#1){\strut\pgf@circ@finallabels{#1}%
     }
 }

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -10,6 +10,14 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%  Voltage management
 
+%% styles
+\ctikzset{bipole voltage style/.style={}}
+\tikzset{bipole voltage style/.code={
+        \ctikzset{bipole voltage style/.style={#1}}
+}}
+\tikzset{bipole voltage append style/.code={
+        \ctikzset{bipole voltage style/.append style={#1}}
+}}
 
 \ctikzset{v^>/.style = {
         v = #1,
@@ -457,8 +465,9 @@
 
     \ifpgf@circuit@bipole@voltage@straight
         coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
-        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt](\ctikzvalof{bipole/name}voltage)
-        at (Vlab) { \pgf@circ@finallabels{voltage/label} }
+        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
+        \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
+        at (Vlab) {\pgf@circ@finallabels{voltage/label}}
     \else
         \ifpgf@circuit@europeanvoltage
             coordinate (Vlab) at ($(pgfcirc@Vcont1)!0.5!(pgfcirc@Vcont2)$)
@@ -470,7 +479,9 @@
                 coordinate (Vlab) at ($(Vlab) ! \alshift ! \pgf@circ@bipole@voltage@label@where :(pgfcirc@Vto)$)
             \fi
         \fi
-        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt](\ctikzvalof{bipole/name}voltage) at (Vlab) { \pgf@circ@finallabels{voltage/label} }
+        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
+        \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
+        at (Vlab) {\pgf@circ@finallabels{voltage/label}}
     \fi
 }%end drawvoltages
 \endinput

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -457,7 +457,7 @@
 
     \ifpgf@circuit@bipole@voltage@straight
         coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
-        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt]
+        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt](\ctikzvalof{bipole/name}voltage)
         at (Vlab) { \pgf@circ@finallabels{voltage/label} }
     \else
         \ifpgf@circuit@europeanvoltage
@@ -470,7 +470,7 @@
                 coordinate (Vlab) at ($(Vlab) ! \alshift ! \pgf@circ@bipole@voltage@label@where :(pgfcirc@Vto)$)
             \fi
         \fi
-        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt] at (Vlab) { \pgf@circ@finallabels{voltage/label} }
+        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt](\ctikzvalof{bipole/name}voltage) at (Vlab) { \pgf@circ@finallabels{voltage/label} }
     \fi
 }%end drawvoltages
 \endinput


### PR DESCRIPTION
Labels and annotations were accessible before, but not documented.
Reorganize a bit the manual to help discoverability of things.

![image](https://user-images.githubusercontent.com/6414907/65981510-8da3aa80-e479-11e9-966c-56a41677db24.png)
