### PR TITLE
Prepare for CTAN release 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 0.9.5 (unreleased)
+* Version 0.9.5 (2019-10-12)
 
-    - Bumped version number
+    This release basically add features to better control labels, voltages and similar text "ornaments" on bipoles, plus some other minor things.
+
+    On the bug fixes side, a big incompatibility with ConTeXt has been fixed, thanks to help from `@TheTeXnician` and `@hmenke` on `github.com`.
+
     - Added a "midtap" anchor for coils and exposed the inner coils shapes in the transformers
     - Added a "curved capacitor" with polarity coherent with "ecapacitor"
     - Added the possibility to apply style and access the nodes of bipole's text ornaments (labels, annotations, voltages, currents and flows)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -9,8 +9,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{0.9.5-unreleased}
-\def\pgfcircversiondate{2019/09/01}
+\def\pgfcircversion{0.9.5}
+\def\pgfcircversiondate{2019/10/12}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
-\def\pgfcircversion{0.9.5-unreleased}
-\def\pgfcircversiondate{2019/09/01}
+\def\pgfcircversion{0.9.5}
+\def\pgfcircversiondate{2019/10/12}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
* Version 0.9.5 (2019-10-12)

    This release basically add features to better control labels, voltages and similar text "ornaments" on bipoles, plus some other minor things.

    On the bug fixes side, a big incompatibility with ConTeXt has been fixed, thanks to help from `@TheTeXnician` and `@hmenke` on `github.com`.

    - Added a "midtap" anchor for coils and exposed the inner coils shapes in the transformers
    - Added a "curved capacitor" with polarity coherent with "ecapacitor"
    - Added the possibility to apply style and access the nodes of bipole's text ornaments (labels, annotations, voltages, currents and flows)
    - Added the possibility to move the wiper in resistive potentiometers
    - Added a command to load and set a style in one go
    - Fixed internal font changing commands for compatibility with ConTeXt
    - Fixed hardcoded black color in "elko" and "elmech"