### PR TITLE
Find optical tip

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -28,6 +28,8 @@
 \newdimen\pgf@circ@res@other
 \newdimen\pgf@circ@res@step
 \newdimen\pgf@circ@res@temp
+\newdimen\pgf@circ@res@x
+\newdimen\pgf@circ@res@y
 % inital thickness
 \newdimen \pgfstartlinewidth
 

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -453,6 +453,25 @@
         \pgf@x=.5\pgf@circ@res@step
         \pgf@y=\pgf@x%
     }
+    \savedanchor{\otip}{% Optical tip of the arrow
+        \pgfpointorigin
+        \pgf@circ@res@step = \pgf@circ@Rlen
+        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
+        \pgfmathsetmacro{\factor}{1.174} % this is 1/(2*sin*atan(0.8/1.7)) which is the arrow semi-angle
+        \iftikz@fullytransformed % this is true if `transform shape` is active
+            % from @Circumscribe https://tex.stackexchange.com/a/474035/38080
+            \pgfgettransformentries{\scaleA}{\scaleB}{\scaleC}{\scaleD}{\whatevs}{\whatevs}%
+            \pgfmathsetmacro{\factor}{\factor/sqrt(abs(\scaleA*\scaleD-\scaleB*\scaleC))}%
+        \fi
+        \advance \pgf@circ@res@step by \factor\pgflinewidth
+        \pgf@x	=\pgf@circ@res@step
+    }
+    \savedanchor{\tip}{%
+        \pgfpointorigin
+        \pgf@circ@res@step = \pgf@circ@Rlen
+        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
+        \pgf@x	=\pgf@circ@res@step
+    }
     \anchor{north}{\northeast\pgf@x=0cm\relax}
     \anchor{east}{\northeast\pgf@y=0cm\relax}
     \anchor{south}{\northeast\pgf@y=-\pgf@y \pgf@x=0cm\relax}
@@ -465,10 +484,10 @@
         \pgfpointorigin
     }
     \anchor{tip}{
-        \pgfpointorigin
-        \pgf@circ@res@step = \pgf@circ@Rlen
-        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
-        \pgf@x	=\pgf@circ@res@step
+       \tip
+    }
+    \anchor{otip}{
+       \otip
     }
     \behindforegroundpath{
         \pgfscope
@@ -477,10 +496,11 @@
 
             \pgfpathmoveto{\pgfpoint{-.7\pgf@circ@res@step}{0pt}}
             \pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{-.8\pgf@circ@res@step}}
-            \pgfpathlineto{\pgfpoint{1\pgf@circ@res@step}{0pt}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{0pt}}
             \pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{.8\pgf@circ@res@step}}
             \pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{0pt}}
             \pgfsetcolor{\ctikzvalof{color}}
+            \pgfsetcolor{red}
             \pgfusepath{draw,fill}
 
         \endpgfscope

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -500,7 +500,7 @@
             \pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{.8\pgf@circ@res@step}}
             \pgfpathlineto{\pgfpoint{-.7\pgf@circ@res@step}{0pt}}
             \pgfsetcolor{\ctikzvalof{color}}
-            \pgfsetcolor{red}
+            % \pgfsetcolor{blue}\pgfsetfillopacity{0.5} % uncomment for debug
             \pgfusepath{draw,fill}
 
         \endpgfscope

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1586,7 +1586,7 @@
             \edef\@@anchor{center}
             \ifpgf@circuit@trans@ntype
                 \ifpgf@circuit@trans@arrowatend
-                    \edef\@@anchor{tip}
+                    \edef\@@anchor{otip}
                     \pgftransformlineattime{1.0}{%
                         \pgfpoint%
                         {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}%
@@ -1607,7 +1607,7 @@
                 \fi
             \else
                 \ifpgf@circuit@trans@arrowatend
-                    \edef\@@anchor{tip}
+                    \edef\@@anchor{otip}
                     \pgftransformlineattime{1.0}{%
                         \pgfpoint{\pgf@circ@res@right}%
                         {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@up}%
@@ -1708,7 +1708,7 @@
             \pgfallowupsidedownattimetrue
             \pgfresetnontranslationattimefalse
             \ifpgf@circuit@trans@arrowatend
-                \edef\@@anchor{tip}\edef\@@pos{1.0}
+                \edef\@@anchor{otip}\edef\@@pos{1.0}
             \else
                 \edef\@@anchor{center}\edef\@@pos{0.5}
             \fi
@@ -1794,7 +1794,7 @@
                     {\pgf@circ@res@right}%
                     {\ctikzvalof{tripoles/pmos/gate height}\pgf@circ@res@down}%
                 }
-                \pgfnode{currarrow}{tip}{}{}{\pgfusepath{stroke}}
+                \pgfnode{currarrow}{otip}{}{}{\pgfusepath{stroke}}
             \else
                 \pgfslopedattimetrue
                 \pgfallowupsidedownattimetrue
@@ -1847,7 +1847,7 @@
                     {\ctikzvalof{tripoles/pmos/gate height}\pgf@circ@res@up}%
                 }
                 \pgftransformrotate{180}
-                \pgfnode{currarrow}{tip}{}{}{\pgfusepath{stroke}}
+                \pgfnode{currarrow}{otip}{}{}{\pgfusepath{stroke}}
             \else
                 \pgfslopedattimetrue
                 \pgfallowupsidedownattimetrue
@@ -2029,7 +2029,7 @@
         \pgfallowupsidedownattimetrue
         \pgfresetnontranslationattimefalse
         \ifpgf@circuit@trans@arrowatend
-            \edef\@@anchor{tip}
+            \edef\@@anchor{otip}
                 \ifpgf@circuit@trans@ntype
                     \edef\@@pos{1.0}
                 \else
@@ -2227,7 +2227,7 @@
         \pgfallowupsidedownattimetrue
         \pgfresetnontranslationattimefalse
         \ifpgf@circuit@trans@arrowatend
-            \edef\@@anchor{tip}\edef\@@pos{1.0}
+            \edef\@@anchor{otip}\edef\@@pos{1.0}
         \else
             \edef\@@anchor{center}\edef\@@pos{0.6}
         \fi
@@ -2282,7 +2282,7 @@
         \pgfallowupsidedownattimetrue
         \pgfresetnontranslationattimefalse
         \ifpgf@circuit@trans@arrowatend
-            \edef\@@anchor{tip}\edef\@@pos{1.0}
+            \edef\@@anchor{otip}\edef\@@pos{1.0}
         \else
             \edef\@@anchor{center}\edef\@@pos{0.4}
         \fi
@@ -2360,7 +2360,7 @@
         \pgfallowupsidedownattimetrue
         \pgfresetnontranslationattimefalse
         \ifpgf@circuit@trans@arrowatend
-            \edef\@@anchor{tip}\edef\@@pos{1.0}
+            \edef\@@anchor{otip}\edef\@@pos{1.0}
         \else
             \edef\@@anchor{center}\edef\@@pos{0.6}
         \fi

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1552,14 +1552,36 @@
 
 \long\def\declarebpt#1{
     \pgfcircdeclaretransistor{#1}{}{
+        % let's calculate retractions lengths for the arrow-at-end optical tip solution
+        \pgf@circ@res@temp=0pt % default case
+        \ifpgf@circuit@trans@arrowatend
+            % the currarrow center is the best place; this is the position with respect to the geometrical tip:
+            \pgf@circ@res@temp = \pgf@circ@Rlen
+            \divide \pgf@circ@res@temp by \ctikzvalof{current arrow scale}
+        \fi
+        % Find the angle of the connections (it's a bjt!)
+        \pgfmathsetmacro{\angle}{atan(
+            (\ctikzvalof{tripoles/#1/base height}*\pgf@circ@res@up - \ctikzvalof{tripoles/#1/base height 2}*\pgf@circ@res@up)/
+            (-\ctikzvalof{tripoles/#1/base width}*\pgf@circ@res@left + \pgf@circ@res@right)
+        )}
+        \pgfmathsetlength{\pgf@circ@res@x}{cos(\angle)*\pgf@circ@res@temp}
+        \pgfmathsetlength{\pgf@circ@res@y}{sin(\angle)*\pgf@circ@res@temp}
+        % upper connection
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
         {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint
+        \ifpgf@circuit@trans@ntype
+            \pgfpathlineto{\pgfpoint
             {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}
-        {\ctikzvalof{tripoles/#1/base height 2}\pgf@circ@res@up}}
+            {\ctikzvalof{tripoles/#1/base height 2}\pgf@circ@res@up}}
+        \else
+            % PNP, this is the emitter, retract the line in the arrow on end
+            \pgfpathlineto{\pgfpoint
+            {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left+\pgf@circ@res@x}
+            {\ctikzvalof{tripoles/#1/base height 2}\pgf@circ@res@up+\pgf@circ@res@y}}
+        \fi
         \pgfusepath{draw}
-
+        % base
         \pgfscope
             \pgfpathmoveto{\pgfpoint
                 {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}
@@ -1570,13 +1592,22 @@
             \pgf@circ@setlinewidth{tripoles}{\pgflinewidth}
             \pgfusepath{draw}
         \endpgfscope
-
+        % lower connection
         \pgfpathmoveto{\pgfpoint
             {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}
-        {\ctikzvalof{tripoles/#1/base height 2}\pgf@circ@res@down}}
+            {\ctikzvalof{tripoles/#1/base height 2}\pgf@circ@res@down}}
+        \ifpgf@circuit@trans@ntype
+            % this is the emitter, retract if arrows are at end
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@x}
+            {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down+\pgf@circ@res@y}}
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}
+            {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down+0.5\pgflinewidth}}
+        \else
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+            {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down}}
+        \fi
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
-        {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
+            {\pgf@circ@res@down-\pgfverticaltransformationadjustment*0.5*\pgflinewidth}}
         \pgfusepath{draw}
         %draw arrow depending on type of transistor
         \pgfscope
@@ -1605,7 +1636,7 @@
                         {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down}%
                     }
                 \fi
-            \else
+            \else %PNP
                 \ifpgf@circuit@trans@arrowatend
                     \edef\@@anchor{otip}
                     \pgftransformlineattime{1.0}{%

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1601,7 +1601,7 @@
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@x}
             {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down+\pgf@circ@res@y}}
             \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}
-            {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down+0.5\pgflinewidth}}
+            {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down}}
         \else
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
             {\ctikzvalof{tripoles/#1/base height}\pgf@circ@res@down}}


### PR DESCRIPTION
Ok, this is a try to solve #302, but I think I will not merge it. The problem is that now the point will not overshoot, but you can see a bit of the "stem": 

![image](https://user-images.githubusercontent.com/6414907/67584483-0d0d5c80-f74e-11e9-9f6b-ea37c0d62645.png)

which I find equally ugly... avoiding this is difficult, and the only way would be to use proper arrows for transistors; but then they won't scale (tikz arrows scale with linewidth, not with scale).