### PR TITLE
Change arrows for transistors with a fill-only one

### DIFF
--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -443,6 +443,82 @@
     }
 }
 
+%% transistor arrow
+
+\def\pgf@circ@find@linescale{
+    % find the scale inverse of the scale factor: line width do not scale
+    % with scale=..., transform shape so we have to counteract it.
+    \iftikz@fullytransformed % this is true if `transform shape` is active
+        % from @Circumscribe https://tex.stackexchange.com/a/474035/38080
+        % Note that this trick is not working inside a `spy` environment...
+        \pgfgettransformentries{\scaleA}{\scaleB}{\scaleC}{\scaleD}{\whatevs}{\whatevs}%
+        \pgfmathsetmacro{\@@factor}{1.0/sqrt(abs(\scaleA*\scaleD-\scaleB*\scaleC))}%
+    \else
+        \pgfmathsetmacro{\@@factor}{1.0}
+    \fi
+}
+
+\pgfdeclareshape{trarrow}{%
+    % this arrow is only filled but grows with the linewidth, more or less
+    % like currarrow do
+    \savedanchor{\northeast}{%
+        \pgf@circ@res@step = \pgf@circ@Rlen
+        \pgf@circ@find@linescale
+        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
+        \pgfpoint{0.7*\pgf@circ@res@step +0.5*\@@factor*\pgflinewidth}
+            {0.8*\pgf@circ@res@step+0.7593*\@@factor*\pgflinewidth}
+    }
+    \savedanchor{\northwest}{%
+        \pgf@circ@res@step = \pgf@circ@Rlen
+        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
+        \pgf@circ@find@linescale
+        \pgfpoint{-0.7*\pgf@circ@res@step -0.5*\@@factor*\pgflinewidth}
+            {0.8*\pgf@circ@res@step+0.7593*\@@factor*\pgflinewidth}
+    }
+    \savedanchor{\tip}{%
+        \pgf@circ@res@step = \pgf@circ@Rlen
+        \divide \pgf@circ@res@step by \ctikzvalof{current arrow scale}
+        \pgf@circ@find@linescale
+        \pgfpoint{\pgf@circ@res@step + 1.743*\@@factor*\pgflinewidth}{0pt}
+    }
+    \anchor{north}{\northeast\pgf@x=0cm\relax}
+    \anchor{east}{\northeast\pgf@y=0cm\relax}
+    \anchor{south}{\northeast\pgf@y=-\pgf@y \pgf@x=0cm\relax}
+    \anchor{west}{\northeast\pgf@y=0cm\pgf@x=-\pgf@x}
+    \anchor{north east}{\northeast}
+    \anchor{north west}{\northeast\pgf@x=-\pgf@x}
+    \anchor{south east}{\northeast\pgf@y=-\pgf@y}
+    \anchor{south west}{\northeast\pgf@y=-\pgf@y\pgf@x=-\pgf@x}
+    \anchor{center}{
+        \pgfpointorigin
+    }
+    \anchor{tip}{
+        \tip
+    }
+    \anchor{btip}{% this anchor is behind the tip of half a linewidth
+        \tip
+        \pgf@circ@find@linescale
+        \pgf@circ@res@temp=\@@factor\pgflinewidth
+        \advance\pgf@x by -.5\pgf@circ@res@temp
+    }
+    \behindforegroundpath{
+        \pgfscope
+            \northwest
+            \pgf@circ@res@up=\pgf@y
+            \pgf@circ@res@left=\pgf@x
+            \tip
+            \pgf@circ@res@step = \pgf@x
+            %
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{1\pgf@circ@res@step}{0pt}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@up}}
+            \pgfpathclose
+            \pgfsetcolor{\ctikzvalof{color}}
+            \pgfusepath{fill} % just fill
+        \endpgfscope
+    }
+}
 
 %% Current arrow
 

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -1586,7 +1586,7 @@
             \edef\@@anchor{center}
             \ifpgf@circuit@trans@ntype
                 \ifpgf@circuit@trans@arrowatend
-                    \edef\@@anchor{tip}
+                    \edef\@@anchor{btip}
                     \pgftransformlineattime{1.0}{%
                         \pgfpoint%
                         {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}%
@@ -1625,7 +1625,7 @@
                     }
                 \fi
             \fi
-            \pgfnode{currarrow}{\@@anchor}{}{}{\pgfusepath{stroke}}
+            \pgfnode{trarrow}{\@@anchor}{}{}{\pgfusepath{stroke}}
         \endpgfscope
 
         \ifpgf@circuit@bpt@drawphoto
@@ -1794,7 +1794,7 @@
                     {\pgf@circ@res@right}%
                     {\ctikzvalof{tripoles/pmos/gate height}\pgf@circ@res@down}%
                 }
-                \pgfnode{currarrow}{tip}{}{}{\pgfusepath{stroke}}
+                \pgfnode{trarrow}{btip}{}{}{\pgfusepath{stroke}}
             \else
                 \pgfslopedattimetrue
                 \pgfallowupsidedownattimetrue
@@ -1847,7 +1847,7 @@
                     {\ctikzvalof{tripoles/pmos/gate height}\pgf@circ@res@up}%
                 }
                 \pgftransformrotate{180}
-                \pgfnode{currarrow}{tip}{}{}{\pgfusepath{stroke}}
+                \pgfnode{trarrow}{tip}{}{}{\pgfusepath{stroke}}
             \else
                 \pgfslopedattimetrue
                 \pgfallowupsidedownattimetrue


### PR DESCRIPTION
The arrow should be (more or less) the same size then the
filled+stroked currarrow used before.
We have two tip arrow, one exact and one that let the arrow overshoot a
bit for aesthetic reasons.

Just npn, pnp, nmos and pmos converted.

This is another idea to solve issue #302