### PR TITLE
Fix anchors for voltage, current and flow arrows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The major changes among the different circuitikz versions are listed here. See <
     - Added the possibility to style the two coils in a transformer independently
     - Added bulk connection to normal MOSFETs and the respective anchors
     - Fixed a problem with "quadpoles style=inner" and "transformer core" having the core lines running too near
+    - Fixed flow, voltage and current arrow positioning when "auto" is active on the path
 
 * Version 0.9.5 (2019-10-12)
 

--- a/tex/pgfcirccurrent.tex
+++ b/tex/pgfcirccurrent.tex
@@ -200,7 +200,8 @@
             \edef\pgf@circ@ffffff{\expandafter\pgf@circ@stripdecimals\pgfmathresult\pgf@nil}
         }
     \fi
-    coordinate[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff](Iarrow)
+    coordinate[currarrow,pos=\ctikzvalof{current/distance},rotate=\pgf@circ@ffffff,
+    anchor=center](Iarrow)
     (Iarrow.\pgf@circ@bipole@current@label@where)
     node[anchor=\pgf@circ@dir, \circuitikzbasekey/bipole current style]
     (\ctikzvalof{bipole/name}current){\pgf@circ@finallabels{current/label}}

--- a/tex/pgfcircflow.tex
+++ b/tex/pgfcircflow.tex
@@ -195,7 +195,7 @@
             \fi
         \fi
     }
-    coordinate[flowarrow,pos=\ctikzvalof{flow/distance},rotate=\pgf@circ@ffffff,yshift=\flow@offset](Farrowpos)
+    coordinate[flowarrow,pos=\ctikzvalof{flow/distance},rotate=\pgf@circ@ffffff,yshift=\flow@offset, anchor=center](Farrowpos)
     (Farrowpos.\pgf@circ@bipole@flow@label@where) node[anchor=\pgf@circ@dir, \circuitikzbasekey/bipole flow style]
     (\ctikzvalof{bipole/name}flow){\pgf@circ@finallabels{flow/label}}
 }

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -262,11 +262,11 @@
             \else
             \ifpgf@circuit@bipole@voltage@backward
                 (pgfcirc@Vto) .. controls (pgfcirc@Vcont2)  and (pgfcirc@Vcont1) ..
-                node[currarrow, sloped,  allow upside down, pos=1] {}
+                node[currarrow, sloped,  allow upside down, pos=1, anchor=tip] {}
                 (pgfcirc@Vfrom)
             \else
                 (pgfcirc@Vfrom) .. controls (pgfcirc@Vcont1)  and (pgfcirc@Vcont2) ..
-                node[currarrow, sloped,  allow upside down, pos=1] {}
+                node[currarrow, sloped,  allow upside down, pos=1, anchor=tip] {}
                 (pgfcirc@Vto)
             \fi
         \fi
@@ -320,9 +320,9 @@
     coordinate (pgfcirc@Vcont2) at (pgfcirc@Vfrom)
     \ifpgf@circuit@europeanvoltage
         \ifpgf@circuit@bipole@voltage@backward
-            (pgfcirc@Vto)  -- node[currarrow, sloped,  allow upside down, pos=1] {} (pgfcirc@Vfrom)
+            (pgfcirc@Vto)  -- node[currarrow, sloped,  allow upside down, pos=1, anchor=tip] {} (pgfcirc@Vfrom)
         \else
-            (pgfcirc@Vfrom)  -- node[currarrow, sloped,  allow upside down, pos=1] {} (pgfcirc@Vto)
+            (pgfcirc@Vfrom)  -- node[currarrow, sloped,  allow upside down, pos=1, anchor=tip] {} (pgfcirc@Vto)
         \fi
         \else% american voltage
         \ifpgf@circuit@bipole@voltageoutsideofsymbol


### PR DESCRIPTION
Add explicit anchor to current, flow and voltage arrows.
    
Correct fix for the `auto` problem; thanks to @marmot to help me see this.

See https://github.com/circuitikz/circuitikz/issues/307

Thanks to [@Schrödinger's cat](https://tex.stackexchange.com/questions/514093/circuitikz-misplaces-arrow-of-current-label-when-using-option-auto#comment1300133_514093)
Fixes #307 