### PR TITLE
Fix spelling of "noinv input down" keys.

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -1253,8 +1253,8 @@
 \newif\ifpgf@circuit@oa@iplusup\pgf@circuit@oa@iplusupfalse
 \pgfkeys{/tikz/noinv input up/.add code={}{\pgf@circuit@oa@iplusuptrue}}
 \ctikzset{noinv input up/.add code={}{\pgf@circuit@oa@iplusuptrue}}
-\pgfkeys{/tikz/input noinv down/.add code={}{\pgf@circuit@oa@iplusupfalse}}
-\ctikzset{input noinv down/.add code={}{\pgf@circuit@oa@iplusupfalse}}
+\pgfkeys{/tikz/noinv input down/.add code={}{\pgf@circuit@oa@iplusupfalse}}
+\ctikzset{noinv input down/.add code={}{\pgf@circuit@oa@iplusupfalse}}
 %
 % changing output polarity (for fully diff objects)
 %


### PR DESCRIPTION
Thanks to Nicholas Ngai @nicholasngai who noticed it in #137.
Fixes issue #351 on GitHub.