### PR TITLE
Change text position in triangular amplifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The major changes among the different circuitikz versions are listed here. See <
 
     Minimal changes for a pre-release of 1.0.0, due early 2020, mainly bug fixes apart from addition to the amplifiers to add flexibility.
 
-    - Bumped version number.
-    - Added a single-input generic amplifier with the same dimension as "plain amp".
+    - Bumped version number
+    - Added a single-input generic amplifier with the same dimension as "plain amp"
     - Added border anchors to amplifiers
     - Added the possibility (expert only!) to add transparency to poles (after a suggestion from user @matthuszagh on GitHub)
     - Make plus and minus symbol on amplifiers configurable
+    - Adjusted the position of text in triangular amplifiers
     - Fixed "plain amp" not respecting "noinv input up"
 
 * Version 0.9.7 (2019-12-01)

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -3029,7 +3029,7 @@
     \anchor{north west}{ \northwest }
     \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
 
-    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+    \anchor{text}{\pgfpoint{-.6\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
 
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}
@@ -3436,6 +3436,7 @@
     \anchor{north east}{ \northwest \pgf@x=-\ctikzvalof{tripoles/fd op amp/port width}\pgf@x }
     \anchor{north west}{ \northwest }
     \anchor{south east}{ \northwest \pgf@x=-\ctikzvalof{tripoles/fd op amp/port width}\pgf@x \pgf@y=-\pgf@y }
+    \anchor{text}{\pgfpoint{-.6\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}
 
@@ -3927,10 +3928,7 @@
     \anchor{north west}{ \northwest }
     \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
 
-    \anchor{text}{\northwest
-        \pgf@x=\ctikzvalof{tripoles/op amp/port width}\pgf@x
-    \pgfpoint{-.5\wd\pgfnodeparttextbox+.25\pgf@x}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
-
+    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}
 
@@ -4559,7 +4557,7 @@
         \pgf@x=-0.7\pgf@x
     }
 
-    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+    \anchor{text}{\pgfpoint{-.6\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
 
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}
@@ -4712,7 +4710,7 @@
         \pgf@x=-\pgf@x
     }
 
-    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+    \anchor{text}{\pgfpoint{-.6\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
 
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}
@@ -4840,7 +4838,7 @@
         \pgf@x=-\pgf@x
     }
 
-    \anchor{text}{\pgfpoint{-.5\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
+    \anchor{text}{\pgfpoint{-.6\wd\pgfnodeparttextbox}{\dimexpr.5\dp\pgfnodeparttextbox-.5\ht\pgfnodeparttextbox}}
 
     \backgroundpath{
         \pgfsetcolor{\ctikzvalof{color}}


### PR DESCRIPTION
Even if the text was centered, the triangular shape makes the text seems
too to the right in these kinds of amplifiers. Move it a bit so it is
more pleasant to the eye.

![image](https://user-images.githubusercontent.com/6414907/70913879-29739a00-2017-11ea-8df2-797e82e5c703.png)
