### PR TITLE
Preparing for release 1.0.0-v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.0.0-pre1 (unreleased)
+* Version 1.0.0-pre1 (2019-12-22)
 
     Last additions before the long promised 1.0! In this pre-release we feature a flip-flop library, a revamped configurability of amplifiers (and a new amplifier as a bonus) and some bug fix around the clock.
 
-    - Bumped version number
     - Added a flip-flop library
     - Added a single-input generic amplifier with the same dimension as "plain amp"
     - Added border anchors to amplifiers

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -10,7 +10,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{1.0.0-pre1}
-\def\pgfcircversiondate{2019/12/06}
+\def\pgfcircversiondate{2019/12/22}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
 \def\pgfcircversion{1.0.0-pre1}
-\def\pgfcircversiondate{2019/12/06}
+\def\pgfcircversiondate{2019/12/22}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
- Added a flip-flop library
- Added a single-input generic amplifier with the same dimension as "plain amp"
- Added border anchors to amplifiers
- Added the possibility (expert only!) to add transparency to poles (after a suggestion from user @matthuszagh on GitHub)
- Make plus and minus symbol on amplifiers configurable
- Adjusted the position of text in triangular amplifiers
- Fixed "plain amp" not respecting "noinv input up"
- Fixed minor incompatibility with ConTeXt and Plain TeX