### PR TITLE
Add multiplexers and de-multiplexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 1.0.0-pre2 (unreleased)
 
-    Trying to go toward the 1.0.0 version. Minor changes and improvements deemed not too risky only.
+    Trying to go toward the 1.0.0 version. The most important change is the addition of multiplexer and de-multiplexers.
 
-    - Changed the shape of the or-type american logic ports (reversible with a flag)
+    - Added mux-demux shapes
     - Added the possibility to suppress the input leads in logic gates
     - Added multiple wires markers
+    - Changed the shape of the or-type american logic ports (reversible with a flag)
 
 * Version 1.0.0-pre1 (2019-12-22)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3985,7 +3985,7 @@ If you like different pin distributions, you can easily define different flip-fl
 \end{groupdesc}
 \endgroup
 
-The standard definition of the default flip-flops are the following (you can find them in the file \texttt{pgfcircmultipoles.tex}):
+The standard definition of the default flip-flops are the following (in the file \texttt{pgfcircmultipoles.tex}):
 
 \begin{lstlisting}[basicstyle=\small\ttfamily]
 \tikzset{
@@ -4063,7 +4063,7 @@ Normally the symbols on the flip-flop are un-rotated when you rotate the symbol,
 
 \subsection{Multiplexer and de-multiplexer}\label{sec:muxdemuxes}
 
-The shape used for muxes and de-muxes is probably the most configurable shape of the package; it has been added by Romano in \texttt{v1.0.0}. The basic shape is a multiplexer with 8 input pin, one output pin, and three control pins ($2^3\to1$ multiplexer). The pins are named in different way (see below for a full description for anchors) for reason that will be clear later.
+The shape used for muxes and de-muxes is probably the most configurable shape of the package; it has been added by Romano in \texttt{v1.0.0}. The basic shape is a multiplexer with 8 input pin, one output pin, and three control pins ($2^3\to1$ multiplexer). The pins are not named as input or output pins (see below for a full description for anchors) for reasons that will be clear later.
 
 \begin{groupdesc}
     \circuitdesc*[0.7]{muxdemux}{mux-demux}{MD1}(lpin 1/180/0.2, lpin 2/180/0.2, bpin 1/-90/0.2, blpin 1/0/0.2, blpin 2/0/0.2, bbpin 1/90/0.2, rpin 1/0/0.1, brpin 1/-110/0.1)
@@ -4140,13 +4140,13 @@ In designing the shape there are several parameters to be taken into account. In
 
 \bigskip
 
-In addition, you can set the following parameters:
+The default values are $\texttt{Lh}=8$, $\texttt{Rh}=6$, $\texttt{w}=3$ and no inset: $\texttt{inset Lh}=\texttt{inset Rh}=\texttt{inset w}=0$. In addition, you can set the following parameters:
 \begin{description}
-    \item [NL, NR, NB, NT]: number of pins relatively on the left, right, bottom and top side. When an inset is active (in other words, when $\texttt{Lh}>0$) the pins are positioned on the top and bottom part, not in the inset; the exception is when the number of left pins is odd, in which case you have one pin set on the center of the inset.
+    \item [NL, NR, NB, NT]: number of pins relatively on the left, right, bottom and top side (default \texttt{8}, \texttt{1}, \texttt{3}, \texttt{0}). When an inset is active (in other words, when $\texttt{Lh}>0$) the pins are positioned on the top and bottom part, not in the inset; the exception is when the number of left pins is odd, in which case you have one pin set on the center of the inset.
     If you do not want a pin in one side, use \texttt{0} as number of pins.
     \item [square pins]: set to \texttt{0} (default) if you want the square pins to stick out following the slope of the bottom or top side, \texttt{1} if you want them to stick out in a square way (see the example above for the ALU).
 \end{description}
-All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a numbers of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- \texttt{inset Lh}$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
+All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a numbers of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- (\texttt{inset Lh})$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
 \begin{circuitikz}
@@ -4165,15 +4165,15 @@ All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default
 
 \subsubsection{Mux-Demux customization}
 
-Mux-demuxes have the normal parameters of their class (\texttt{muxdemuxes}),  like \texttt{muxdemuxs/scale}, \texttt{muxdemuxes/thickness} and \texttt{muxdemuxes/fill} --- they are set, by default, at the same values than \texttt{logic ports}.
+Mux-demuxes have the normal parameters of their class (\texttt{muxdemuxes}):  you can scale them with the \verb|\ctikzset| key \texttt{muxdemuxes/scale}, control the border thickness with \texttt{muxdemuxes/thickness} and the default fill color with  \texttt{muxdemuxes/fill} --- they are set, by default, at the same values than \texttt{logic ports}.
 
-External pins' length is controlled by the key \texttt{multipoles/external pins
-width} (default \texttt{0.2}) or by the style \texttt{external pins width}
+External pins' length is controlled by the key \texttt{multipoles/external pins width} (default \texttt{0.2}) or by the style \texttt{external pins width}. The parameter
+\texttt{multipoles/external pins thickness} is also respected.
 like in chips. In addition, like in logic ports, you can suppress the
 drawing of the leads by using the boolean key
 \texttt{logic ports draw input leads} (default \texttt{true}) or, locally,
 with the style \texttt{no inputs leads} (that can be reverted with
-\texttt{input leads}.
+\texttt{input leads}).
 
 The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no inputs lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3364,6 +3364,23 @@ But notice that the ``A'' is also flipped by the \texttt{xscale} parameter. So t
 \end{LTXexample}
 
 
+\subsubsection{Designing your own amplifier}
+
+If you need a different kind of amplifier, you can use the \texttt{muxdemux}
+(see section~\ref{sec:muxdemuxes}) shape for defining one that suits your needs (you need version \texttt{1.0.0} for this to work).
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\tikzset{tdax/.style={muxdemux,
+        muxdemux def={NL=2, Lh=3, NR=1, Rh=0,
+        NB=4, NT=5}, font=\scriptsize\ttfamily}}
+\begin{circuitikz}
+    \draw (0,0) node[tdax](A){TDA1};
+    \draw (2.5,0) node[tdax,
+        muxdemux def={Rh=0.5}]{TDA2};
+\end{circuitikz}
+\end{LTXexample}
+
+
 \subsection{Switches and buttons}
 
 Switches and button come in to-style (the simple ones and the pushbuttons), and as nodes.
@@ -4043,6 +4060,184 @@ Normally the symbols on the flip-flop are un-rotated when you rotate the symbol,
     \draw (7,0) node[flipflop JK, add async SR, rotate=90, rotated numbers]{};
 \end{tikzpicture}
 \end{LTXexample}
+
+\subsection{Multiplexer and de-multiplexer}\label{sec:muxdemuxes}
+
+The shape used for muxes and de-muxes is probably the most configurable shape of the package; it has been added by Romano in \texttt{v1.0.0}. The basic shape is a multiplexer with 8 input pin, one output pin, and three control pins ($2^3\to1$ multiplexer). The pins are named in different way (see below for a full description for anchors) for reason that will be clear later.
+
+\begin{groupdesc}
+    \circuitdesc*[0.7]{muxdemux}{mux-demux}{MD1}(lpin 1/180/0.2, lpin 2/180/0.2, bpin 1/-90/0.2, blpin 1/0/0.2, blpin 2/0/0.2, bbpin 1/90/0.2, rpin 1/0/0.1, brpin 1/-110/0.1)
+\end{groupdesc}
+
+You can define a custom shape for the \texttt{muxdemux}es using an interface similar to the one used in flip-flops; for example:
+
+\begin{lstlisting}
+\tikzset{demux/.style={muxdemux, muxdemux def={Lh=4, Rh=8, NL=1, NB=3, NR=8}}}
+\end{lstlisting}
+
+will generate the following shape (the definition above is already defined in the package):
+
+\begin{groupdesc}
+    \circuitdesc*[0.7]{demux}{Demultiplexer $1\to2^3$ with \texttt{Lh=4, Rh=8, NL=1, NB=3, NR=8} }{MD2}
+\end{groupdesc}
+
+The shape can be also defined with an inset. For example it can be used like this to define a 1-bit adder (also already available):
+
+\begin{lstlisting}
+\tikzset{one bit adder/.style={muxdemux,
+         muxdemux def={Lh=4, NL=2, Rh=2, NR=1, NB=1, w=1.5,
+         inset w=0.5, inset Lh=2, inset Rh=1.5}}}
+\end{lstlisting}
+\begin{groupdesc}
+    \circuitdesc*{one bit adder}{One-bit adder}{\Large$\oplus$}
+\end{groupdesc}
+
+Or a Arithmetic Logic Unit (again, already defined by default):
+
+\begin{lstlisting}
+\tikzset{ALU/.style={muxdemux,
+         muxdemux def={Lh=5, NL=2, Rh=2, NR=1, NB=2, NT=1, w=2,
+         inset w=1, inset Lh=2, inset Rh=0, square pins=1}}}
+\end{lstlisting}
+\begin{groupdesc}
+    \circuitdesc*{ALU}{ALU}{\rotatebox{90}{\small\ttfamily ALU}}
+\end{groupdesc}
+
+\subsubsection{Mux-Demux: design your own shape}
+
+\begin{minipage}{0.45\linewidth}
+\RaggedRight
+In designing the shape there are several parameters to be taken into account. In the diagram on the right they are shown in a (hopefully) practical way. The parameter can be set in a node or in a style using the \texttt{muxdemux def} key as shown above, or set with \verb|\ctikzset| as \texttt{multipoles/muxdemux/Lh} keys and so on.
+\end{minipage}%
+\begin{minipage}{0.5\linewidth}
+\centering
+\begin{circuitikz}[quote/.style={thin, blue, <->}, refline/.style={red, dashed}]
+    \def\myquotev#1#2#3#4{%
+        \draw [refline] (A.#1) -- ++(#2,0) coordinate(tmp) --++(#3,0);
+        \draw [quote] (tmp|-A.center) -- (tmp |- A.#1)
+        node [midway, below=4pt, sloped, fill=white]{\texttt{#4}};
+    }
+    \def\myquoteh#1#2#3#4#5{%
+        \draw [refline] (A.#1) -- ++(0,#2) coordinate(tmp) --++(0,#3);
+        \draw [quote] (tmp) -- (tmp -| A.#5)
+        node [right, fill=white]{\texttt{#4}};
+    }
+    \begin{scope}
+        \clip (-4,-0.5) rectangle (2,3);
+        \node [muxdemux, muxdemux def={NL=6, NR=3, NT=3,
+        inset w=1.0, inset Lh=3.0, inset Rh=2.0}, no input leads](A) at(0,0) {};
+        \draw [refline] (-4,0) -- (2,0);
+        \draw [refline] (0,-1) -- (0,3);
+    \end{scope}
+    \myquotev{top left}{-2.8}{-.2}{Lh}
+    \myquotev{inset top left}{-2.0}{-.2}{inset Lh}
+    \myquotev{inset top right}{-1.4}{-.2}{inset Rh}
+    \myquotev{top right}{.5}{.2}{Rh}
+    \myquoteh{top left}{.3}{.2}{w}{center}
+    \myquoteh{inset top left}{-1.5}{-.2}{inset w}{inset top right}
+\end{circuitikz}
+\end{minipage}
+
+\bigskip
+
+In addition, you can set the following parameters:
+\begin{description}
+    \item [NL, NR, NB, NT]: number of pins relatively on the left, right, bottom and top side. When an inset is active (in other words, when $\texttt{Lh}>0$) the pins are positioned on the top and bottom part, not in the inset; the exception is when the number of left pins is odd, in which case you have one pin set on the center of the inset.
+    If you do not want a pin in one side, use \texttt{0} as number of pins.
+    \item [square pins]: set to \texttt{0} (default) if you want the square pins to stick out following the slope of the bottom or top side, \texttt{1} if you want them to stick out in a square way (see the example above for the ALU).
+\end{description}
+All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a numbers of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- \texttt{inset Lh}$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{circuitikz}
+    \tikzset{mux 4by2/.style={muxdemux,
+        muxdemux def={Lh=4, NL=4, Rh=3,
+        NB=2, w=2, square pins=1}}}
+    \node [dipchip, num pins=8](A) at (0,0) {IC1};
+    \node [one bit adder, scale=-1, anchor=lpin 2]
+        at (A.pin 1){};
+    \node [mux 4by2, anchor=lpin 1](B)
+        at (A.pin 8){MUX};
+    \node [qfpchip, num pins=8, anchor=pin 8] at
+        (B.bpin 1) {IC2};
+\end{circuitikz}
+\end{LTXexample}
+
+\subsubsection{Mux-Demux customization}
+
+Mux-demuxes have the normal parameters of their class (\texttt{muxdemuxes}),  like \texttt{muxdemuxs/scale}, \texttt{muxdemuxes/thickness} and \texttt{muxdemuxes/fill} --- they are set, by default, at the same values than \texttt{logic ports}.
+
+External pins' length is controlled by the key \texttt{multipoles/external pins
+width} (default \texttt{0.2}) or by the style \texttt{external pins width}
+like in chips. In addition, like in logic ports, you can suppress the
+drawing of the leads by using the boolean key
+\texttt{logic ports draw input leads} (default \texttt{true}) or, locally,
+with the style \texttt{no inputs leads} (that can be reverted with
+\texttt{input leads}.
+
+The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no inputs lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
+
+\subsubsection{Mux-Demux anchors}
+
+Mux-demuxes have a plethora of anchors. As in the case of chips, the geographic anchors mark the rectangle occupied by the component, without taking into account the pin leads.
+
+\begin{quote}
+    \scalebox{0.7}{%
+        \geocoord[baseline=(N.center)]{muxdemux}
+        \showanchors[baseline=(N.center)]{muxdemux}{X}(top left/180/0.3, top/90/0.3, top right/0/0.3,
+        bottom left/180/0.3, bottom/-90/0.3, bottom right/0/0.3, left/180/0.3, right/0/0.3,
+        center/45/0.2, center up/0/0.4, center down/0/0.4)
+        \showanchors[baseline=(N.center)]{muxdemux, muxdemux def={NL=6, NR=3, NT=3, inset w=1.0,
+        inset Lh=3.0, inset Rh=2.0}, no input leads}{}(inset top left/180/0.3, inset top/90/0.5,
+        inset top right/0/0.3, inset bottom left/180/0.3, inset bottom/-90/0.5,
+        inset bottom right/-20/0.3, inset left/180/0.3, inset right/-20/0.2, inset center/135/0.2,
+        narrow center/20/0.2, center up/45/0.4, center down/-45/0.4)
+}
+\end{quote}
+
+The pins anchors are named \texttt{lpin}, \texttt{rpin}, \texttt{bpin} and \texttt{tpin} for the left, right, bottom and top pin respectively, and points to the ``external'' pin. The border pins are named the same, with a \texttt{b} added in front: \texttt{blpin}, \texttt{brpin}, \texttt{bbpin} and \texttt{btpin}.
+The following graph will show the numbering and position of the pin anchors.
+
+\begin{quote}
+\begin{circuitikz}
+    \node [muxdemux, muxdemux def={NL=4, NR=3, NT=3, NB=3, w=2, inset w=0.5,
+        Lh=4, inset Lh=2.0, inset Rh=1.0, square pins=1}](C) at (0,0) {X};
+    \node [muxdemux, muxdemux def={NL=7, NR=8, NT=4, inset w=1.0,
+        inset Lh=4.0, inset Rh=0.0}](D) at (4,0) {X};
+    \foreach \myn/\NL/\NR/\NB/\NT in {C/4/3/3/3,D/7/8/3/4} {
+        \foreach \myp in {1,...,\NL} \node[right, font=\tiny] at (\myn.blpin \myp){\myp};
+        \foreach \myp in {1,...,\NR} \node[left, font=\tiny] at(\myn.brpin \myp) {\myp};
+        \foreach \myp in {1,...,\NB} \node[above, font=\tiny] at (\myn.bbpin \myp){\myp};
+        \foreach \myp in {1,...,\NT} \node[below, font=\tiny] at (\myn.btpin \myp){\myp};
+    }
+    \path (C.lpin 1) \showcoord(lpin 1)<180:0.3>;
+    \path (D.blpin 1) \showcoord(blpin 1)<135:0.3>;
+    \path (C.tpin 1) \showcoord(tpin 1)<180:0.3>;
+    \path (D.btpin 1) \showcoord(btpin 1)<45:0.3>;
+    \path (C.rpin 1) \showcoord(rpin 1)<0:0.3>;
+    \path (D.brpin 1) \showcoord(brpin 1)<45:0.3>;
+    \path (C.bpin 2) \showcoord(bpin 2)<-90:0.3>;
+    \path (C.bbpin 2) \showcoord(bbpin 2)<-60:0.3>;
+    \path (D.bbpin 2) \showcoord(bbpin 2)<-45:0.3>;
+\end{circuitikz}
+\end{quote}
+
+
+The code that implemented the printing of the numbers (which in \texttt{muxdemux}es, differently from chips, are never printed automatically) in the last graph is the following one.
+
+\begin{lstlisting}[basicstyle=\small\ttfamily]
+\begin{circuitikz}
+\node [muxdemux, muxdemux def={NL=4, NR=3, NT=3, NB=3, w=2, inset w=0.5,
+    Lh=4, inset Lh=2.0, inset Rh=1.0, square pins=1}](C) at (0,0) {X};
+\node [muxdemux, muxdemux def={NL=7, NR=8, NT=4, inset w=1.0,
+    inset Lh=4.0, inset Rh=0.0}](D) at (4,0) {X};
+\foreach \myn/\NL/\NR/\NB/\NT in {C/4/3/3/3,D/7/8/3/4} {
+    \foreach \myp in {1,...,\NL} \node[right, font=\tiny] at (\myn.blpin \myp){\myp};
+    \foreach \myp in {1,...,\NR} \node[left, font=\tiny] at(\myn.brpin \myp) {\myp};
+    \foreach \myp in {1,...,\NB} \node[above, font=\tiny] at (\myn.bbpin \myp){\myp};
+    \foreach \myp in {1,...,\NT} \node[below, font=\tiny] at (\myn.btpin \myp){\myp};
+}
+\end{lstlisting}
 
 \subsection{Chips (integrated circuits)}
 

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -3,6 +3,7 @@
 \RequirePackage{ifthen}
 \RequirePackage{xparse}
 \RequirePackage{showexpl}
+\RequirePackage{ragged2e}
 %
 % The following trick is used to silence showexpl a bit, so that the
 % logs are readable...
@@ -131,14 +132,14 @@
 }
 
 
-\def\geolrcoord#1{\showanchors{#1}{text}(north/90/0.4, north east/45/0.4, east/0/0.4,
+\newcommand{\geolrcoord}[2][]{\showanchors[#1]{#2}{text}(north/90/0.4, north east/45/0.4, east/0/0.4,
     south east/-45/0.4,
     south/-90/0.4, south west/-135/0.4, west/180/0.4, north west/135/0.4,
     left/160/0.4, right/30/0.4, center/-120/0.3
     )
 }
 
-\def\geocoord#1{\showanchors{#1}{text}(north/90/0.4, north east/45/0.4, east/0/0.4,
+\newcommand{\geocoord}[2][]{\showanchors[#1]{#2}{text}(north/90/0.4, north east/45/0.4, east/0/0.4,
     south east/-45/0.4,
     south/-90/0.4, south west/-135/0.4, west/180/0.4, north west/135/0.4,
     center/-120/0.3

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -364,6 +364,10 @@
 \ctikzset{flipflops/fill/.initial=none}
 \ctikzset{flipflops/thickness/.initial=none}
 
+\ctikzset{muxdemuxes/scale/.initial=1.0}
+\ctikzset{muxdemuxes/fill/.initial=none}
+\ctikzset{muxdemuxes/thickness/.initial=none}
+
 \ctikzset{chips/scale/.initial=1.0}
 \ctikzset{chips/fill/.initial=none}
 \ctikzset{chips/thickness/.initial=none}
@@ -1299,11 +1303,27 @@
 \pgfkeys{/tikz/number inputs/.default=0}
 
 %% flip-flop specific keys (most others are the same as chips)
+
 \ctikzset{multipoles/flipflop/font/.initial=\pgf@circ@font@small}
 \ctikzset{multipoles/flipflop/fontud/.initial=\pgf@circ@font@tiny}
 \ctikzset{multipoles/flipflop/width/.initial=1.2}
 \ctikzset{multipoles/flipflop/pin spacing/.initial=0.6}
 \ctikzset{multipoles/flipflop/clock wedge size/.initial=0.2}
+
+%% muxdemuxes keys
+
+\ctikzset{multipoles/muxdemux/base len/.initial=0.4}
+\ctikzset{multipoles/muxdemux/Lh/.initial=8.0}
+\ctikzset{multipoles/muxdemux/Rh/.initial=6.0}
+\ctikzset{multipoles/muxdemux/w/.initial=3.0}
+\ctikzset{multipoles/muxdemux/inset w/.initial=0.0}
+\ctikzset{multipoles/muxdemux/inset Lh/.initial=0.0}
+\ctikzset{multipoles/muxdemux/inset Rh/.initial=0.0}
+\ctikzset{multipoles/muxdemux/NL/.initial=8}
+\ctikzset{multipoles/muxdemux/NR/.initial=1}
+\ctikzset{multipoles/muxdemux/NB/.initial=3}
+\ctikzset{multipoles/muxdemux/NT/.initial=0}
+\ctikzset{multipoles/muxdemux/square pins/.initial=0}
 %
 % switches for op amps
 % changing input polarity

--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -1281,5 +1281,492 @@
                 \advance\pgf@circ@count@a by -1\relax%
                 \repeatpgfmathloop%
             }%
-        }
+}
 
+%
+% MUX-DEMUXES
+%
+% Thanks to @marmot
+\tikzset{muxdemux def/.code=\pgfqkeys{\circuitikzbasekey/multipoles/muxdemux}{#1}}
+\tikzset{demux/.style={muxdemux, muxdemux def={Lh=4, Rh=8, NL=1, NB=3, NR=8}}}
+\tikzset{one bit adder/.style={muxdemux,
+         muxdemux def={Lh=4, NL=2, Rh=2, NR=1, NB=1, w=1.5,
+         inset w=0.5, inset Lh=2, inset Rh=1.5}}}
+\tikzset{ALU/.style={muxdemux,
+         muxdemux def={Lh=5, NL=2, Rh=2, NR=1, NB=2, NT=1, w=2,
+         inset w=1, inset Lh=2, inset Rh=0, square pins=1}}}
+%generic mux-demux shape
+\pgfdeclareshape{muxdemux}{
+    \savedmacro{\ctikzclass}{\edef\ctikzclass{muxdemuxes}}
+    \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}}
+    \savedmacro{\thisshape}{\def\thisshape{\tikz@fig@name}}
+    % pins on the four sides
+    % \savedmacro\NL{%
+    %         \pgf@circ@count@a=\ctikzvalof{multipoles/muxdemux/NL}%
+    %         \def\NL{\the\pgf@circ@count@a}
+    % }
+    \savedmacro\NL{\edef\NL{\ctikzvalof{multipoles/muxdemux/NL}}}
+    \savedmacro\NR{\edef\NR{\ctikzvalof{multipoles/muxdemux/NR}}}
+    \savedmacro\NT{\edef\NT{\ctikzvalof{multipoles/muxdemux/NT}}}
+    \savedmacro\NB{\edef\NB{\ctikzvalof{multipoles/muxdemux/NB}}}
+    \savedmacro\squarepins{\edef\squarepins{\ctikzvalof{multipoles/muxdemux/square pins}}}
+    % topleft and topright sizes
+    \savedanchor{\topleft}{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@y{\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/Lh}*\pgf@circ@scaled@Rlen/2}
+        \pgfmathsetlength\pgf@x{-\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/w}*\pgf@circ@scaled@Rlen/2}
+    }
+    \savedanchor{\topright}{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@y{\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/Rh}*\pgf@circ@scaled@Rlen/2}
+        \pgfmathsetlength\pgf@x{\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/w}*\pgf@circ@scaled@Rlen/2}
+    }
+    \savedanchor{\insetnortheast}{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@y{\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/inset Lh}*\pgf@circ@scaled@Rlen/2}
+        \pgfmathsetlength\pgf@x{-\ctikzvalof{multipoles/muxdemux/base len}*
+        (\ctikzvalof{multipoles/muxdemux/w}-2*\ctikzvalof{multipoles/muxdemux/inset w})*\pgf@circ@scaled@Rlen/2}
+    }
+    \saveddimen{\insethright}{
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@x{\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/inset Rh}*\pgf@circ@scaled@Rlen/2}}
+    \saveddimen{\extshift}{
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@x{\pgf@circ@scaled@Rlen*\ctikzvalof{multipoles/external pins width}}}
+    \savedanchor{\northwest}{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@y{\ctikzvalof{multipoles/muxdemux/base len}*max(\ctikzvalof{multipoles/muxdemux/Rh},\ctikzvalof{multipoles/muxdemux/Lh})*\pgf@circ@scaled@Rlen/2}
+        \pgfmathsetlength\pgf@x{-\ctikzvalof{multipoles/muxdemux/base len}*\ctikzvalof{multipoles/muxdemux/w}*\pgf@circ@scaled@Rlen/2}
+    }
+    \anchor{nw}{\northwest}
+    \anchor{ne}{\northwest\pgf@x=-\pgf@x}
+    \anchor{se}{\northwest\pgf@x=-\pgf@x\pgf@y=-\pgf@y}
+    \anchor{sw}{\northwest\pgf@y=-\pgf@y}
+    \anchor{north west}{\northwest}
+    \anchor{north east}{\northwest\pgf@x=-\pgf@x}
+    \anchor{south east}{\northwest\pgf@x=-\pgf@x \pgf@y=-\pgf@y}
+    \anchor{south west}{\northwest\pgf@y=-\pgf@y}
+    \anchor{n}{\northwest\pgf@x=0pt }
+    \anchor{e}{\northwest\pgf@x=-\pgf@x\pgf@y=0pt }
+    \anchor{s}{\northwest\pgf@x=0pt\pgf@y=-\pgf@y}
+    \anchor{w}{\northwest\pgf@y=0pt }
+    \anchor{north}{\northwest\pgf@x=0pt }
+    \anchor{east}{\northwest\pgf@x=-\pgf@x\pgf@y=0pt }
+    \anchor{south}{\northwest\pgf@x=0pt\pgf@y=-\pgf@y}
+    \anchor{west}{\northwest\pgf@y=0pt }
+    \anchor{center}{\pgfpointorigin}
+    \anchor{top right}{\topright}
+    \anchor{bottom right}{\topright\pgf@y=-\pgf@y}
+    \anchor{right}{\topright\pgf@y=0pt\relax}
+    \anchor{top left}{\topleft}
+    \anchor{bottom left}{\topleft\pgf@y=-\pgf@y}
+    \anchor{left}{\topleft\pgf@y=0pt\relax}
+    \anchor{top}{\topright\pgf@ya=\pgf@y \topleft \advance\pgf@y by \pgf@ya
+        \divide\pgf@y by 2 \pgf@x=0pt\relax}
+    \anchor{bottom}{\topright\pgf@ya=\pgf@y \topleft \advance\pgf@y by \pgf@ya
+        \divide\pgf@y by 2 \pgf@y=-\pgf@y \pgf@x=0pt\relax}
+    \anchor{inset top right}{\pgf@ya=\insethright\insetnortheast\advance\pgf@y by -0.5\pgf@ya}
+    \anchor{inset bottom right}{\pgf@ya=\insethright\insetnortheast\advance\pgf@y by -0.5\pgf@ya\pgf@y=-\pgf@y}
+    \anchor{inset right}{\insetnortheast\pgf@y=0pt\relax}
+    \anchor{inset top left}{\insetnortheast\pgf@ya=\pgf@y\topleft\pgf@y=\pgf@ya}
+    \anchor{inset bottom left}{\insetnortheast\pgf@ya=\pgf@y\topleft\pgf@y=-\pgf@ya}
+    \anchor{inset left}{\topleft\pgf@y=0pt\relax}
+    \anchor{inset bottom}{\topleft\pgf@xa=\pgf@x\pgf@ya=\insethright
+        \insetnortheast\pgf@xb=\pgf@x\pgf@yb=\pgf@x
+        \pgfpoint{(\pgf@xa+\pgf@xb)/2}{-\pgf@ya+\pgf@yb/2}}
+    \anchor{inset top}{\topleft\pgf@xa=\pgf@x\pgf@ya=\insethright
+        \insetnortheast\pgf@xb=\pgf@x\pgf@yb=\pgf@x
+        \pgfpoint{(\pgf@xa+\pgf@xb)/2}{\pgf@ya-\pgf@yb/2}}
+    \anchor{inset center}{\topleft\pgf@xa=\pgf@x\insetnortheast
+        \advance\pgf@x by \pgf@xa \divide\pgf@x by 2 \pgf@y=0pt\relax}
+    \anchor{narrow center}{\insetnortheast\pgf@xa=\pgf@x\topright
+        \advance\pgf@x by \pgf@xa \divide\pgf@x by 2\pgf@y=0pt\relax}
+    \anchor{center up}{\topright\pgf@ya=\pgf@y \topleft \advance\pgf@y by \pgf@ya
+        \divide\pgf@y by 2
+        \pgf@yb = \insethright \advance\pgf@y by \pgf@yb
+        \divide\pgf@y by 2 \pgf@x=0pt\relax}
+    \anchor{center down}{\topright\pgf@ya=\pgf@y \topleft \advance\pgf@y by \pgf@ya
+        \divide\pgf@y by 2
+        \pgf@yb = \insethright \advance\pgf@y by \pgf@yb
+        \divide\pgf@y by 2 \pgf@y=-\pgf@y \pgf@x=0pt\relax}
+    \anchor{text}{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgfmathsetlength\pgf@x{\ctikzvalof{multipoles/muxdemux/base len}*
+          \ctikzvalof{multipoles/muxdemux/inset w}*\pgf@circ@scaled@Rlen/2}
+        \advance\pgf@x by -.5\wd\pgfnodeparttextbox%
+        \pgf@y=-.5\ht\pgfnodeparttextbox%
+        \advance\pgf@y by+.5\dp\pgfnodeparttextbox%
+    }%
+    \backgroundpath{%
+        \topleft
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@left = \pgf@x
+        \topright
+        \pgf@circ@res@other = \pgf@y
+        \pgf@circ@res@right = \pgf@x
+        \insetnortheast
+        \pgf@circ@res@step = \pgf@x
+        \pgf@circ@res@temp = \pgf@y
+        %
+        % external block
+        %
+        \pgfscope% (for the line width)
+            \pgf@circ@setlinewidth{multipoles}{\pgflinewidth}
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@other}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{-\pgf@circ@res@other}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+            % inset, starting down
+            \ifdim\pgf@circ@res@temp>0pt % inset
+                % \typeout{INSETw\space\the\pgf@circ@res@right\space x\space\the\pgf@circ@res@step\space  y\space\the\pgf@circ@res@temp}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@temp}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{-\insethright}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{\insethright}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@temp}}
+            \fi
+            \pgfpathclose
+            \pgf@circ@draworfill
+        \endpgfscope
+        % now we have to draw the pins, if needed
+        \ifdim\extshift>0pt\ifpgfcirc@draw@leads\pgfscope % let's avoid too much indent
+        % Ok, we have to draw the leads (a.k.a. pins)
+            \pgfsetlinewidth{\ctikzvalof{multipoles/external pins thickness}\pgflinewidth}
+            % We mimic the anchors here --- probably there is a better way
+            % left pins
+            \ifnum\NL>0\relax % not indented, closed on \repeatpgfmathloop
+            \pgf@circ@count@a=\NL\relax
+            \pgf@circ@count@b=\NL \divide\pgf@circ@count@b by 2 % see https://tex.stackexchange.com/questions/146523/why-does-numexpr-integer-division-round-rather-than-truncate
+            \topleft\pgf@circ@res@left=\pgf@x \pgf@circ@res@up=\pgf@y
+            \insetnortheast\pgf@circ@res@right=\pgf@x \pgf@circ@res@down=\pgf@y
+            \ifdim\pgf@circ@res@down>0pt % check if we have an inset
+            % we have to check oddity
+                \ifodd\NL
+                    \ifnum\NL=1
+                        % only centerpin, step should not be used, but anyway...
+                        \pgfmathsetlength{\pgf@circ@res@step}{2*(\pgf@circ@res@up-\pgf@circ@res@down)/(\NL)}
+                    \else
+                        \pgfmathsetlength{\pgf@circ@res@step}{2*(\pgf@circ@res@up-\pgf@circ@res@down)/(\NL-1)}
+                    \fi
+                \else
+                    \pgfmathsetlength{\pgf@circ@res@step}{2*(\pgf@circ@res@up-\pgf@circ@res@down)/\NL}
+                \fi
+            \else % no inset
+                \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@circ@res@up/\NL}
+            \fi
+            \pgfmathloop%
+            \ifnum\pgf@circ@count@a>0
+                %%%%%
+                \ifdim\pgf@circ@res@down>0pt % check if we have an inset
+                    \ifnum\pgf@circ@count@a>\pgf@circ@count@b\relax
+                        % for lower pins we have to shift them down
+                        % \typeout{DEBUGTEST1\space #1\space entering\space \NL}
+                        \ifodd\NL
+                            % odd number of pins
+                            \ifnum\pgf@circ@count@a=\numexpr\the\pgf@circ@count@b+1\relax
+                                % centerpin!
+                                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+                                \ifnum\squarepins>0
+                                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\extshift}{0pt}}
+                                \else
+                                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\extshift}{0pt}}
+                                \fi
+                            \else
+                                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a+1)*\pgf@circ@res@step-2*\pgf@circ@res@down}}
+                                \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\extshift}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a+1)*\pgf@circ@res@step-2*\pgf@circ@res@down}}
+                            \fi
+                        \else
+                            % even numer of pins: just go down
+                            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step-2*\pgf@circ@res@down}}
+                            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\extshift}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step-2*\pgf@circ@res@down}}
+                        \fi
+                    \else
+                        % nothing need for #1<=NL/2
+                        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+                        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\extshift}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+                    \fi
+                \else
+                % no inset
+                    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\extshift}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+                \fi
+                %%%%%
+                \advance\pgf@circ@count@a by -1\relax%
+            \repeatpgfmathloop\fi%
+            % right pins
+            \ifnum\NR>0\pgf@circ@count@a=\NR\relax
+            \pgfmathloop%
+            \topright\pgf@circ@res@right=\pgf@x \pgf@circ@res@up=\pgf@y
+            \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@circ@res@up/\NR}
+            \ifnum\pgf@circ@count@a>0
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@right+\extshift}{\pgf@circ@res@up+(0.5-\pgf@circ@count@a)*\pgf@circ@res@step}}
+            \advance\pgf@circ@count@a by -1\relax%
+            \repeatpgfmathloop\fi%
+            % bottom pins
+            \ifnum\NB>0\pgf@circ@count@a=\NB\relax %%%
+            \pgfmathloop%
+            \topleft\pgf@circ@res@left=\pgf@x \pgf@circ@res@up=\pgf@y
+            \topright\pgf@circ@res@right=\pgf@x \pgf@circ@res@down=\pgf@y
+            \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@circ@res@right/\NB}
+            \pgfmathsetlength{\pgf@circ@res@other}{(\pgf@circ@res@down-\pgf@circ@res@up)/(\pgf@circ@res@right-\pgf@circ@res@left)*\pgf@circ@res@step}
+            \ifnum\pgf@circ@count@a>0
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                {-\pgf@circ@res@down+(\NB-\pgf@circ@count@a+0.5)*\pgf@circ@res@other}}
+                \ifnum\squarepins>0
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                    {-max(\pgf@circ@res@down, \pgf@circ@res@up)-\extshift}}
+                \else
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                    {-\pgf@circ@res@down+(\NB-\pgf@circ@count@a+0.5)*\pgf@circ@res@other-\extshift}}
+                \fi
+            \advance\pgf@circ@count@a by -1\relax%
+            \repeatpgfmathloop\fi%
+            % top pins
+            \ifnum\NT>0\pgf@circ@count@a=\NT\relax
+            \pgfmathloop%
+            \topleft\pgf@circ@res@left=\pgf@x \pgf@circ@res@up=\pgf@y
+            \topright\pgf@circ@res@right=\pgf@x \pgf@circ@res@down=\pgf@y
+            \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@circ@res@right/\NT}
+            \pgfmathsetlength{\pgf@circ@res@other}{(\pgf@circ@res@down-\pgf@circ@res@up)/(\pgf@circ@res@right-\pgf@circ@res@left)*\pgf@circ@res@step}
+            \ifnum\pgf@circ@count@a>0
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                {\pgf@circ@res@down-(\NT-\pgf@circ@count@a+0.5)*\pgf@circ@res@other}}
+                \ifnum\squarepins>0
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                    {max(\pgf@circ@res@down, \pgf@circ@res@up)+\extshift}}
+                \else
+                    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+(\pgf@circ@count@a-0.5)*\pgf@circ@res@step}
+                    {\pgf@circ@res@down-(\NT-\pgf@circ@count@a+0.5)*\pgf@circ@res@other+\extshift}}
+                \fi
+            \advance\pgf@circ@count@a by -1\relax%
+            \repeatpgfmathloop\fi%
+        % end drawing pins; stroke them
+        \pgfusepath{stroke}
+        \endpgfscope\fi\fi
+    }
+    % let's start adding anchors
+    \pgfutil@g@addto@macro\pgf@sh@s@muxdemux{%
+        % left side anchors
+        \pgf@circ@count@a=\NL\relax
+        % \typeout{STARTGENERATINGLEFT\space\the\pgf@circ@count@a\space FOR\space\thisshape\space\NL}
+        \pgfmathloop%
+        \ifnum\pgf@circ@count@a>0
+        % \typeout{GENERATINGLEFT\space\the\pgf@circ@count@a\space FOR\space\thisshape\space\NL}
+            % we will create two anchors per pin: the "normal one" like `lpin 1` for the
+            % external leads, and the "border one" like `blpin 1` for internal ones.
+            % they will coincide if `external pins width` is set to 0.
+            \expandafter\xdef\csname pgf@anchor@muxdemux@lpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@L@anchor{\the\pgf@circ@count@a}{1}%
+            }
+            \expandafter\xdef\csname pgf@anchor@muxdemux@blpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@L@anchor{\the\pgf@circ@count@a}{0}%
+            }
+            \advance\pgf@circ@count@a by -1\relax%
+        \repeatpgfmathloop%
+        % right anchors
+        \pgf@circ@count@a=\NR\relax
+        \pgfmathloop%
+        \ifnum\pgf@circ@count@a>0
+            % we will create two anchors per pin: the "normal one" like `rpin 1` for the
+            % external leads, and the "border one" like `brpin 1` for internal ones.
+            % they will coincide if `external pins width` is set to 0.
+            \expandafter\xdef\csname pgf@anchor@muxdemux@rpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@R@anchor{\the\pgf@circ@count@a}{1}%
+            }
+            \expandafter\xdef\csname pgf@anchor@muxdemux@brpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@R@anchor{\the\pgf@circ@count@a}{0}%
+            }
+            \advance\pgf@circ@count@a by -1\relax%
+        \repeatpgfmathloop%
+        % bottom anchors
+        \pgf@circ@count@a=\NB\relax
+        \pgfmathloop%
+        \ifnum\pgf@circ@count@a>0
+            % we will create two anchors per pin: the "normal one" like `bpin 1` for the
+            % external leads, and the "border one" like `bbpin 1` for internal ones.
+            % they will coincide if `external pins width` is set to 0.
+            \expandafter\xdef\csname pgf@anchor@muxdemux@bpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@B@anchor{\the\pgf@circ@count@a}{1}%
+            }
+            \expandafter\xdef\csname pgf@anchor@muxdemux@bbpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@B@anchor{\the\pgf@circ@count@a}{0}%
+            }
+            \advance\pgf@circ@count@a by -1\relax%
+        \repeatpgfmathloop%
+        % top anchors
+        \pgf@circ@count@a=\NT\relax
+        \pgfmathloop%
+        \ifnum\pgf@circ@count@a>0
+            % we will create two anchors per pin: the "normal one" like `tpin 1` for the
+            % external leads, and the "border one" like `btpin 1` for internal ones.
+            % they will coincide if `external pins width` is set to 0.
+            \expandafter\xdef\csname pgf@anchor@muxdemux@tpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@T@anchor{\the\pgf@circ@count@a}{1}%
+            }
+            \expandafter\xdef\csname pgf@anchor@muxdemux@btpin\space\the\pgf@circ@count@a\endcsname{%
+                \noexpand\pgf@circ@muxdemux@T@anchor{\the\pgf@circ@count@a}{0}%
+            }
+            \advance\pgf@circ@count@a by -1\relax%
+        \repeatpgfmathloop%
+    }%
+}
+
+%% left anchors for muxdemux
+
+\def\pgf@circ@muxdemux@L@anchor#1#2{% #1: pin number #2: 0 for border pin, 1 for external pin
+    \topleft
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
+    \insetnortheast
+    \pgf@xb=\pgf@x
+    \pgf@yb=\pgf@y
+    \ifnum#1>\NL
+        \PackageError{circuitikz}{%
+            You requested left pin #1 for mux/demux shape \thisshape\space \MessageBreak
+            which has been defined with \NL\space left pins%
+        }{Please check the manual about mux/demux shapes; if you press return I'll try to continue}
+    \fi
+    \pgf@circ@count@a=\NL \divide\pgf@circ@count@a by 2 % see https://tex.stackexchange.com/questions/146523/why-does-numexpr-integer-division-round-rather-than-truncate
+    % \typeout{LEFT \the\pgf@xa \space \the\pgf@ya \space \NL}
+    \ifnum\NL>1
+        \ifdim\pgf@yb>0pt % check if we have an inset
+        % we have to check oddity
+            \ifodd\NL
+                \pgfmathsetlength{\pgf@circ@res@step}{2*(\pgf@ya-\pgf@yb)/(\NL-1)}
+            \else
+                \pgfmathsetlength{\pgf@circ@res@step}{2*(\pgf@ya-\pgf@yb)/\NL}
+            \fi
+        \else % no inset
+            \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@ya/\NL}
+        \fi
+        \ifdim\pgf@yb>0pt % check if we have an inset
+            \ifnum#1>\pgf@circ@count@a\relax
+                % for lower pins we have to shift them down
+                % \typeout{DEBUGTEST1\space #1\space entering\space \NL}
+                \ifodd\NL
+                    % odd number of pins
+                    \ifnum#1=\numexpr\the\pgf@circ@count@a+1\relax
+                        % centerpin!
+                        \ifnum#2=0\relax
+                            \pgfpoint{\pgf@xb}{0pt}
+                        \else
+                            \ifnum\squarepins>0
+                                \pgfpoint{\pgf@xa-#2*\extshift}{0pt}
+                            \else
+                                \pgfpoint{\pgf@xb-#2*\extshift}{0pt}
+                            \fi
+                        \fi
+                    \else
+                        \pgfpoint{\pgf@xa-#2*\extshift}{\pgf@ya+(0.5-#1+1)*\pgf@circ@res@step-2*\pgf@yb}
+                    \fi
+                \else
+                    % even numer of pins: just go down
+                    \pgfpoint{\pgf@xa-#2*\extshift}{\pgf@ya+(0.5-#1)*\pgf@circ@res@step-2*\pgf@yb}
+                \fi
+            \else
+                % nothing need for #1<=NL/2
+                \pgfpoint{\pgf@xa-#2*\extshift}{\pgf@ya+(0.5-#1)*\pgf@circ@res@step}
+            \fi
+        \else
+        % no inset
+            \pgfpoint{\pgf@xa-#2*\extshift}{\pgf@ya+(0.5-#1)*\pgf@circ@res@step}
+        \fi
+    \else
+        \pgfpoint{\pgf@xa-#2*\extshift}{0pt}
+    \fi
+}
+
+% right anchors
+\def\pgf@circ@muxdemux@R@anchor#1#2{% #1: pin number #2: 0 for border pin, 1 for external pin
+    \topright
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
+    \ifnum#1>\NR
+        \PackageError{circuitikz}{%
+            You requested right pin #1 for mux/demux shape \thisshape\space \MessageBreak
+            which has been defined with \NR\space right pins%
+        }{Please check the manual about mux/demux shapes; if you press return I'll try to continue}
+    \fi
+    \ifnum\NR>1
+        \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@ya/\NR}
+        \pgfpoint{\pgf@xa+#2*\extshift}{\pgf@ya+(0.5-#1)*\pgf@circ@res@step}
+    \else
+        \pgfpoint{\pgf@xa+#2*\extshift}{0pt}
+    \fi
+}
+
+% bottom anchors
+\def\pgf@circ@muxdemux@B@anchor#1#2{% #1: pin number #2: 0 for border pin, 1 for external pin
+    \topleft
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
+    \topright
+    \pgf@xb=\pgf@x
+    \pgf@yb=\pgf@y
+    \ifnum#1>\NB
+        \PackageError{circuitikz}{%
+            You requested bottom pin #1 for mux/demux shape \thisshape\space \MessageBreak
+            which has been defined with \NB\space bottom pins%
+        }{Please check the manual about mux/demux shapes; if you press return I'll try to continue}
+    \fi
+    \ifnum\NB>0
+        % \typeout{DEBUGTESTtopleft\space\the\pgf@ya \space topright\space\the\pgf@yb \space\NB}
+        \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@xb/\NB}
+        \pgfmathsetlength{\pgf@circ@res@other}{(\pgf@yb-\pgf@ya)/(\pgf@xb-\pgf@xa)*\pgf@circ@res@step}
+        \pgfmathsetlength\pgf@x{\pgf@xa+(#1-0.5)*\pgf@circ@res@step}
+        \ifnum#2=0\relax
+            \pgfmathsetlength\pgf@y{-\pgf@yb+(\NB-#1+0.5)*\pgf@circ@res@other}
+        \else
+            \ifnum\squarepins>0\relax
+                \pgfmathsetlength\pgf@y{-max(\pgf@ya,\pgf@yb)-\extshift}
+            \else
+                \pgfmathsetlength\pgf@y{-\pgf@yb+(\NB-#1+0.5)*\pgf@circ@res@other-\extshift}
+            \fi
+        \fi
+    \else
+        % should not happen, give the same as pin 1 anyway
+        \ifnum#2=0\relax
+        \pgfpoint{0pt}{-\pgf@yb+(\pgf@yb-\pgf@ya)/2}
+        \else
+            \pgfpoint{0pt}{-max(\pgf@ya,\pgf@yb)-\extshift}
+        \fi
+    \fi
+}
+
+% top anchors
+\def\pgf@circ@muxdemux@T@anchor#1#2{% #1: pin number #2: 0 for border pin, 1 for external pin
+    \topleft
+    \pgf@xa=\pgf@x
+    \pgf@ya=\pgf@y
+    \topright
+    \pgf@xb=\pgf@x
+    \pgf@yb=\pgf@y
+    \ifnum#1>\NT
+        \PackageError{circuitikz}{%
+            You requested top pin #1 for mux/demux shape \thisshape\space \MessageBreak
+            which has been defined with \NT\space top pins%
+        }{Please check the manual about mux/demux shapes; if you press return I'll try to continue}
+    \fi
+    \ifnum\NT>0
+        \pgfmathsetlength{\pgf@circ@res@step}{2*\pgf@xb/\NT}
+        \pgfmathsetlength{\pgf@circ@res@other}{(\pgf@yb-\pgf@ya)/(\pgf@xb-\pgf@xa)*\pgf@circ@res@step}
+        \pgfmathsetlength\pgf@x{\pgf@xa+(#1-0.5)*\pgf@circ@res@step}
+        \ifnum#2=0\relax
+            \pgfmathsetlength\pgf@y{\pgf@yb-(\NT-#1+0.5)*\pgf@circ@res@other}
+        \else
+            \ifnum\squarepins>0
+                \pgfmathsetlength\pgf@y{max(\pgf@ya,\pgf@yb)+\extshift}
+            \else
+                \pgfmathsetlength\pgf@y{\pgf@yb-(\NT-#1+0.5)*\pgf@circ@res@other+\extshift}
+            \fi
+        \fi
+    \else
+        % should not happen, give the same as pin 1 anyway
+        \ifnum#2=0\relax
+        \pgfpoint{0pt}{\pgf@yb-(\pgf@yb-\pgf@ya)/2}
+        \else
+            \pgfpoint{0pt}{max(\pgf@ya,\pgf@yb)+\extshift}
+        \fi
+    \fi
+}


### PR DESCRIPTION
This adds an important missing piece to components: the multiplexers and demultiplexers. 
The shape is highly configurable and you can obtain a lot of shapes from it: 

![image](https://user-images.githubusercontent.com/6414907/72687384-8de5b580-3afd-11ea-87d7-74f974a52076.png)

You can see the manual preview here: 
[mux-demux.pdf](https://github.com/circuitikz/circuitikz/files/4083445/mux-demux.pdf)

This is the last big addition to the package before 1.0.0.  (I have still a couple of things more). 
