### PR TITLE
Prepearing release v1.0.0-pre2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.0.0-pre2 (unreleased)
+* Version 1.0.0-pre2 (2020-01-23)
 
     **Really** last additions toward the 1.0.0 version. The most important change is the addition of multiplexer and de-multiplexers; also added the multi-wires (bus) markers.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -10,7 +10,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{1.0.0-pre2}
-\def\pgfcircversiondate{2019/12/24}
+\def\pgfcircversiondate{2020/01/23}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -1,5 +1,5 @@
 \def\pgfcircversion{1.0.0-pre2}
-\def\pgfcircversiondate{2019/12/24}
+\def\pgfcircversiondate{2020/01/23}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
**Really** last additions toward the 1.0.0 version. The most important change is the addition of multiplexer and de-multiplexers; also added the multi-wires (bus) markers.

    - Added mux-demux shapes
    - Added the possibility to suppress the input leads in logic gates
    - Added multiple wires markers
    - Added a style to switch off the automatic rotation of instruments
    - Changed the shape of the or-type american logic ports (reversible with a flag)