### PR TITLE
Add a way to adjust the voltage label distance of single elements

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -5946,6 +5946,28 @@ which leads to:
 \end{circuitikz}
 \end{LTXexample}
 
+Now you can check if the voltage labels are correct for your new component:
+
+\begin{LTXexample}[varwidth]
+\begin{circuitikz}[]
+    \draw (0,0) to[spring] ++(2,0)
+    to[viscoe, v=V] ++(2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+If you think they are too tight or too loose you can use a (developer-only) key to adjust the distance:
+
+\begin{LTXexample}[varwidth]
+\begin{circuitikz}
+    \ctikzset{bipoles/viscoe/voltage/additional label shift/.initial=1}
+    \draw (0,0) to[spring] ++(2,0)
+    to[viscoe, v=V] ++(2,0);
+\end{circuitikz}
+\end{LTXexample}
+
+Notice that by default the key \texttt{bipoles/\emph{mybipole}/voltage/additional label shift} is not defined, so if you want to use it you must create it before (this is the meaning of the \texttt{.initial} here).
+
+
 As a final note, notice that the \texttt{viscoe} element is already added to the standard package.
 
 \subsection{Node-style component}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -688,13 +688,21 @@
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
 \ctikzset{bipoles/smeter/height/.initial=.60}
 \ctikzset{bipoles/smeter/width/.initial=.60}
+\ctikzset{bipoles/smeter/voltage/additional label shift/.initial=1}
 \ctikzset{bipoles/qmeter/depth/.initial=.40}
 \ctikzset{bipoles/qmeter/height/.initial=.80}
 \ctikzset{bipoles/qmeter/width/.initial=.60}
+% this must be specified for each one
+\ctikzset{bipoles/qvprobe/voltage/additional label shift/.initial=.5}
+\ctikzset{bipoles/qiprobe/voltage/additional label shift/.initial=.5}
+\ctikzset{bipoles/qpprobe/voltage/additional label shift/.initial=.5}
 \ctikzset{bipoles/iloop/width/.initial=.40}
 \ctikzset{bipoles/iloop/height/.initial=.60}
+
 \ctikzset{bipoles/oscope/height/.initial=.60}
 \ctikzset{bipoles/oscope/width/.initial=.60}
+\ctikzset{bipoles/oscope/voltage/additional label shift/.initial=1}
+
 
 % option to not rotate the new (Romano's) instruments
 \newif\ifpgf@circuit@straightinstruments\pgf@circuit@straightinstrumentstrue

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -195,8 +195,17 @@
             { \edef\bumpb{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump b}} }
             { \edef\bumpb{\ctikzvalof{voltage/bump b}} }
         \edef\shiftv{\ctikzvalof{voltage/shift}}
+        % additional per-bipole voltage shift (internal)
+        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/additional label shift}
+        \pgfkeysifdefined{\pgf@temp}
+        {
+            \edef\addvshift{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/additional label shift}}
+        }
+        {
+            \edef\addvshift{0}
+        }
         \newdimen{\absvshift}
-        \pgfmathsetlength{\absvshift}{\shiftv*\distfromline+\distfromline}
+        \pgfmathsetlength{\absvshift}{(1+\shiftv+\addvshift)*(\distfromline)}
         % put this to true to see the voltage label coordinate anchors
         \newif\ifpgf@circ@debugv\pgf@circ@debugvfalse
     }


### PR DESCRIPTION
Apply it to square instruments where the voltage label was too tight
around them.

![image](https://user-images.githubusercontent.com/6414907/73592161-ac817e80-44f7-11ea-907e-1fea12120967.png)

