### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.0.1 (unreleased)
+* Version 1.0.1 (2020-02-22)
 
-- bump version number.
+Minor fixes and addition to 1.0, in time to catch the freeze for TL2020.
+
 - add v1.0 version snapshots
 - added crossed generic impedance (suggested by Radványi Patrik Tamás)
 - added open barrier bipole (suggested by Radványi Patrik Tamás)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -13,7 +13,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{1.0.1}
-\def\pgfcircversiondate{2020/02/11}
+\def\pgfcircversiondate{2020/02/22}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -11,7 +11,7 @@
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
 \def\pgfcircversion{1.0.1}
-\def\pgfcircversiondate{2020/02/11}
+\def\pgfcircversiondate{2020/02/22}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
* Version 1.0.1 (2020-02-22)

Minor fixes and addition to 1.0, in time to catch the freeze for TL2020.

- add v1.0 version snapshots
- added crossed generic impedance (suggested by Radványi Patrik Tamás)
- added open barrier bipole (suggested by Radványi Patrik Tamás)
- added two flags to flip the direction of light's arrows on LED and photodiode (suggested by karlkappe on GitHub)
- added a special key to help with precision loss in case of fractional scaling (thanks to AndreaDiPietro92 on GitHub for noticing and reporting, and to Schrödinger's cat for finding a fix)
- fixed a nasty bug for the flat file generation for ConTeXt