### PR TITLE
Prepare for release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.0.2 (unreleased)
+* Version 1.0.2 (2020-03-22)
 
-    - bumped version number
-    - added Schottky transistors
+    - added Schottky transistors (thanks to a suggestion by Jérôme Monclard on GitHub)
     - fixed formatting of `CHANGELOG.md`
 
 * Version 1.0.1 (2020-02-22)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.0.2-unreleased}
-\def\pgfcircversiondate{2020/02/29}
+\def\pgfcircversion{1.0.2}
+\def\pgfcircversiondate{2020/03/22}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.0.2-unreleased}
-\def\pgfcircversiondate{2020/02/29}
+\def\pgfcircversion{1.0.2}
+\def\pgfcircversiondate{2020/03/22}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
    - added Schottky transistors (thanks to a suggestion by Jérôme Monclard on GitHub)
    - fixed formatting of changelog.