### PR TITLE
Prepare for release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.0.3 (unreleased)
+* Version 1.1.0 (2020-04-19)
 
-    - bumped version number
+    Version bumped to 1.1 because the new logic ports are quite a big addition: now there is a new style for logic ports, conforming to IEEE recommendations.
+
+    Several minor additions all over the map too.
+
     - added IEEE standard logic ports suggested by user Jason-s on GitHub
     - added configurability to european logic port "not" output symbol, suggested by j-hap on GitHub
     - added `inerter` component by user Tadashi on GitHub

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1749,7 +1749,7 @@ The size of the broken part of the DC current source is configurable by changing
 
 You can change the scale of the batteries by setting the key \texttt{batteries/scale}, for the controlled (dependent) sources with \texttt{csources/scale}, and for all the other independent sources and generators with \texttt{sources/scale}, to something different from the default \texttt{1.0}.
 
-The symbols drawn into the \texttt{american voltage source}\footnote{Since version \texttt{1.0.3}, thanks to the suggestions and discussion
+The symbols drawn into the \texttt{american voltage source}\footnote{Since version \texttt{1.1.0}, thanks to the suggestions and discussion
 \href{https://tex.stackexchange.com/questions/538723/circuitikz-what-should-i-do-to-put-the-and-on-the-appropriate-places-like-t}{in this TeX.SX question}.} can be changed by using the \verb|\ctikzset|  keys \texttt{bipoles/vsourceam/inner plus} and \texttt{bipoles/vsourceam/inner minus} (by default they are \verb|$+$| and \verb|$-$| respectively, in the current font), and move them nearer of farther away by twiddling \texttt{bipoles/vsourceam/margin} (default \texttt{0.7}, less means nearer).
 
 Moreover, you can move the two symbols nearer of farther away by twiddling \texttt{bipoles/vsourceam/margin} (default \texttt{0.7}, less means nearer).
@@ -3436,7 +3436,7 @@ If you want different symbols for input and output you can use a null symbol and
 \end{circuitikz}
 \end{LTXexample}
 
-The amplifier label (given as the text  of the node) is normally more or less centered in the shape (in the case of the triangular shape, it is shifted a bit to the left to \emph{seem} visually centered); since version \texttt{1.0.3} you can move it at the left side plus a fixed offset setting the key \texttt{component text} or the style with the same name to \texttt{left}; by default the key is \texttt{center}.
+The amplifier label (given as the text  of the node) is normally more or less centered in the shape (in the case of the triangular shape, it is shifted a bit to the left to \emph{seem} visually centered); since version \texttt{1.1.0} you can move it at the left side plus a fixed offset setting the key \texttt{component text} or the style with the same name to \texttt{left}; by default the key is \texttt{center}.
 You can change the offset with the key \texttt{left text distance} (default \texttt{0.3em}; you must use a length here).
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
@@ -3871,7 +3871,7 @@ There is no ``european''  version of the following symbols (but you can probably
 
 \subsubsection{IEEE logic gates}\label{sec:ieeestdports}
 
-In addition to the legacy ports, since release 1.0.3, logic ports following the recommended geometry of distinctive-shape symbols in IEEE Std 91a-1991 Annex A (Recommended symbol proportions) are also available\footnote{Thanks to Jason for proposing it and digging out the info, see this \href{https://github.com/circuitikz/circuitikz/issues/383}{GitHub issue}.}.
+In addition to the legacy ports, since release 1.1.0, logic ports following the recommended geometry of distinctive-shape symbols in IEEE Std 91a-1991 Annex A (Recommended symbol proportions) are also available\footnote{Thanks to Jason for proposing it and digging out the info, see this \href{https://github.com/circuitikz/circuitikz/issues/383}{GitHub issue}.}.
 
 These ports are completely independent from the legacy set (either \texttt{american} or \texttt{european}); they are not eanbled by default because the relative size of the ports is very different from the legacy ones, and that will disrupt every schematic (especially if drawn with absolute coordinate). If you want to use them as default, you can use the command \verb|\ctikzset{logic ports=ieee}| and by default the shapes \texttt{and port}, \texttt{or port} and so on will be the IEEE standard ones.
 
@@ -3909,7 +3909,7 @@ If (default behaviour) \texttt{americanports} option is active (or the style \te
 
 If otherwise \texttt{europeanports} option is active (or the style \texttt{[european ports]} is used), the shorthands \texttt{and port}, \texttt{or port}, \texttt{not port}, \texttt{nand port}, \texttt{not port}, \texttt{xor port}, and \texttt{xnor port} are equivalent to the european version of the respective logic port.
 
-Finally, for version \texttt{1.0.3} and up, you can use the style \texttt{ieee ports} to set the shorthands to the set of \texttt{ieeestd} ports. (There is no global option for this).
+Finally, for version \texttt{1.1.0} and up, you can use the style \texttt{ieee ports} to set the shorthands to the set of \texttt{ieeestd} ports. (There is no global option for this).
 \end{framed}
 
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.0.3-unreleased}
-\def\pgfcircversiondate{2020/03/25}
+\def\pgfcircversion{1.1.0}
+\def\pgfcircversiondate{2020/04/19}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.0.3-unreleased}
-\def\pgfcircversiondate{2020/03/25}
+\def\pgfcircversion{1.1.0}
+\def\pgfcircversiondate{2020/04/19}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Version 1.1.0 (2020-04-19)

Version bumped to 1.1 because the new logic ports are quite a big
addition: now there is a new style for logic ports, conforming to IEEE
recommendations.
Several minor additions all over the map too.

- added IEEE standard logic ports suggested by user Jason-s on GitHub
- added configurability to european logic port "not" output symbol,
suggested by j-hap on GitHub
- added `inerter` component by user Tadashi on GitHub
- added variable outer base height for IGBT, suggested by user RA-EE on
GitHub
- added configurable "+" and "-" signs on american-style voltage
generators
- text on amplifiers can be positioned to the left or centered