### PR TITLE
Version 1.1.1 (2020-04-24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.1.1 (2020-04-24)
+
+    One-line bugfix release for the IEEE ports "not" circle thickness
+
 * Version 1.1.0 (2020-04-19)
 
     Version bumped to 1.1 because the new logic ports are quite a big addition: now there is a new style for logic ports, conforming to IEEE recommendations.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.1.0}
-\def\pgfcircversiondate{2020/04/19}
+\def\pgfcircversion{1.1.1}
+\def\pgfcircversiondate{2020/04/24}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.1.0}
-\def\pgfcircversiondate{2020/04/19}
+\def\pgfcircversion{1.1.1}
+\def\pgfcircversiondate{2020/04/24}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
One-line bugfix release for the IEEE ports "not" circle thickness