### PR TITLE
Powerelectronics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The major changes among the different circuitikz versions are listed here. See <
 * Version 1.1.2 (unreleased)
 
     - bumped version number
+    - Blocks and component for three-phase networks (3-lines wire, AC/DC and DC/AC converters blocks and grid node block) added by user `@olfline` on GitHub
 
 * Version 1.1.1 (2020-04-24)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2049,12 +2049,14 @@ This are simple drawings to indicate multiple wires.
 \begin{groupdesc}
 \circuitdescbip{multiwire}{Single line multiple wires}{multiwire}
 \circuitdescbip{bmultiwire}{Double line multiple wires}{bmultiwire}
+\circuitdescbip{tmultiwire}{Triple line multiple wires}{tmultiwire}
 \end{groupdesc}
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
     \draw (0,0) to[multiwire=4] ++(1,0);
     \draw (0,-2) to[bmultiwire=6] ++(1,0);
+    \draw (0,-4) to[tmultiwire=3] ++(1,0);
 \end{circuitikz}
 \end{LTXexample}
 
@@ -2209,6 +2211,7 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
     \circuitdesc*{oscillator}{oscillator}{}
     \circuitdesc*{circulator}{circulator}{}
     \circuitdesc*{wilkinson}{wilkinson divider}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
+    \circuitdesc*{gridnode}{gridnode}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
 \end{groupdesc}
 
 \begin{groupdesc}
@@ -2232,6 +2235,10 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
     \circuitdescbip*{phaseshifter}{phase shifter}{}
     \circuitdescbip*{vphaseshifter}{var.\ phase shifter}{}
     \circuitdescbip*{detector}{detector}{}
+    \circuitdescbip*{sacdc}{sacdc}{}
+    \circuitdescbip*{sdcac}{sdcac}{}
+    \circuitdescbip*{tacdc}{tacdc}{}
+    \circuitdescbip*{tdcac}{tdcac}{}(left/170/0.5, right/5/0.5, center/-90/0.3, ac1/45/0.1, ac2/-5/.3, ac3/-45/.1, dc1/135/.3, dc2/185/.3)
 \end{groupdesc}
 
 \begin{groupdesc}
@@ -6753,6 +6760,21 @@ The best way of contributing is forking the project, adding your component in th
 \end{document}
 	\end{lstlisting}
 \end{tabular}
+
+\begin{LTXexample}[varwidth=true,pos=t]
+\begin{circuitikz}[smallR/.style={european resistor, resistors/scale=0.5}]
+    \draw (0,0) node[tacdcshape, anchor=ac2](acdc){} to[smallR] ++(-2,0) -- node[circ](point){} ++(-1,0);
+    \draw (acdc.ac1) to[nos, invert, mirror, name=switch,color=red] ++(-2,0) -- (point);
+    \draw (acdc.ac3) to[smallR] ++(-2,0)
+        -- (point) 
+        to[tmultiwire] ++(-1,0) 
+        node[gridnode, anchor=right]{}; 
+    \node[above=.3cm,color=red] at (switch) {fault};
+    \draw (acdc.dc1) to[smallR,l=HVDC line] ++(2,0) node[tdcacshape, anchor=dc1](dcac){};
+    \draw (acdc.dc2) -- (dcac.dc2);
+    \draw (dcac.right) to[tmultiwire] ++(2,0) node[gridnode,anchor=left]{};
+\end{circuitikz}
+\end{LTXexample}
 
 % % changelog.tex will be updated by makefile from CHANGELOG.md
 \section{Changelog and Release Notes}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2049,7 +2049,8 @@ This are simple drawings to indicate multiple wires.
 \begin{groupdesc}
 \circuitdescbip{multiwire}{Single line multiple wires}{multiwire}
 \circuitdescbip{bmultiwire}{Double line multiple wires}{bmultiwire}
-\circuitdescbip{tmultiwire}{Triple line multiple wires}{tmultiwire}
+\circuitdescbip{tmultiwire}{Triple line multiple wires\footnotemark}{tmultiwire}
+\footnotetext{added by \texttt{olfline}}
 \end{groupdesc}
 
 \begin{LTXexample}[varwidth=true]
@@ -2211,7 +2212,8 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
     \circuitdesc*{oscillator}{oscillator}{}
     \circuitdesc*{circulator}{circulator}{}
     \circuitdesc*{wilkinson}{wilkinson divider}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
-    \circuitdesc*{gridnode}{gridnode}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
+    \circuitdesc*{gridnode}{gridnode\footnotemark}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
+    \footnotetext{added by \texttt{olfline}}
 \end{groupdesc}
 
 \begin{groupdesc}
@@ -2238,7 +2240,8 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
     \circuitdescbip*{sacdc}{sacdc}{}
     \circuitdescbip*{sdcac}{sdcac}{}
     \circuitdescbip*{tacdc}{tacdc}{}
-    \circuitdescbip*{tdcac}{tdcac}{}(left/170/0.5, right/5/0.5, center/-90/0.3, ac1/45/0.1, ac2/-5/.3, ac3/-45/.1, dc1/135/.3, dc2/185/.3)
+    \circuitdescbip*{tdcac}{tdcac\footnotemark}{}(left/170/0.5, right/5/0.5, center/-90/0.3, ac1/45/0.1, ac2/-5/.3, ac3/-45/.1, dc1/135/.3, dc2/185/.3)
+    \footnotetext{the 4 converter blocks added by \texttt{olfline}}
 \end{groupdesc}
 
 \begin{groupdesc}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -2022,4 +2022,11 @@
 \pgfkeys{/tikz/fullcathode/.add code={}{\pgf@circuit@tubes@fullcathodetrue}}
 \ctikzset{tubes/fullcathode/.add code={}{\pgf@circuit@tubes@fullcathodetrue}}
 
+% powerelectronic blocks
+\ctikzset{bipoles/sacdc/width/.initial=.7}
+\ctikzset{bipoles/sdcac/width/.initial=.7}
+\ctikzset{bipoles/tacdc/width/.initial=.7}
+\ctikzset{bipoles/tdcac/width/.initial=.7}
+\ctikzset{quadpoles/gridnode/width/.initial=.7} %not sure if quadpole?
+
 \endinput

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -255,7 +255,7 @@
 {bmultiwire}
 {\ctikzvalof{bipoles/multiwire/height}}
 {\ctikzvalof{bipoles/multiwire/width}}
-{
+{blocks
     \pgf@circ@res@other=\ctikzvalof{bipoles/multiwire/spacing}\pgf@circ@Rlen
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@up}}
@@ -4732,6 +4732,376 @@
     \fi
 
 }
+
+%% single phase ac/dc converter
+\pgfcircdeclarebipolescaled{blocks}
+{
+    \anchor{dc1}{
+        \northeast
+        \pgf@y=.4\pgf@y
+    }
+    \anchor{dc2}{
+        \northeast
+        \pgf@y=-.4\pgf@y
+    }
+}
+{\ctikzvalof{bipoles/sacdc/width}}
+{sacdc}
+{\ctikzvalof{bipoles/sacdc/width}}
+{\ctikzvalof{bipoles/sacdc/width}}
+{
+    \pgf@circ@res@step = \ctikzvalof{bipoles/sacdc/width}\pgf@circ@scaled@Rlen
+    \divide \pgf@circ@res@step by 2
+
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+    \pgf@circ@res@other = \pgf@circ@res@left
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+
+    \ifpgf@circuit@dashed
+        \pgfsetdash{{0.1cm}{0.1cm}}{0cm}
+    \fi
+
+    % draw outer box
+    \pgf@circ@twoportbox
+
+    \ifpgf@circuit@inputarrow
+        {
+            \advance \pgf@circ@res@left by -.5\ctikzvalof{bipoles/thickness}\pgfstartlinewidth
+            \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+            \pgfnode{inputarrow}{tip}{}{pgf@inputarrow}{\pgfusepath{fill}}
+        }
+    \fi
+
+    % rotate inner symbol
+    \def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+    \ifnum \pgfcircmathresult > 45 \ifnum \pgfcircmathresult < 135
+        \pgftransformrotate{270}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 134 \ifnum \pgfcircmathresult < 225  % 134 degree, because >= 135 is not possible
+        \pgftransformrotate{180}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 225 \ifnum \pgfcircmathresult < 315
+        \pgftransformrotate{90}
+    \fi\fi
+
+    % draw inner symbol
+    \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+    \pgfsetarrows{-} %never draw arrows
+    \pgfsetlinewidth{\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+    \pgfusepath{draw}
+    
+    % draw sin wave
+    \pgfpathmoveto{\pgfpoint{-.76\pgf@circ@res@step}{.5\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    
+    % draw equal sign
+    \pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@step}{-.375\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0.7\pgf@circ@res@step}{-0.375\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@step}{-.625\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0.7\pgf@circ@res@step}{-0.625\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+
+
+
+%% single phase dc/ac converter
+\pgfcircdeclarebipolescaled{blocks}
+{
+    \anchor{dc1}{
+        \northeast
+        \pgf@y=.4\pgf@y
+        \pgf@x=-\pgf@x
+    }
+    \anchor{dc2}{
+        \northeast
+        \pgf@y=-.4\pgf@y
+        \pgf@x=-\pgf@x
+    }
+}
+{\ctikzvalof{bipoles/sdcac/width}}
+{sdcac}
+{\ctikzvalof{bipoles/sdcac/width}}
+{\ctikzvalof{bipoles/sdcac/width}}
+{
+    \pgf@circ@res@step = \ctikzvalof{bipoles/sdcac/width}\pgf@circ@scaled@Rlen
+    \divide \pgf@circ@res@step by 2
+
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+    \pgf@circ@res@other = \pgf@circ@res@left
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+
+    \ifpgf@circuit@dashed
+        \pgfsetdash{{0.1cm}{0.1cm}}{0cm}
+    \fi
+
+    % draw outer box
+    \pgf@circ@twoportbox
+
+    \ifpgf@circuit@inputarrow
+        {
+            \advance \pgf@circ@res@left by -.5\ctikzvalof{bipoles/thickness}\pgfstartlinewidth
+            \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+            \pgfnode{inputarrow}{tip}{}{pgf@inputarrow}{\pgfusepath{fill}}
+        }
+    \fi
+
+    % rotate inner symbol
+    \def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+    \ifnum \pgfcircmathresult > 45 \ifnum \pgfcircmathresult < 135
+        \pgftransformrotate{270}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 134 \ifnum \pgfcircmathresult < 225  % 134 degree, because >= 135 is not possible
+        \pgftransformrotate{180}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 225 \ifnum \pgfcircmathresult < 315
+        \pgftransformrotate{90}
+    \fi\fi
+
+    % draw inner symbol
+    \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+    \pgfsetarrows{-} %never draw arrows
+    \pgfsetlinewidth{\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+    \pgfusepath{draw}
+    
+    % draw sin wave
+    \pgfpathmoveto{\pgfpoint{.14\pgf@circ@res@step}{-.5\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    
+    % draw equal sign
+    \pgfpathmoveto{\pgfpoint{-.2\pgf@circ@res@step}{.375\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.7\pgf@circ@res@step}{0.375\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{-.2\pgf@circ@res@step}{.625\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.7\pgf@circ@res@step}{0.625\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+
+
+%% threephase ac/dc converter
+\pgfcircdeclarebipolescaled{blocks}
+{
+    \anchor{dc1}{
+        \northeast
+        \pgf@y=.4\pgf@y
+    }
+    \anchor{dc2}{
+        \northeast
+        \pgf@y=-.4\pgf@y
+    }
+    \anchor{ac1}{
+        \northeast
+        \pgf@y=.6\pgf@y
+        \pgf@x=-\pgf@x
+    }
+    \anchor{ac2}{
+        \northeast
+        \pgf@y=0\pgf@y
+        \pgf@x=-\pgf@x
+    }
+    \anchor{ac3}{
+        \northeast
+        \pgf@y=-.6\pgf@y
+        \pgf@x=-\pgf@x
+    }
+}
+{\ctikzvalof{bipoles/tacdc/width}}
+{tacdc}
+{\ctikzvalof{bipoles/tacdc/width}}
+{\ctikzvalof{bipoles/tacdc/width}}
+{
+    \pgf@circ@res@step = \ctikzvalof{bipoles/tacdc/width}\pgf@circ@scaled@Rlen
+    \divide \pgf@circ@res@step by 2
+
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+    \pgf@circ@res@other = \pgf@circ@res@left
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+
+    \ifpgf@circuit@dashed
+        \pgfsetdash{{0.1cm}{0.1cm}}{0cm}
+    \fi
+
+    % draw outer box
+    \pgf@circ@twoportbox
+
+    \ifpgf@circuit@inputarrow
+        {
+            \advance \pgf@circ@res@left by -.5\ctikzvalof{bipoles/thickness}\pgfstartlinewidth
+            \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+            \pgfnode{inputarrow}{tip}{}{pgf@inputarrow}{\pgfusepath{fill}}
+        }
+    \fi
+
+    % rotate inner symbol
+    \def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+    \ifnum \pgfcircmathresult > 45 \ifnum \pgfcircmathresult < 135
+        \pgftransformrotate{270}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 134 \ifnum \pgfcircmathresult < 225  % 134 degree, because >= 135 is not possible
+        \pgftransformrotate{180}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 225 \ifnum \pgfcircmathresult < 315
+        \pgftransformrotate{90}
+    \fi\fi
+
+    % draw inner symbol
+    \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+    \pgfsetarrows{-} %never draw arrows
+    \pgfsetlinewidth{\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+    \pgfusepath{draw}
+    
+    % draw sin waves
+    \pgfpathmoveto{\pgfpoint{-.76\pgf@circ@res@step}{.65\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{-.76\pgf@circ@res@step}{.5\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{-.76\pgf@circ@res@step}{.35\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    
+    
+    
+    
+    % draw equal sign
+    \pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@step}{-.375\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0.7\pgf@circ@res@step}{-0.375\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{.2\pgf@circ@res@step}{-.625\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0.7\pgf@circ@res@step}{-0.625\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+
+
+%% threephase dc/ac converter
+\pgfcircdeclarebipolescaled{blocks}
+{
+    \anchor{dc1}{
+        \northeast
+        \pgf@y=.4\pgf@y
+        \pgf@x=-\pgf@x
+    }
+    \anchor{dc2}{
+        \northeast
+        \pgf@y=-.4\pgf@y
+        \pgf@x=-\pgf@x
+    }
+    \anchor{ac1}{
+        \northeast
+        \pgf@y=.6\pgf@y
+    }
+    \anchor{ac2}{
+        \northeast
+        \pgf@y=0\pgf@y
+    }
+    \anchor{ac3}{
+        \northeast
+        \pgf@y=-.6\pgf@y
+    }
+}
+{\ctikzvalof{bipoles/tdcac/width}}
+{tdcac}
+{\ctikzvalof{bipoles/tdcac/width}}
+{\ctikzvalof{bipoles/tdcac/width}}
+{
+    \pgf@circ@res@step = \ctikzvalof{bipoles/tdcac/width}\pgf@circ@scaled@Rlen
+    \divide \pgf@circ@res@step by 2
+
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+    \pgf@circ@res@other = \pgf@circ@res@left
+    \advance\pgf@circ@res@other by \pgf@circ@res@step
+
+    \ifpgf@circuit@dashed
+        \pgfsetdash{{0.1cm}{0.1cm}}{0cm}
+    \fi
+
+    % draw outer box
+    \pgf@circ@twoportbox
+
+    \ifpgf@circuit@inputarrow
+        {
+            \advance \pgf@circ@res@left by -.5\ctikzvalof{bipoles/thickness}\pgfstartlinewidth
+            \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+            \pgfnode{inputarrow}{tip}{}{pgf@inputarrow}{\pgfusepath{fill}}
+        }
+    \fi
+
+    % rotate inner symbol
+    \def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+    \ifnum \pgfcircmathresult > 45 \ifnum \pgfcircmathresult < 135
+        \pgftransformrotate{270}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 134 \ifnum \pgfcircmathresult < 225  % 134 degree, because >= 135 is not possible
+        \pgftransformrotate{180}
+    \fi\fi
+    \ifnum \pgfcircmathresult > 225 \ifnum \pgfcircmathresult < 315
+        \pgftransformrotate{90}
+    \fi\fi
+
+    % draw inner symbol
+    \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+    \pgfsetarrows{-} %never draw arrows
+    \pgfsetlinewidth{\pgfstartlinewidth}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+    \pgfusepath{draw}
+    
+    % draw sin waves
+    \pgfpathmoveto{\pgfpoint{.14\pgf@circ@res@step}{-.65\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{.14\pgf@circ@res@step}{-.5\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{.14\pgf@circ@res@step}{-.35\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathsine{\pgfpoint{.17\pgf@circ@res@step}{-.17\pgf@circ@res@step}}
+    \pgfpathcosine{\pgfpoint{.17\pgf@circ@res@step}{.17\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    
+    
+    
+    
+    % draw equal sign
+    \pgfpathmoveto{\pgfpoint{-.2\pgf@circ@res@step}{.375\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.7\pgf@circ@res@step}{0.375\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgfpathmoveto{\pgfpoint{-.2\pgf@circ@res@step}{.625\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.7\pgf@circ@res@step}{0.625\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%
 %% MECHANICAL SYMBOLS

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -265,6 +265,28 @@
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
     \pgfusepath{draw}
 }
+
+\pgfcircdeclarebipole
+{}
+{\ctikzvalof{bipoles/multiwire/height}}
+{tmultiwire}
+{\ctikzvalof{bipoles/multiwire/height}}
+{\ctikzvalof{bipoles/multiwire/width}}
+{
+    \pgf@circ@res@other=\ctikzvalof{bipoles/multiwire/spacing}\pgf@circ@Rlen
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@up}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left+\pgf@circ@res@other}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left+2\pgf@circ@res@other}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{2\pgf@circ@res@other}{\pgf@circ@res@up}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+    \pgfusepath{draw}
+}
+
+%
+%
 %% Generic bipole - used as resistor by some (bleah)
 \pgfcircdeclarebipolescaled{resistors}
 {}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -255,7 +255,7 @@
 {bmultiwire}
 {\ctikzvalof{bipoles/multiwire/height}}
 {\ctikzvalof{bipoles/multiwire/width}}
-{blocks
+{
     \pgf@circ@res@other=\ctikzvalof{bipoles/multiwire/spacing}\pgf@circ@Rlen
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@up}}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -360,6 +360,11 @@
 \def\pgf@circ@phaseshifter@path#1{\pgf@circ@bipole@path{phaseshifter}{#1}}
 \def\pgf@circ@vphaseshifter@path#1{\pgf@circ@bipole@path{vphaseshifter}{#1}}
 \def\pgf@circ@detector@path#1{\pgf@circ@bipole@path{detector}{#1}}
+%
+\def\pgf@circ@sacdc@path#1{\pgf@circ@bipole@path{sacdc}{#1}}
+\def\pgf@circ@sdcac@path#1{\pgf@circ@bipole@path{sdcac}{#1}}
+\def\pgf@circ@tacdc@path#1{\pgf@circ@bipole@path{tacdc}{#1}}
+\def\pgf@circ@tdcac@path#1{\pgf@circ@bipole@path{tdcac}{#1}}
 
 %%Mechanical
 \def\pgf@circ@spring@path#1{\pgf@circ@bipole@path{spring}{#1}}
@@ -484,6 +489,11 @@
 \compattikzset{phaseshifter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@phaseshifter@path}}
 \compattikzset{vphaseshifter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@vphaseshifter@path}}
 \compattikzset{detector/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@detector@path}}
+%
+\compattikzset{sacdc/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@sacdc@path, l=#1}}
+\compattikzset{sdcac/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@sdcac@path, l=#1}}
+\compattikzset{tacdc/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@tacdc@path, l=#1}}
+\compattikzset{tdcac/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@tdcac@path, l=#1}}
 
 % % % % % %
 % % Begin of Diodes

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -823,6 +823,9 @@
 \def\pgf@circ@multiwire@path#1{\pgf@circ@bipole@path{multiwire}{#1}}
 \compattikzset{multiwire/.style = {\circuitikzbasekey,
 /tikz/to path=\pgf@circ@multiwire@path, l=#1}}
+\def\pgf@circ@tmultiwire@path#1{\pgf@circ@bipole@path{tmultiwire}{#1}}
+\compattikzset{tmultiwire/.style = {\circuitikzbasekey,
+/tikz/to path=\pgf@circ@tmultiwire@path, l=#1}}
 
 % reed switches
 \def\pgf@circ@reed@path#1{\pgf@circ@bipole@path{reed}{#1}}

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -839,8 +839,145 @@
 
             \endpgfscope
         }
+}
+
+%% gridnode
+\pgfdeclareshape{gridnode}
+{
+    \savedmacro{\ctikzclass}{\edef\ctikzclass{blocks}}
+    \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}}
+    \savedanchor\northwest{
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+            \pgf@y=\ctikzvalof{quadpoles/gridnode/width}\pgf@circ@scaled@Rlen
+            \pgf@y=.5\pgf@y
+            \pgf@x=-\ctikzvalof{quadpoles/gridnode/width}\pgf@circ@scaled@Rlen
+            \pgf@x=.5\pgf@x
+    }
+    \anchor{center}{
+        \pgfpointorigin
     }
 
+    \anchor{north}{
+        \northwest
+        \pgf@x=0pt
+    }
+    \anchor{up}{
+        \northwest
+        \pgf@x=0pt
+    }
+    \anchor{south}{
+        \northwest
+        \pgf@x=0pt
+        \pgf@y=-\pgf@y
+    }
+    \anchor{down}{
+        \northwest
+        \pgf@x=0pt
+        \pgf@y=-\pgf@y
+    }
+    \anchor{east}{
+        \northwest
+        \pgf@y=0pt
+        \pgf@x=-\pgf@x
+    }
+    \anchor{right}{
+        \northwest
+        \pgf@y=0pt
+        \pgf@x=-\pgf@x
+    }
+    \anchor{west}{
+        \northwest
+        \pgf@y=0pt
+    }    
+    \anchor{left}{
+        \northwest
+        \pgf@y=0pt
+    }
+    \anchor{south west}{ 
+        \northwest 
+        \pgf@y=-\pgf@y
+    }
+    \anchor{north east}{
+        \northwest 
+        \pgf@x=-\pgf@x
+        \relax
+    }
+    \anchor{north west}{ 
+        \northwest 
+    }
+    \anchor{south east}{ 
+        \northwest 
+        \pgf@x=-\pgf@x
+        \pgf@y=-\pgf@y
+    }
+    \anchor{text}{
+        \pgf@x=-2\pgf@x
+        \advance \pgf@x by -.5\wd\pgfnodeparttextbox
+        \advance \pgf@y by -1.5\ht\pgfnodeparttextbox
+    }
+    \backgroundpath{
+        \pgfsetcolor{\ctikzvalof{color}}
+        \pgf@circ@scaled@Rlen=\scaledRlen
+
+        \pgf@circ@res@step=\ctikzvalof{quadpoles/gridnode/width}\pgf@circ@scaled@Rlen
+    
+        \northwest
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@right = -\pgf@x
+        \pgf@circ@res@left = \pgf@x
+        
+        \pgf@circ@res@step = \ctikzvalof{quadpoles/gridnode/width}\pgf@circ@scaled@Rlen
+        \divide \pgf@circ@res@step by 2
+
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
+        \pgf@circ@res@other = \pgf@circ@res@left
+        \advance\pgf@circ@res@other by \pgf@circ@res@step
+
+        \ifpgf@circuit@dashed
+            \pgfsetdash{{0.1cm}{0.1cm}}{0cm}
+        \fi
+
+        % draw outer box
+        \pgf@circ@twoportbox
+        
+        
+        \ifpgf@circuit@inputarrow
+            {
+                \advance \pgf@circ@res@left by -.5\ctikzvalof{bipoles/thickness}\pgfstartlinewidth
+                \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
+                \pgfnode{inputarrow}{tip}{}{pgf@inputarrow}{\pgfusepath{fill}}
+            }
+        \fi
+    
+        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        \pgfsetarrows{-} %never draw arrows
+        \pgfsetlinewidth{0.05mm}
+        
+        % draw grid
+        \foreach \line in {-1,-.5,...,1}
+        {
+            
+            \pgfpathmoveto{\pgfpoint{\line\pgf@circ@res@right}{\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\line\pgf@circ@res@up}}
+%             \pgfusepath{draw}
+            
+            \pgfpathmoveto{\pgfpoint{\line\pgf@circ@res@right}{\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\line\pgf@circ@res@down}}
+%             \pgfusepath{draw}
+            
+            \pgfpathmoveto{\pgfpoint{\line\pgf@circ@res@right}{\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\line\pgf@circ@res@up}}
+%             \pgfusepath{draw}
+            
+            \pgfpathmoveto{\pgfpoint{\line\pgf@circ@res@right}{\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\line\pgf@circ@res@down}}
+            \pgfusepath{draw}
+
+        }
+    }
+}
+    
 
 % Wilkinson divider
 \pgfdeclareshape{wilkinson}{


### PR DESCRIPTION
Added some blocks, which are useful for threephase networks:
 - three line wire
 - AC/DC converter (single phase and threephase)
 - DC/AC converter (single phase and threephase)
 - grid node

Regarding the manual:
 - the three line wire was added to the multiwire section
 - the blocks were added to the blocks section
 - An example for the blocks in action at the example section

thanks to the creators for the easy reusable shapes!!