### PR TITLE
Prepare for release-1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.1.2 (unreleased)
+* Version 1.1.2 (2020-05-17)
 
-    - bumped version number
     - Blocks and component for three-phase networks (3-lines wire, AC/DC and DC/AC converters blocks and grid node block) added by user `@olfline` on GitHub
     - added transformer sources with optional vector groups for three-phase networks by `@olfline` on Github
     - added subsections to the examples
-    - fixed position of american voltages on open circuitos (suggested by user `@rhandley` on GitHub)
+    - fixed position of american voltages on open circuits (suggested by user `@rhandley` on GitHub)
 
 * Version 1.1.1 (2020-04-24)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3460,7 +3460,7 @@ If you want different symbols for input and output you can use a null symbol and
 \end{LTXexample}
 
 The amplifier label (given as the text  of the node) is normally more or less centered in the shape (in the case of the triangular shape, it is shifted a bit to the left to \emph{seem} visually centered); since version \texttt{1.1.0} you can move it at the left side plus a fixed offset setting the key \texttt{component text} or the style with the same name to \texttt{left}; by default the key is \texttt{center}.
-You can change the offset with the key \texttt{left text distance} (default \texttt{0.3em}; you must use a length here).
+You can change the offset with the key \texttt{left text distance} (default \texttt{0.3em}; you must use a length here). These parameters are shared with IEEE-style logic ports.
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
 \begin{circuitikz}[]
@@ -4241,7 +4241,7 @@ You can use the additional elements (the \texttt{notcirc} and the \texttt{schmit
 \end{circuitikz}
 \end{LTXexample}
 
-Notice the key \texttt{component text=left} that moves the label near to the left border of the component. There is also a \verb|\ctikzset{component text=left}| if you prefer to have it as a default for all the IEEE ports.\footnote{There is a plan to extend this to other components, too.}
+Notice the key \texttt{component text=left} that moves the label near to the left border of the component. There is also a \verb|\ctikzset{component text=left}| if you prefer to have it as a default for all the IEEE ports.\footnote{You can use the same key with amplifiers, too.}
 
 
 \paragraph{Stacking and aligning IEEE standard gates.} The standard gates are designed so that they stacks up nicely when positioned using the external leads as anchors. Notice that the ports \textbf{do} have different sizes, but the leads lengths are designed to counter the differences.
@@ -4375,7 +4375,8 @@ Most of the anchors can be seen in the following diagram:
     }
 \end{circuitikz}
 
-The inputs anchor are \texttt{in \emph{number}} (on the tip of the lead) and   \texttt{bin \emph{number}} (\textbf{b}order  \textbf{in}puts) on the component's border (useful if you draw the ports with \texttt{no inut leads}. Additionally, you have \texttt{ibin \emph{number}} (\textbf{i}nner \textbf{b}order \textbf{in}puts) for the \emph{x}-type ports. The anchor named \texttt{left} is where a central border input would be.
+The inputs anchor are \texttt{in \emph{number}} (on the tip of the lead) and   \texttt{bin \emph{number}} (\textbf{b}order  \textbf{in}puts) on the component's border (useful if you draw the ports with \texttt{no inut leads}).
+Additionally, you have \texttt{ibin \emph{number}} (\textbf{i}nner \textbf{b}order \textbf{in}puts) for the \emph{x}-type ports. The anchor named \texttt{left} is where a central border input would be.
 
 In one-input ports (\texttt{not port}, the buffer, and Schmitt-type ports) you can use plain \texttt{in} or \texttt{in 1} indifferently.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.1.2-unreleased}
-\def\pgfcircversiondate{2020/04/25}
+\def\pgfcircversion{1.1.2}
+\def\pgfcircversiondate{2020/05/17}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.1.2-unreleased}
-\def\pgfcircversiondate{2020/04/25}
+\def\pgfcircversion{1.1.2}
+\def\pgfcircversiondate{2020/05/17}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Version 1.1.2 (2020-05-17)

- Blocks and component for three-phase networks (3-lines wire, AC/DC and DC/AC converters blocks and grid node block) added by user `@olfline` on GitHub
- added transformer sources with optional vector groups for three-phase networks by `@olfline` on Github
- added subsections to the examples
- fixed position of american voltages on open circuits (suggested by user `@rhandley` on GitHub)

