### PR TITLE
Fixes for the voltage label positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.1.3 (unreleased)
+* Version 1.2.0 (unreleased)
 
-    - Bumped version number
+    In this release, the big change is the rewriting of the voltages output routine. Now all voltage options (american, european, and straight) take into account the shape (square border) of the component. The adjusting parameters are now (at least for passive elements) acting in similar way for all the options, too.
+
+    - Bumped version number to 1.2 (potentially incompatible changes!)
     - New path-style not, buffer, and Schmitt logic ports
     - New tutorial (using the "inline not" component)
+    - Voltage output routine rewrite; now it takes into account the shape of the component also for "american" and "straight" voltages
     - Several fixes in the logic ports: fixed IEEE `invschmitt` name, added symmetry to the three-style shorthands for the ports, and so on
     - Fixed a gross bug in square poles anchor borders
     - Fixed size of not circles in flip-flops (based on logic ports style)
+    - Fixed the order of initial options, to avoid "european" overwriting single options
 
 * Version 1.1.2 (2020-05-17)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -280,6 +280,7 @@ They \texttt{use fpu reciprocal} key seems to have no side effects, but given th
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item After v1.2.0: voltage arrows, symbols and label positions are calculated with a rewritten routine. There should be little change, \emph{unless} you touched internal values\dots
     \item After v1.1.3: during the 1.1.0 --- 1.1.2 version, the inverted Schmitt buffer in IEEE style ports was called \texttt{inv schmitt} (with an additional space). The correct name is \texttt{invschmitt port} (the same as the legacy american port).
     \item After v1.1.2: the position of \texttt{american} voltages for the \texttt{open} bipoles (you can revert to old behavior, see section~\ref{sec:sub-voltage-position}).
     \item After v0.9.7: the position of the text of transistor nodes has changed; see section~\ref{sec:transistors-labels}.
@@ -1862,12 +1863,12 @@ Notice that source and generators are divided in three classes that can be style
 
 \subsubsection{Stationary sources}
 \begin{groupdesc}
-    \circuitdescbip*[vsource]{european voltage source}{Voltage source (european style)}{}
+    \circuitdescbip*[vsource]{european voltage source}{Voltage source (european style)}{vsource}
     \circuitdescbip*[vsourceC]{cute european voltage source}{Voltage source (cute european style)}{vsourceC, ceV}
-    \circuitdescbip*[vsourceAM]{american voltage source}{Voltage source (american style)}{}
-    \circuitdescbip*[isource]{european current source}{Current source (european style)}{}
+    \circuitdescbip*[vsourceAM]{american voltage source}{Voltage source (american style)}{vsourceAM}
+    \circuitdescbip*[isource]{european current source}{Current source (european style)}{isource}
     \circuitdescbip*[isourceC]{cute european current source}{Current source (cute european style)}{isourceC, ceI}
-    \circuitdescbip*[isourceAM]{american current source}{Current source (american style)}{}
+    \circuitdescbip*[isourceAM]{american current source}{Current source (american style)}{isourceAM}
 \end{groupdesc}
 
 \begin{framed}
@@ -1893,12 +1894,12 @@ Similarly, if (default behaviour) \texttt{europeanvoltages} option is active (or
 
 \subsubsection{Controlled sources}
 \begin{groupdesc}
-    \circuitdescbip*[cvsource]{european controlled voltage source}{Controlled voltage source (european style)}{}
+    \circuitdescbip*[cvsource]{european controlled voltage source}{Controlled voltage source (european style)}{cvsource}
     \circuitdescbip*[cvsourceC]{cute european controlled voltage source}{Voltage source (cute european style)}{cvsourceC, cceV}
-    \circuitdescbip*[cvsourceAM]{american controlled voltage source}{Controlled voltage source (american style)}{}
-    \circuitdescbip*[cisource]{european controlled current source}{Controlled current source (european style)}{}
+    \circuitdescbip*[cvsourceAM]{american controlled voltage source}{Controlled voltage source (american style)}{cvsourceAM}
+    \circuitdescbip*[cisource]{european controlled current source}{Controlled current source (european style)}{cisource}
     \circuitdescbip*[cisourceC]{cute european controlled current source}{Current source (cute european style)}{cisourceC, cceI}
-    \circuitdescbip*[cisourceAM]{american controlled current source}{Controlled current source (american style)}{}
+    \circuitdescbip*[cisourceAM]{american controlled current source}{Controlled current source (american style)}{cisourceAM}
     \circuitdescbip*[ecsource]{empty controlled source}{Empty controlled source}{ecsource}
 \end{groupdesc}
 
@@ -5871,7 +5872,7 @@ Use option \texttt{americanvoltage} or set \verb![american voltages]! or use the
 \end{circuitikz}
 \end{LTXexample}
 
-You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \texttt{voltage/shift} (default \texttt{0.0} for the former and \texttt{voltage/american label distance} (the distance of the label form the lines of the symbols, default \texttt{1.1}) for the latter.
+You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \texttt{voltage/shift} (default \texttt{0.0} for the former and \texttt{voltage/american label distance} (the distance of the label form the lines of the symbols, default \texttt{1.4}) for the latter.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american voltages]
@@ -5962,7 +5963,7 @@ This could be especially useful if you define a style, to use like this:
 \tikz \draw (0,0) to[C, i=$\imath$] (2,0);
 \end{LTXexample}
 
-However, you can override the properties \texttt{voltage/distance from node} (how distant from the initial and final points of the path the arrow starts and ends) and \texttt{voltage/bump b} (how high the bump of the arrow is --- how curved it is)\footnote{Prior to 0.9.4 you had also \texttt{voltage/european label distance} (how distant from the bipole the voltage label will be) but this is deprecated, and the european-style label is printed near the bump)} on a per-component basis, in order to fine-tune the voltages:
+However, you can override the properties \texttt{voltage/distance from node} (how distant from the initial and final points of the path the arrow starts and ends, default \texttt{0.5}) and \texttt{voltage/bump b} (how high the bump of the arrow is --- how curved it is, default \texttt{1.5}), and also \texttt{voltage/european label distance} (how distant from the ``bump''  the voltage label will be, default \texttt{1.4}) on a per-component basis, in order to fine-tune the voltages:
 
 
 \begin{LTXexample}[varwidth=true]
@@ -6850,13 +6851,13 @@ If you think they are too tight or too loose you can use a (developer-only) key 
 
 \begin{LTXexample}[varwidth]
 \begin{circuitikz}
-    \ctikzset{bipoles/viscoe/voltage/additional label shift/.initial=1}
+    \ctikzset{bipoles/viscoe/voltage/additional shift/.initial=1}
     \draw (0,0) to[spring] ++(2,0)
     to[viscoe, v=V] ++(2,0);
 \end{circuitikz}
 \end{LTXexample}
 
-Notice that by default the key \texttt{bipoles/\emph{mybipole}/voltage/additional label shift} is not defined, so if you want to use it you must create it before (this is the meaning of the \texttt{.initial} here).
+Notice that by default the key \texttt{bipoles/\emph{mybipole}/voltage/additional shift} is not defined, so if you want to use it you must create it before (this is the meaning of the \texttt{.initial} here).
 
 
 As a final note, notice that the \texttt{viscoe} element is already added to the standard package.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.1.3-unreleased}
-\def\pgfcircversiondate{2020/05/18}
+\def\pgfcircversion{1.2.0-unreleased}
+\def\pgfcircversiondate{2020/06/17}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -29,212 +29,45 @@
 %
 \usetikzlibrary{arrows.meta, bending}
 \usetikzlibrary{fpu} % may be needed for use fpu reciprocal (v1.0.1)
-
-% The options are listed in the manual in this order
-
-\DeclareOption{europeanvoltage}{
-    \ctikzset{voltage=european}
-}
-
-\DeclareOption{straightvoltages}{
-    \pgf@circuit@bipole@voltage@straighttrue
-}
-
-\DeclareOption{americanvoltage}{
-    \ctikzset{voltage=american}
-}
-
-\DeclareOption{europeancurrent}{
-    \ctikzset{current = european}
-}
-
-\DeclareOption{americancurrent}{
-    \ctikzset{current = american}
-}
-
-
-
-\DeclareOption{americanresistor}{
-    \ctikzset{resistor = american}
-}
-
-\DeclareOption{europeanresistor}{
-    \ctikzset{resistor = european}
-}
-
-\DeclareOption{americaninductor}{
-    \ctikzset{inductor = american}
-}
-
-\DeclareOption{europeaninductor}{
-    \ctikzset{inductor = european}
-}
-
-\DeclareOption{cuteinductor}{
-    \ctikzset{inductor = cute}
-}
-
-\DeclareOption{americanport}{
-    \ctikzset{logic ports = american}
-}
-
-\DeclareOption{europeanport}{
-    \ctikzset{logic ports = european}
-}
-
+%
+% global of options (better use styles!)
+%
 \DeclareOption{european}{
     \ctikzset{voltage=european} \ctikzset{current=european} \ctikzset{inductor=european}
     \ctikzset{resistor=european} \ctikzset{logic ports=european} \ctikzset{gas filled surge arrester choice = european}
 }
-
 \DeclareOption{american}{
     \ctikzset{voltage=american} \ctikzset{current=american} \ctikzset{resistor=american} \ctikzset{inductor=american} \ctikzset{gas filled surge arrester choice = american}
     \ctikzset{logic ports = american}
 }
-
-\DeclareOption{fulldiodes}{
-    \ctikzset{diode = full}
-}
-
-\DeclareOption{emptydiodes}{
-    \ctikzset{diode = empty}
-}
-
-\DeclareOption{europeanvoltages}{
-    \ctikzset{voltage=european}
-}
-
-\DeclareOption{americanvoltages}{
-    \ctikzset{voltage=american}
-}
-
-\DeclareOption{europeancurrents}{
-    \ctikzset{current = european}
-}
-
-\DeclareOption{americancurrents}{
-    \ctikzset{current = american}
-}
-
-\DeclareOption{americanresistors}{
-    \ctikzset{resistor = american}
-}
-
-\DeclareOption{europeanresistors}{
-    \ctikzset{resistor = european}
-}
-
-\DeclareOption{americaninductors}{
-    \ctikzset{inductor = american}
-}
-
-\DeclareOption{europeaninductors}{
-    \ctikzset{inductor = european}
-}
-
-\DeclareOption{cuteinductors}{
-    \ctikzset{inductor = cute}
-}
-
-\DeclareOption{americanports}{
-    \ctikzset{logic ports = american}
-}
-
-\DeclareOption{europeanports}{
-    \ctikzset{logic ports = european}
-}
-
-\DeclareOption{americangfsurgearrester}{
-    \ctikzset{gas filled surge arrester choice = american}
-}
-
-\DeclareOption{europeangfsurgearrester}{
-    \ctikzset{gas filled surge arrester choice = european}
-}
-
 \DeclareOption{siunitx}{
     \pgf@circ@siunitxtrue
 }
-
 \DeclareOption{nosiunitx}{
     \pgf@circ@siunitxfalse
 }
-
-\DeclareOption{fulldiode}{
-    \ctikzset{diode = full}
-}
-
-\DeclareOption{emptydiode}{
-    \ctikzset{diode = empty}
-}
-
-\DeclareOption{strokediode}{
-    \ctikzset{diode = stroke}
-}
-
-\DeclareOption{arrowmos}{
-    \pgf@circuit@mos@arrowstrue
-}
-
-\DeclareOption{noarrowmos}{
-    \pgf@circuit@mos@arrowsfalse
-}
-
-\DeclareOption{fetbodydiode}{
-    \pgf@circuit@fet@bodydiodetrue
-}
-
-\DeclareOption{nofetbodydiode}{
-    \pgf@circuit@fet@bodydiodefalse
-}
-
-\DeclareOption{fetsolderdot}{
-    \pgf@circuit@fet@solderdottrue
-}
-
-\DeclareOption{nofetsolderdot}{
-    \pgf@circuit@fet@solderdotfalse
-}
-
-\DeclareOption{emptypmoscircle}{
-    \pgf@circuit@pmos@emptycircletrue
-}
-
-
-\DeclareOption{lazymos}{
-    \ctikzset{tripoles/nmos/width=.5}
-    \ctikzset{tripoles/nmos/gate height=.35}
-    \ctikzset{tripoles/nmos/base height=.35}
-    \ctikzset{tripoles/nmos/height/.initial=1.2}
-    \ctikzset{tripoles/nmos/base width=.5}
-    \ctikzset{tripoles/nmos/gate width=.65}
-
-    \ctikzset{tripoles/pmos/width=.5}
-    \ctikzset{tripoles/pmos/gate height=.35}
-    \ctikzset{tripoles/pmos/base height=.35}
-    \ctikzset{tripoles/pmos/height/.initial=1.2}
-    \ctikzset{tripoles/pmos/base width=.5}
-    \ctikzset{tripoles/pmos/gate width=.65}
-
-    \pgf@circuit@pmos@emptycircletrue
-}
-
-\DeclareOption{straightlabels}{
-    \ctikzset{label/align = straight}
-}
-
-\DeclareOption{rotatelabels}{
-    \ctikzset{label/align = rotate}
-}
-
-\DeclareOption{smartlabels}{
-    \ctikzset{label/align = smart}
-}
-
 \DeclareOption{compatibility}{
     \pgf@circuit@compattrue
 }
-
+%
+% voltages
+%
+\DeclareOption{europeanvoltage}{
+    \ctikzset{voltage=european}
+}
+\DeclareOption{straightvoltages}{
+    \ctikzset{voltage=straight}
+}
+\DeclareOption{americanvoltage}{
+    \ctikzset{voltage=american}
+}
+\DeclareOption{europeanvoltages}{
+    \ctikzset{voltage=european}
+}
+\DeclareOption{americanvoltages}{
+    \ctikzset{voltage=american}
+}
+% Voltage directions
 \DeclareOption{oldvoltagedirection}{
     \pgf@circ@oldvoltagedirectiontrue
     \pgf@circ@explicitvdirtrue
@@ -245,7 +78,6 @@
     \pgf@circ@explicitvdirtrue
     \pgf@circ@fixbatteriesfalse
 }
-
 \DeclareOption{RPvoltages}{
     \pgf@circ@oldvoltagedirectiontrue
     \pgf@circ@explicitvdirtrue
@@ -256,22 +88,170 @@
     \pgf@circ@explicitvdirtrue
     \pgf@circ@fixbatteriestrue
 }
-
+%
+% currents
+%
+\DeclareOption{europeancurrent}{
+    \ctikzset{current = european}
+}
+\DeclareOption{americancurrent}{
+    \ctikzset{current = american}
+}
+\DeclareOption{europeancurrents}{
+    \ctikzset{current = european}
+}
+\DeclareOption{americancurrents}{
+    \ctikzset{current = american}
+}
+%
+% resistors
+%
+\DeclareOption{americanresistor}{
+    \ctikzset{resistor = american}
+}
+\DeclareOption{europeanresistor}{
+    \ctikzset{resistor = european}
+}
+\DeclareOption{americanresistors}{
+    \ctikzset{resistor = american}
+}
+\DeclareOption{europeanresistors}{
+    \ctikzset{resistor = european}
+}
+%
+% inductors
+%
+\DeclareOption{americaninductor}{
+    \ctikzset{inductor = american}
+}
+\DeclareOption{europeaninductor}{
+    \ctikzset{inductor = european}
+}
+\DeclareOption{cuteinductor}{
+    \ctikzset{inductor = cute}
+}
+\DeclareOption{americaninductors}{
+    \ctikzset{inductor = american}
+}
+\DeclareOption{europeaninductors}{
+    \ctikzset{inductor = european}
+}
+\DeclareOption{cuteinductors}{
+    \ctikzset{inductor = cute}
+}
+%
+% logic ports
+%
+\DeclareOption{americanport}{
+    \ctikzset{logic ports = american}
+}
+\DeclareOption{europeanport}{
+    \ctikzset{logic ports = european}
+}
+\DeclareOption{americanports}{
+    \ctikzset{logic ports = american}
+}
+\DeclareOption{europeanports}{
+    \ctikzset{logic ports = european}
+}
+%
+% surge arresters (really?)
+%
+\DeclareOption{americangfsurgearrester}{
+    \ctikzset{gas filled surge arrester choice = american}
+}
+\DeclareOption{europeangfsurgearrester}{
+    \ctikzset{gas filled surge arrester choice = european}
+}
+%
+% diodes
+%
+\DeclareOption{fulldiodes}{
+    \ctikzset{diode = full}
+}
+\DeclareOption{emptydiodes}{
+    \ctikzset{diode = empty}
+}
+\DeclareOption{strokediodes}{
+    \ctikzset{diode = stroke}
+}
+\DeclareOption{fulldiode}{
+    \ctikzset{diode = full}
+}
+\DeclareOption{emptydiode}{
+    \ctikzset{diode = empty}
+}
+\DeclareOption{strokediode}{
+    \ctikzset{diode = stroke}
+}
+%
+% MOSes and FETs
+%
+\DeclareOption{arrowmos}{
+    \pgf@circuit@mos@arrowstrue
+}
+\DeclareOption{noarrowmos}{
+    \pgf@circuit@mos@arrowsfalse
+}
+\DeclareOption{fetbodydiode}{
+    \pgf@circuit@fet@bodydiodetrue
+}
+\DeclareOption{nofetbodydiode}{
+    \pgf@circuit@fet@bodydiodefalse
+}
+\DeclareOption{fetsolderdot}{
+    \pgf@circuit@fet@solderdottrue
+}
+\DeclareOption{nofetsolderdot}{
+    \pgf@circuit@fet@solderdotfalse
+}
+\DeclareOption{emptypmoscircle}{
+    \pgf@circuit@pmos@emptycircletrue
+}
+\DeclareOption{lazymos}{
+    \ctikzset{tripoles/nmos/width=.5}
+    \ctikzset{tripoles/nmos/gate height=.35}
+    \ctikzset{tripoles/nmos/base height=.35}
+    \ctikzset{tripoles/nmos/height/.initial=1.2}
+    \ctikzset{tripoles/nmos/base width=.5}
+    \ctikzset{tripoles/nmos/gate width=.65}
+    \ctikzset{tripoles/pmos/width=.5}
+    \ctikzset{tripoles/pmos/gate height=.35}
+    \ctikzset{tripoles/pmos/base height=.35}
+    \ctikzset{tripoles/pmos/height/.initial=1.2}
+    \ctikzset{tripoles/pmos/base width=.5}
+    \ctikzset{tripoles/pmos/gate width=.65}
+    \pgf@circuit@pmos@emptycircletrue
+}
+%
+% BJTs labels
+%
 \DeclareOption{legacytransistorstext}{
     \pgf@circuit@transisors@fixlabelsfalse
 }
-
 \DeclareOption{nolegacytransistorstext}{
     \pgf@circuit@transisors@fixlabelstrue
 }
-
 \DeclareOption{centertransistorstext}{
     \pgf@circuit@transisors@fixlabelstrue
 }
-
+%
+% labels
+%
+\DeclareOption{straightlabels}{
+    \ctikzset{label/align = straight}
+}
+\DeclareOption{rotatelabels}{
+    \ctikzset{label/align = rotate}
+}
+\DeclareOption{smartlabels}{
+    \ctikzset{label/align = smart}
+}
+%
+% Several options (better use styles)
+%
 \DeclareOption{betterproportions}{
     \ctikzset{monopoles/ground/width/.initial=.15}
-
     \ctikzset{bipoles/resistor/height/.initial=.23}
     \ctikzset{bipoles/resistor/width/.initial=.6}
     \ctikzset{bipoles/capacitor/height/.initial=.4}
@@ -319,20 +299,17 @@
     \ctikzset{bipoles/bidirectionaldiode/width/.initial=.6}
     \ctikzset{bipoles/bidirectionaldiode/diode width left/.initial=.3}
     \ctikzset{bipoles/bidirectionaldiode/diode width right/.initial=.3}
-
     \ctikzset{tripoles/thyristor/height/.initial=.66}
     \ctikzset{tripoles/thyristor/height 2/.initial=.3}
     \ctikzset{tripoles/thyristor/width/.initial=.6}
     \ctikzset{tripoles/thyristor/diode height/.initial=.3}
     \ctikzset{tripoles/thyristor/diode width left/.initial=.4}
     \ctikzset{tripoles/thyristor/diode width right/.initial=.3}
-
     \ctikzset{tripoles/triac/height/.initial=.66}
     \ctikzset{tripoles/triac/width/.initial=.6}
     \ctikzset{tripoles/triac/diode width left/.initial=.3}
     \ctikzset{tripoles/triac/diode width right/.initial=.3}
 }
-
 % This is a nice hack that prints all the shapes declared
 % by the package. Very useful for coverage testing and debugging.
 %
@@ -341,8 +318,8 @@
 %     \typeout{SHAPE:\space"#1"}%
 %     \origpgfdeclareshape{#1}
 % }
-
-
+%
+%
 %%%%%%%%%
 \input pgfcirc.defines.tex
 \input pgfcircutils.tex
@@ -360,7 +337,7 @@
 \input pgfcircflow.tex
 
 % notice that the default is nooldvoltagedirection; it's not explicitly set to allow for the warning
-\ExecuteOptions{nofetbodydiode, nofetsolderdot, europeancurrents, europeanvoltages,americanports, americanresistors, cuteinductors ,europeangfsurgearrester, nosiunitx, noarrowmos, smartlabels}
+\ExecuteOptions{nofetbodydiode, nofetsolderdot, europeancurrents, europeanvoltages, americanports, americanresistors, cuteinductors ,europeangfsurgearrester, nosiunitx, noarrowmos, smartlabels}
 
 \ProcessOptions\relax
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -722,10 +722,8 @@
 \ctikzset{bipoles/open/width/.initial=.3} %necessary for curly voltages
 \ctikzset{bipoles/open/voltage/straight label distance/.initial=0}
 \ctikzset{bipoles/open/voltage/distance from node/.initial=.2}
-\ctikzset{bipoles/short/height/.initial=0} %dummy height for voltage positioning
-\ctikzset{bipoles/short/width/.initial=0} %dummy width for voltage positioning
-%\ctikzset{bipoles/short/voltage/straight label distance/.initial=.2}
-%\ctikzset{bipoles/short/voltage/distance from node/.initial=.5}
+\ctikzset{bipoles/short/height/.initial=.2} %dummy height for voltage positioning
+\ctikzset{bipoles/short/width/.initial=.0} % you can't set a dummy width, the short is not short anymore...
 % multiwire
 \ctikzset{bipoles/multiwire/height/.initial=0.4}
 \ctikzset{bipoles/multiwire/width/.initial=0.2}
@@ -739,20 +737,20 @@
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
 \ctikzset{bipoles/smeter/height/.initial=.60}
 \ctikzset{bipoles/smeter/width/.initial=.60}
-\ctikzset{bipoles/smeter/voltage/additional label shift/.initial=1}
+\ctikzset{bipoles/smeter/voltage/additional shift/.initial=1}
 \ctikzset{bipoles/qmeter/depth/.initial=.40}
 \ctikzset{bipoles/qmeter/height/.initial=.80}
 \ctikzset{bipoles/qmeter/width/.initial=.60}
 % this must be specified for each one
-\ctikzset{bipoles/qvprobe/voltage/additional label shift/.initial=.5}
-\ctikzset{bipoles/qiprobe/voltage/additional label shift/.initial=.5}
-\ctikzset{bipoles/qpprobe/voltage/additional label shift/.initial=.5}
+\ctikzset{bipoles/qvprobe/voltage/additional shift/.initial=.5}
+\ctikzset{bipoles/qiprobe/voltage/additional shift/.initial=.5}
+\ctikzset{bipoles/qpprobe/voltage/additional shift/.initial=.5}
 \ctikzset{bipoles/iloop/width/.initial=.40}
 \ctikzset{bipoles/iloop/height/.initial=.60}
 
 \ctikzset{bipoles/oscope/height/.initial=.60}
 \ctikzset{bipoles/oscope/width/.initial=.60}
-\ctikzset{bipoles/oscope/voltage/additional label shift/.initial=1}
+\ctikzset{bipoles/oscope/voltage/additional shift/.initial=1}
 
 
 % option to not rotate the new (Romano's) instruments
@@ -1889,7 +1887,7 @@
 \ctikzset{voltage/american/.code = {\pgf@circuit@europeanvoltagefalse\pgf@circuit@bipole@voltage@straightfalse}}
 \ctikzset{voltage/european/.code = {\pgf@circuit@europeanvoltagetrue\pgf@circuit@bipole@voltage@straightfalse}}
 \ctikzset{voltage/straight/.code = {\pgf@circuit@europeanvoltagetrue\pgf@circuit@bipole@voltage@straighttrue}}
-\ctikzset{voltage/curved/.code = {\pgf@circuit@europeanvoltagetrue\pgf@circuit@bipole@voltage@straighttrue}}
+\ctikzset{voltage/curved/.code = {\pgf@circuit@europeanvoltagetrue\pgf@circuit@bipole@voltage@straightfalse}}
 
 \ctikzset{current/.is choice}
 \ctikzset{current/american/.code = \pgf@circuit@europeancurrentfalse}
@@ -1900,61 +1898,100 @@
 \ctikzset{straight/true/.code = {\pgf@circuit@bipole@voltage@straighttrue}}
 \ctikzset{straight/false/.code = {\pgf@circuit@bipole@voltage@straightfalse}}
 \ctikzset{bipole/straight/.is if=pgf@circuit@bipole@voltage@straight}
-% never used, removed (RG 2020-05-17)
-% \ctikzset{straightvoltage value/.initial=true}
-% \ctikzset{straightvoltage/.style = {/tikz/circuitikz/straight=true}}
-
 %
 % voltage is used also to set parameters, apart for the /.is choice
 % above. I hope it is ok --- would be a mess otherwise
 %
-
-\ctikzset{voltage/distance from node/.initial=.5} %\pgf@circ@Rlen units
-\ctikzset{voltage/distance from line/.initial=.08} % pos, tra 0 e 1
-\ctikzset{voltage/bump a/.initial=1.2}
-\ctikzset{voltage/bump b/.initial=1.5}
 \ctikzset{voltage/shift/.initial=0.0} % shift form the cable of voltage symbols
 \ctikzset{voltage shift/.style={voltage/shift=#1}}
 \tikzset{voltage shift/.style={\circuitikzbasekey/voltage/shift=#1}}
-\ctikzset{voltage/european label distance/.initial=1.4}
-\ctikzset{voltage/american label distance/.initial=1.1}
+
 % shaping the +/- sign, see pgfcircvoltage.tex
 \ctikzset{voltage/american font/.initial={}}
 \ctikzset{voltage/american plus/.initial={$+$}}
 \ctikzset{voltage/american minus/.initial={$-$}}
-
+% here we start the voltage adjustments for special components.
+% default values:
+%
+% this is the distance of the "point" marking the voltage along the line
+% 0.0 is on the external nodes of the to path
+% 1.0 is cramped on the object
+% this can be overriden component by component
+\ctikzset{voltage/distance from node/.initial=.5}% pos, 0->1
+%
+% this is the distance from the line (perpendicular to) where the voltage is drawn.
+% It is global, and not adjustable by component (use the "label distance" or locally
+% if you need it)
+\ctikzset{voltage/distance from line/.initial=.08}% in \pgf@circ@scaled@Rlen units
+%
+% bend paramenters for european arc. You can override them component-based
+\ctikzset{voltage/bump b/.initial=1.5}
+%
+% generator voltages symbols or arrows (always straight) are put along the
+% 60 ... 120 angles of the symbol (don't ask why). The distance here is on the
+% center..angle line. It's called bump a because I don't know...
+%
+\ctikzset{voltage/bump a/.initial=1.2}
+%
+% these are the label distances FROM the drawings.
+% You can override them component by component.
+\ctikzset{voltage/european label distance/.initial=1.4}
+\ctikzset{voltage/straight label distance/.initial=1.4}
+\ctikzset{voltage/american label distance/.initial=1.4}
+%
+% the KIND is the node name without SHAPE
+% See the definition above for meaning
+% if bipoles/KIND/voltage/straight label distance is not defined, it uses the height
+% if bipoles/KIND/voltage/additional shift is not defined, it is 0 (extra distance)
+%
 % special cases for voltage positions
-\ctikzset{bipoles/generic/voltage/distance from node/.initial=.4}
+\ctikzset{bipoles/generic/voltage/distance from node/.initial=0.4}
 \ctikzset{bipoles/generic/voltage/bump b/.initial=2}
-\ctikzset{bipoles/generic/voltage/european label distance/.initial=1.8}
-%\ctikzset{bipoles/thermocouple/voltage/distance from node/.initial=.3}
-\ctikzset{bipoles/thermocouple/voltage/bump b/.initial=2.2}
-\ctikzset{bipoles/thermocouple/voltage/european label distance/.initial=1.5}
+%
 \ctikzset{bipoles/ageneric/voltage/distance from node/.initial=.4}
 \ctikzset{bipoles/ageneric/voltage/bump b/.initial=2}
-\ctikzset{bipoles/ageneric/voltage/european label distance/.initial=1.8}
+%
 \ctikzset{bipoles/fullgeneric/voltage/distance from node/.initial=.4}
 \ctikzset{bipoles/fullgeneric/voltage/bump b/.initial=2}
-\ctikzset{bipoles/fullgeneric/voltage/european label distance/.initial=1.8}
+%
 \ctikzset{bipoles/memristor/voltage/distance from node/.initial=.4}
 \ctikzset{bipoles/memristor/voltage/bump b/.initial=2}
-\ctikzset{bipoles/memristor/voltage/european label distance/.initial=1.8}
-%\ctikzset{bipoles/tline/voltage/distance from node/.initial=.2}
+%
 \ctikzset{bipoles/tline/voltage/bump b/.initial=2.4}
-\ctikzset{bipoles/tline/voltage/european label distance/.initial=2.1}
-%\ctikzset{bipoles/varistor/voltage/distance from node/.initial=.2}
+%
 \ctikzset{bipoles/varistor/voltage/bump b/.initial=2.4}
-\ctikzset{bipoles/varistor/voltage/european label distance/.initial=2}
-%\ctikzset{bipoles/photoresistor/voltage/distance from node/.initial=.2}
-\ctikzset{bipoles/photoresistor/voltage/bump b/.initial=2}
-\ctikzset{bipoles/photoresistor/voltage/european label distance/.initial=1.8}
-%\ctikzset{bipoles/thermistor/voltage/distance from node/.initial=.2}
+\ctikzset{bipoles/varistor/voltage/american label distance/.initial=1.8}
+%
+\ctikzset{bipoles/photoresistor/voltage/bump b/.initial=1.6}
+%
 \ctikzset{bipoles/thermistor/voltage/bump b/.initial=2.4}
-\ctikzset{bipoles/thermistor/voltage/european label distance/.initial=2}
-%\ctikzset{bipoles/thermistorntc/voltage/distance from node/.initial=.2}
+\ctikzset{bipoles/thermistor/voltage/european label distance/.initial=0.8}
 \ctikzset{bipoles/thermistorntc/voltage/bump b/.initial=1.6}
-%\ctikzset{bipoles/thermistorptc/voltage/distance from node/.initial=.2}
+\ctikzset{bipoles/thermistorntc/voltage/european label distance/.initial=0.8}
 \ctikzset{bipoles/thermistorptc/voltage/bump b/.initial=1.6}
+\ctikzset{bipoles/thermistorptc/voltage/european label distance/.initial=0.8}
+%
+\ctikzset{bipoles/ccapacitor/voltage/bump b/.initial=2.2}
+%
+\ctikzset{bipoles/emptyzzdiode/voltage/bump b/.initial=2.5}
+\ctikzset{bipoles/emptyzzdiode/voltage/european label distance/.initial=1.0}
+\ctikzset{bipoles/fullzzdiode/voltage/bump b/.initial=2.5}
+\ctikzset{bipoles/fullzzdiode/voltage/european label distance/.initial=1.0}
+\ctikzset{bipoles/emptythyristor/voltage/bump b/.initial=2.0}
+\ctikzset{bipoles/emptythyristor/voltage/european label distance/.initial=1.2}
+\ctikzset{bipoles/fullthyristor/voltage/bump b/.initial=2.0}
+\ctikzset{bipoles/fullthyristor/voltage/european label distance/.initial=1.2}
+\ctikzset{bipoles/emptytriac/voltage/bump b/.initial=1.8}
+\ctikzset{bipoles/emptytriac/voltage/european label distance/.initial=0.8}
+\ctikzset{bipoles/fulltriac/voltage/bump b/.initial=1.8}
+\ctikzset{bipoles/fulltriac/voltage/european label distance/.initial=0.8}
+%
+\ctikzset{bipoles/short/voltage/american label distance/.initial=2.8}
+\ctikzset{bipoles/open/voltage/distance from node/.initial=0.3}
+%
+\ctikzset{bipoles/battery/voltage/bump a/.initial=1.4}
+\ctikzset{bipoles/vsourceAM/voltage/american label distance/.initial=1.2}
+\ctikzset{bipoles/cvsourceAM/voltage/american label distance/.initial=1.2}
 %
 % american open voltage adjusting
 %
@@ -1962,7 +1999,6 @@
 \ctikzset{american open voltage/.is choice}
 \ctikzset{american open voltage/center/.code={\pgf@adjust@open@voltagetrue}}
 \ctikzset{american open voltage/legacy/.code={\pgf@adjust@open@voltagefalse}}
-
 %
 % currents
 %

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -438,7 +438,7 @@
 \ctikzset{bipoles/loudspeaker/depth/.initial=.3}
 \ctikzset{bipoles/loudspeaker/width/.initial=.8}
 \ctikzset{bipoles/mic/height/.initial=1.2}
-\ctikzset{bipoles/mic/depth/.initial=.0}
+\ctikzset{bipoles/mic/depth/.initial=.1}
 \ctikzset{bipoles/mic/width/.initial=.8}
 
 % Zig Zag resistors
@@ -722,8 +722,8 @@
 \ctikzset{bipoles/open/width/.initial=.3} %necessary for curly voltages
 \ctikzset{bipoles/open/voltage/straight label distance/.initial=0}
 \ctikzset{bipoles/open/voltage/distance from node/.initial=.2}
-\ctikzset{bipoles/short/height/.initial=.2} %dummy height for voltage positioning
-\ctikzset{bipoles/short/width/.initial=.0} % you can't set a dummy width, the short is not short anymore...
+\ctikzset{bipoles/short/height/.initial=.1} %dummy height for voltage positioning
+\ctikzset{bipoles/short/width/.initial=.1} %dummy width for voltage positioning
 % multiwire
 \ctikzset{bipoles/multiwire/height/.initial=0.4}
 \ctikzset{bipoles/multiwire/width/.initial=0.2}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -170,16 +170,16 @@
         \anchorborder{%
             \ifpgf@circuit@bipole@inverted
                 \pgf@circ@res@left=-\pgf@x
-                \pgf@circ@res@right=-\pgf@y
+                \pgf@circ@res@up=-\pgf@y
             \else
                 \pgf@circ@res@left=\pgf@x
-                \pgf@circ@res@right=\pgf@y
+                \pgf@circ@res@up=\pgf@y
             \fi
-            \ifdim\pgf@circ@res@right>0cm
-                \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@right}}{\northeastborder}
+            \ifdim\pgf@circ@res@up>0cm
+                \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\northeastborder}
             \else
                 \southwestborder
-                \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@right}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
+                \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
             \fi
         }
 
@@ -218,12 +218,34 @@
 %%% NOTICE that the short is really NOT drawn; we trust the fact that its
 %%% natural length is zero.
 \pgfcircdeclarebipole
-{}
+{% fix the anchor border to add a bit of space for voltage and labels
+    % it uses the dummy width and height
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \pgf@x=\ctikzvalof{bipoles/short/width}\pgf@circ@Rlen
+            \pgf@y=\ctikzvalof{bipoles/short/height}\pgf@circ@Rlen
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+            {\pgfpoint{\pgf@x}{\pgf@y}}
+        \else
+            \pgf@x=-\ctikzvalof{bipoles/short/width}\pgf@circ@Rlen
+            \pgf@y=-\ctikzvalof{bipoles/short/height}\pgf@circ@Rlen
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+            {\pgfpoint{-\pgf@x}{-\pgf@y}}
+        \fi
+    }
+}
 {0}
 {short}
 {0}
 {0}
-{ }
+{}
 
 %% Open circuit
 \pgfcircdeclarebipole
@@ -232,7 +254,7 @@
 {open}
 {\ctikzvalof{bipoles/open/height}}
 {\ctikzvalof{bipoles/open/width}}
-{ }
+{}
 
 % multiwire(s)
 \pgfcircdeclarebipole
@@ -2414,7 +2436,24 @@
 
 %% Black alternative zigzag Zener diode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.3\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-1.3\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {fullzzdiode}
 {\ctikzvalof{bipoles/diode/height}}
@@ -2540,7 +2579,24 @@
 }
 %% Black light emitting diode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.8\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {fulllediode}
 {\ctikzvalof{bipoles/diode/height}}
@@ -2565,7 +2621,24 @@
 
 %% Black photodiode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.8\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {fullpdiode}
 {\ctikzvalof{bipoles/diode/height}}
@@ -2671,7 +2744,24 @@
 
 %% Empty alternative zigzag Zener diode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.3\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-1.3\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {emptyzzdiode}
 {\ctikzvalof{bipoles/diode/height}}
@@ -2735,7 +2825,24 @@
 
 %% Empty light emitting diode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.8\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {emptylediode}
 {\ctikzvalof{bipoles/diode/height}}
@@ -2755,7 +2862,24 @@
 
 %% Empty photodiode
 \pgfcircdeclarebipolescaled{diodes}
-{}
+{% fix the anchor border
+    \anchorborder{%
+        \ifpgf@circuit@bipole@inverted
+            \pgf@circ@res@left=-\pgf@x
+            \pgf@circ@res@up=-\pgf@y
+        \else
+            \pgf@circ@res@left=\pgf@x
+            \pgf@circ@res@up=\pgf@y
+        \fi
+        \ifdim\pgf@circ@res@up>0cm
+            \northeastborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@x}{1.8\pgf@y}}
+        \else
+            \southwestborder
+            \pgfpointborderrectangle{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{-\pgf@x}{-\pgf@y}}
+        \fi
+    }
+}
 {\ctikzvalof{bipoles/diode/height}}
 {emptypdiode}
 {\ctikzvalof{bipoles/diode/height}}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -414,7 +414,9 @@
 %% Styles
 
 \def\comnpatname{\ifpgf@circuit@compat *\else\fi}
-\def\compattikzset#1{\tikzset{\comnpatname#1}}
+\def\compattikzset#1{%
+    % \typeout{BIPOLEDEF:\space \detokenize{#1}}%
+    \tikzset{\comnpatname#1}}
 
 %\def\ctikzsetbipole#1#2{%
 %	\tikzset{#1/.style= {to path=#2, \circuitikzbasekey, l=##1}}%
@@ -708,9 +710,9 @@
 \compattikzset{dcisource/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@dcisource@path, \circuitikzbasekey/bipole/is current=true, l=#1}}
 
 \compattikzset{ioosource/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is current=true,/tikz/to path=\pgf@circ@oosource@path, i=#1}}
-\compattikzset{voosource/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true,/tikz/to path=\pgf@circ@oosource@path, v=#1}}
-\compattikzset{oosourcetrans/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true,/tikz/to path=\pgf@circ@oosourcetrans@path, v=#1}}
-\compattikzset{ooosource/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true,/tikz/to path=\pgf@circ@ooosource@path, v=#1}}
+\compattikzset{voosource/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true, \circuitikzbasekey/bipole/is voltageoutsideofsymbol=true, /tikz/to path=\pgf@circ@oosource@path, v=#1}}
+\compattikzset{oosourcetrans/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true,\circuitikzbasekey/bipole/is voltageoutsideofsymbol=true, /tikz/to path=\pgf@circ@oosourcetrans@path, v=#1}}
+\compattikzset{ooosource/.style = {\circuitikzbasekey, \circuitikzbasekey/bipole/is voltage=true,\circuitikzbasekey/bipole/is voltageoutsideofsymbol=true, /tikz/to path=\pgf@circ@ooosource@path, v=#1}}
 
 \compattikzset{vsource/.style = {\comnpatname voltage source = #1}}
 \compattikzset{isource/.style = {\comnpatname current source = #1}}

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -123,62 +123,23 @@
 }
 
 %% Output routine for generic bipoles
+% put this to true to see the voltage label coordinate anchors
+\newif\ifpgf@circ@debugv\pgf@circ@debugvfalse
 
 \def\pgf@circ@drawvoltagegeneric{
     \pgfextra{
-        % \typeout{NAME:\ctikzvalof{bipole/name}}
-        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}
-        \pgfkeysifdefined{\pgf@temp}
-        {
-            \edef\partheight{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}}
-            \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen)}
-        }
-        {
-            \pgfkeysifdefined{/tikz/circuitikz/bipoles/voltage/straight label distance}
-            {
-                \edef\partheight{\ctikzvalof{bipoles/voltage/straight label distance}}
-                \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen)}
-            }
-            {%calculate default value from part height
-                \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/height}
-                \pgfkeysifdefined{\pgf@temp}
-                {
-                    \edef\partheight{0.5*\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/height}}
-                    \edef\tmpdistfromline{(\partheight\pgf@circ@scaled@Rlen+0.2\pgf@circ@scaled@Rlen)}
-                }
-                {
-                    \edef\tmpdistfromline{(.5\pgf@circ@scaled@Rlen)} %fallback to fixed value
-                }
-            }
-        }
         % \typeout{KIND:\ctikzvalof{bipole/kind}\space RLEN:\the\pgf@circ@Rlen\space SCALED:\the\pgf@circ@scaled@Rlen}
         \ifnum \ctikzvalof{mirror value}=-1
-        \ifpgf@circuit@bipole@inverted
-            \ifpgf@circuit@bipole@voltage@straight
-                \def\distfromline{\tmpdistfromline}
-            \else
+            \ifpgf@circuit@bipole@inverted
                 \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
-            \fi
-            \else
-            \ifpgf@circuit@bipole@voltage@straight
-                \def\distfromline{-\tmpdistfromline}
             \else
                 \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
             \fi
-        \fi
         \else
             \ifpgf@circuit@bipole@inverted
-                \ifpgf@circuit@bipole@voltage@straight
-                    \def\distfromline{-\tmpdistfromline}
-                \else
                     \def\distfromline{-\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
-                \fi
-                \else
-                \ifpgf@circuit@bipole@voltage@straight
-                    \def\distfromline{\tmpdistfromline}
                 \else
                     \def\distfromline{\ctikzvalof{voltage/distance from line}\pgf@circ@scaled@Rlen}
-                \fi
             \fi
         \fi
         \ifpgf@circuit@bipole@voltage@below
@@ -196,71 +157,121 @@
             { \edef\bumpb{\ctikzvalof{voltage/bump b}} }
         \edef\shiftv{\ctikzvalof{voltage/shift}}
         % additional per-bipole voltage shift (internal)
-        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/additional label shift}
+        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/additional shift}
         \pgfkeysifdefined{\pgf@temp}
         {
-            \edef\addvshift{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/additional label shift}}
+            \edef\addvshift{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/additional shift}}
         }
         {
             \edef\addvshift{0}
         }
         \newdimen{\absvshift}
         \pgfmathsetlength{\absvshift}{(1+\shiftv+\addvshift)*(\distfromline)}
-        % put this to true to see the voltage label coordinate anchors
-        \newif\ifpgf@circ@debugv\pgf@circ@debugvfalse
+        % reset anchor if american and open
+        \ifpgf@circuit@europeanvoltage
+        \else
+            \ifx\@@kind\@@open
+                \def\pgf@circ@bipole@voltage@label@anchor{center}
+            \fi
+        \fi
     }
     % %\pgf@circ@Rlen/\ctikzvalof{current arrow scale} is equal to the length of the currarrow
-    coordinate (pgfcirc@midtmp) at ($(\tikztostart) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorstartnode)$) %absolute move, minimum space is length of arrowhead
+    %absolute move, minimum space is length of arrowhead
+    coordinate (pgfcirc@midtmp) at ($(\tikztostart) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorstartnode)$)
     coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distancefromnode ! (anchorstartnode)$)
     coordinate (pgfcirc@Vfrom@flat) at (pgfcirc@midtmp)
-    coordinate (pgfcirc@Vfrom) at ($(pgfcirc@midtmp) ! -\distfromline ! \pgf@circ@voltage@angle:(anchorstartnode)$)
-
-    coordinate (pgfcirc@midtmp) at ($(\tikztotarget) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorendnode)$)%absolute move, minimum space is length of arrowhead
+    %absolute move, minimum space is length of arrowhead
+    coordinate (pgfcirc@midtmp) at ($(\tikztotarget) ! \pgf@circ@Rlen/\ctikzvalof{current arrow scale} ! (anchorendnode)$)
     coordinate (pgfcirc@midtmp) at ($(pgfcirc@midtmp) ! \distancefromnode ! (anchorendnode)$)
     coordinate (pgfcirc@Vto@flat) at (pgfcirc@midtmp)
-    coordinate (pgfcirc@Vto) at ($(pgfcirc@midtmp) ! \distfromline ! \pgf@circ@voltage@angle : (anchorendnode)$)
+    coordinate (pgfcirc@mid) at ($(pgfcirc@Vfrom@flat)!0.5!(pgfcirc@Vto@flat)$)
 
     \ifpgf@circuit@bipole@voltage@below
-        \ifpgf@circ@debugv
-            node [ocirc, fill=red] at (anchorstartnode) {}
-            node [ocirc, fill=blue] at (anchorendnode) {}
-            node [ocirc, fill=green] at (pgfcirc@Vto) {}
-            node [ocirc, fill=yellow] at (pgfcirc@Vfrom) {}
-            node [odiamondpole, fill=green!50!black] at (pgfcirc@Vto@flat) {}
-            node [odiamondpole, fill=orange] at (pgfcirc@Vfrom@flat) {}
-        \fi
-        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! \absvshift!90 :  (anchorendnode)$)
-        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! \absvshift!-90 :  (anchorstartnode)$)
-        coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-110)$)
-        coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-70)$)
-        coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! -\absvshift!90 : (pgfcirc@Vcont2t)$)
-        coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! -\absvshift!-90 : (pgfcirc@Vcont1t)$)
-        \ifpgf@circ@debugv
-            node [odiamondpole, fill=green] at (pgfcirc@Vto) {}
-            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom) {}
-            node [osquarepole, fill=red] at (pgfcirc@Vcont1) {}
-            node [osquarepole, fill=blue] at (pgfcirc@Vcont2) {}
+    % see comments for the "above" part (similar)
+        \ifpgf@circuit@europeanvoltage
+            \ifpgf@circuit@bipole@voltage@straight
+                coordinate (pgfcirc@bottom) at (\ctikzvalof{bipole/name}.-90)
+                coordinate (pgfcirc@Vto1) at ($(pgfcirc@mid)+(pgfcirc@bottom)-(pgfcirc@Vfrom@flat)$)
+                coordinate (pgfcirc@Vfrom1) at ($(pgfcirc@mid)+(pgfcirc@bottom)-(pgfcirc@Vto@flat)$)
+                coordinate (pgfcirc@Vto)   at ($(pgfcirc@Vto1) ! \absvshift!90 :  (pgfcirc@Vfrom1)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom1) ! \absvshift!-90 :  (pgfcirc@Vto1)$)
+                coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
+                coordinate (pgfcirc@Vdir) at (pgfcirc@Vto)
+            \else
+                coordinate (pgfcirc@Vto)   at ($(pgfcirc@Vto@flat) ! \absvshift!90 :  (anchorendnode)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! \absvshift!-90 :  (anchorstartnode)$)
+                coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-110)$)
+                coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.-70)$)
+                coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! -\absvshift!90 : (pgfcirc@Vcont2t)$)
+                coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! -\absvshift!-90 : (pgfcirc@Vcont1t)$)
+                coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vcont2)!0.5!(pgfcirc@Vcont1)$)
+                coordinate (pgfcirc@Vdir) at (pgfcirc@Vcont2)
+            \fi
+        \else % we are here in case of american here
+            % we are in case of american here
+            coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! \absvshift!90 :  (anchorendnode)$)
+            coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! \absvshift!-90 :  (anchorstartnode)$)
+            coordinate (pgfcirc@bottom) at (\ctikzvalof{bipole/name}.-90)
+            coordinate (pgfcirc@Vdir0) at ($(pgfcirc@mid)+(pgfcirc@bottom)-(pgfcirc@Vfrom@flat)$)
+            coordinate (pgfcirc@Vlab) at ($(pgfcirc@bottom) !  \absvshift!-90 : (pgfcirc@Vdir0)$)
+            coordinate (pgfcirc@Vdir) at ($(pgfcirc@mid)+(pgfcirc@Vlab)-(pgfcirc@Vfrom@flat)$)
         \fi
     \else
-        \ifpgf@circ@debugv
-            node [ocirc, fill=red] at (anchorstartnode) {}
-            node [ocirc, fill=blue] at (anchorendnode) {}
-            node [ocirc, fill=green] at (pgfcirc@Vto) {}
-            node [ocirc, fill=yellow] at (pgfcirc@Vfrom) {}
-            node [odiamondpole, fill=green] at (pgfcirc@Vto@flat) {}
-            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom@flat) {}
+        \ifpgf@circuit@europeanvoltage
+            \ifpgf@circuit@bipole@voltage@straight
+                coordinate (pgfcirc@top) at (\ctikzvalof{bipole/name}.90)
+                % move parallel to the component line at pgfcirc@top distance
+                coordinate (pgfcirc@Vto1) at ($(pgfcirc@mid)+(pgfcirc@top)-(pgfcirc@Vfrom@flat)$)
+                coordinate (pgfcirc@Vfrom1) at ($(pgfcirc@mid)+(pgfcirc@top)-(pgfcirc@Vto@flat)$)
+                % add the extra distance
+                coordinate (pgfcirc@Vto)   at ($(pgfcirc@Vto1) ! \absvshift!-90 :  (pgfcirc@Vfrom1)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom1) ! \absvshift!90 :  (pgfcirc@Vto1)$)
+                coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
+                % direction line to shift the label later
+                coordinate (pgfcirc@Vdir) at (pgfcirc@Vto)
+            \else
+                % european voltages here
+                coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! -\absvshift!90 :  (anchorendnode)$)
+                coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! -\absvshift!-90 :  (anchorstartnode)$)
+                % identify the two control points for the "arc" of the voltage
+                coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.110)$)
+                coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.70)$)
+                % and shift them a bit
+                coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! \absvshift!90 : (pgfcirc@Vcont2t)$)
+                coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! \absvshift!-90 : (pgfcirc@Vcont1t)$)
+                coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vcont2)!0.5!(pgfcirc@Vcont1)$)
+                % direction line to shift the label later
+                coordinate (pgfcirc@Vdir) at (pgfcirc@Vcont2)
+            \fi
+        \else
+            % we are in case of american here
+            coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! \absvshift!-90 :  (anchorendnode)$)
+            coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! \absvshift!90 :  (anchorstartnode)$)
+            coordinate (pgfcirc@top) at (\ctikzvalof{bipole/name}.90)
+            % move parallel to the component line
+            coordinate (pgfcirc@Vdir0) at ($(pgfcirc@mid)+(pgfcirc@top)-(pgfcirc@Vfrom@flat)$)
+            % and add the extra distance
+            coordinate (pgfcirc@Vlab) at ($(pgfcirc@top) !  \absvshift!90 : (pgfcirc@Vdir0)$)
+            coordinate (pgfcirc@Vdir) at ($(pgfcirc@mid)+(pgfcirc@Vlab)-(pgfcirc@Vfrom@flat)$)
         \fi
-        coordinate (pgfcirc@Vto) at ($(pgfcirc@Vto@flat) ! -\absvshift!90 :  (anchorendnode)$)
-        coordinate (pgfcirc@Vfrom) at ($(pgfcirc@Vfrom@flat) ! -\absvshift!-90 :  (anchorstartnode)$)
-        coordinate (pgfcirc@Vcont1t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.110)$)
-        coordinate (pgfcirc@Vcont2t) at ($(\ctikzvalof{bipole/name}.center) ! \bumpb ! (\ctikzvalof{bipole/name}.70)$)
-        coordinate (pgfcirc@Vcont1) at ($(pgfcirc@Vcont1t) ! \absvshift!90 : (pgfcirc@Vcont2t)$)
-        coordinate (pgfcirc@Vcont2) at ($(pgfcirc@Vcont2t) ! \absvshift!-90 : (pgfcirc@Vcont1t)$)
-        \ifpgf@circ@debugv
-            node [odiamondpole, fill=green] at (pgfcirc@Vto) {}
-            node [odiamondpole, fill=yellow] at (pgfcirc@Vfrom) {}
-            node [osquarepole, fill=red] at (pgfcirc@Vcont1) {}
-            node [osquarepole, fill=blue] at (pgfcirc@Vcont2) {}
+    \fi
+    \ifx\@@kind\@@open
+        coordinate (pgfcirc@Vto) at (pgfcirc@Vto@flat)
+        coordinate (pgfcirc@Vfrom) at (pgfcirc@Vfrom@flat)
+    \fi
+    \ifpgf@circ@debugv
+        node [ocirc, fill=red] at (anchorstartnode) {}
+        node [ocirc, fill=blue] at (anchorendnode) {}
+        node [ocirc, fill=green] at (pgfcirc@Vto) {}
+        node [ocirc, fill=yellow] at (pgfcirc@Vfrom) {}
+        node [odiamondpole, fill=green!50!black] at (pgfcirc@Vto@flat) {}
+        node [odiamondpole, fill=orange] at (pgfcirc@Vfrom@flat) {}
+        \ifpgf@circuit@europeanvoltage
+            \ifpgf@circuit@bipole@voltage@straight
+            \else
+                node [osquarepole, fill=red] at (pgfcirc@Vcont1) {}
+                node [osquarepole, fill=blue] at (pgfcirc@Vcont2) {}
+            \fi
         \fi
     \fi
 
@@ -283,57 +294,29 @@
             \fi
         \fi
     \else % american
-        \ifx\@@kind\@@open % open circuit; put + and - directly on it
-            \ifpgf@circuit@bipole@voltage@backward
-                \ifpgf@circ@oldvoltagedirection
-                    (pgfcirc@Vfrom@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avplus}
-                    (pgfcirc@Vto@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avminus}
-                \else
-                    (pgfcirc@Vfrom@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avminus}
-                    (pgfcirc@Vto@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avplus}
-                \fi
-                \else
-                \ifpgf@circ@oldvoltagedirection
-                    (pgfcirc@Vfrom@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avminus}
-                    (pgfcirc@Vto@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avplus}
-                \else
-                    (pgfcirc@Vfrom@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avplus}
-                    (pgfcirc@Vto@flat) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=center]{\pgf@circ@avminus}
-                \fi
+        \ifpgf@circuit@bipole@voltage@backward
+            \ifpgf@circ@oldvoltagedirection
+                (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
+                (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
+            \else
+                (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
+                (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
             \fi
-        \else % not open circuit
-            \ifpgf@circuit@bipole@voltage@backward
-                \ifpgf@circ@oldvoltagedirection
-                    (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
-                    (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
-                \else
-                    (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
-                    (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
-                \fi
-                \else
-                \ifpgf@circ@oldvoltagedirection
-                    (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
-                    (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
-                \else
-                    (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
-                    (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
-                        anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
-                \fi
+            \else
+            \ifpgf@circ@oldvoltagedirection
+                (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
+                (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
+            \else
+                (pgfcirc@Vfrom) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avplus}
+                (pgfcirc@Vto) node[inner sep=0, node font=\pgf@circ@avfont,
+                    anchor=\pgf@circ@bipole@voltage@label@anchor]{\pgf@circ@avminus}
             \fi
         \fi
     \fi
@@ -345,19 +328,39 @@
     % it's not perfect, but I can't find the way to do it correctly...
     \pgfextra{
         \edef\shiftv{\ctikzvalof{voltage/shift}}
-        \edef\bumpa{\ctikzvalof{voltage/bump a}}
+        % distance along the 60-120 axis
+        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/bump a}
+        \pgfkeysifdefined{\pgf@temp}
+        {
+            \edef\bumpa{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/bump a}}
+        }
+        {
+            \edef\bumpa{\ctikzvalof{voltage/bump a}}
+        }
+        % additional per-bipole voltage shift (internal)
+        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/additional shift}
+        \pgfkeysifdefined{\pgf@temp}
+        {
+            \edef\addvshift{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/additional shift}}
+        }
+        {
+            \edef\addvshift{0}
+        }
         \pgfmathsetmacro{\bumpaplus}{\bumpa + 0.5*\shiftv} % coefficient added "by feel". Sorry.
     }
     \ifpgf@circuit@bipole@voltage@below
-        coordinate (pgfcirc@Vfrom) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-120)$)
-        coordinate (pgfcirc@Vto) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-60)$)
+        coordinate (pgfcirc@Vfrom0) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-120)$)
+        coordinate (pgfcirc@Vto0) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-60)$)
+        coordinate (pgfcirc@Vfrom) at ($ (pgfcirc@Vfrom0) ! \addvshift! -90: (pgfcirc@Vto0) $)
+        coordinate (pgfcirc@Vto) at ($ (pgfcirc@Vto0) ! \addvshift! 90: (pgfcirc@Vfrom0) $)
     \else
-        coordinate (pgfcirc@Vfrom) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.120)$)
-        coordinate (pgfcirc@Vto) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.60)$)
+        coordinate (pgfcirc@Vfrom0) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.120)$)
+        coordinate (pgfcirc@Vto0) at ($ (\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.60)$)
+        coordinate (pgfcirc@Vfrom) at ($ (pgfcirc@Vfrom0) ! \addvshift! 90: (pgfcirc@Vto0) $)
+        coordinate (pgfcirc@Vto) at ($ (pgfcirc@Vto0) ! \addvshift! -90: (pgfcirc@Vfrom0) $)
     \fi
-    % fix the (unused in this case) Vcont1/2 coords for label placement along the line
-    coordinate (pgfcirc@Vcont1) at (pgfcirc@Vto)
-    coordinate (pgfcirc@Vcont2) at (pgfcirc@Vfrom)
+    coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
+    coordinate (pgfcirc@Vdir) at (pgfcirc@Vto)
     \ifpgf@circuit@europeanvoltage
         \ifpgf@circuit@bipole@voltage@backward
             (pgfcirc@Vto)  -- node[currarrow, sloped,  allow upside down, pos=1, anchor=tip] {} (pgfcirc@Vfrom)
@@ -392,6 +395,8 @@
 %% Output routine
 %% this is the entry point
 %%
+%% locally used dimensions
+\newdimen{\pgfcirc@labelshift}
 \def\pgf@circ@drawvoltage{% node name
     \pgfextra{ %WARNING: indentation is probably wrong
         \edef\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
@@ -454,11 +459,11 @@
 
         % this must be set *before* changing for mirroring and inverting; in that case
         % the xscale/yscale parameters take it into account
-        \ifpgf@circuit@bipole@voltage@below
-            \def\pgf@circ@bipole@voltage@label@where{-90}
-        \else
-            \def\pgf@circ@bipole@voltage@label@where{90}
-        \fi
+            \ifpgf@circuit@bipole@voltage@below
+                \def\pgf@circ@bipole@voltage@label@where{-90}
+            \else
+                \def\pgf@circ@bipole@voltage@label@where{90}
+            \fi
 
         % magic to counteract the scale and yscale effects (there should be a better way...)
         \ifnum \ctikzvalof{mirror value}=-1
@@ -480,20 +485,46 @@
         % take into account scaling
         \setscaledRlenforclass
 
-        \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}
-        \pgfkeysifdefined{\pgf@temp}
-            { \edef\eudist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}} }
-            { \edef\eudist{\ctikzvalof{voltage/european label distance}} }
+        \ifpgf@circuit@europeanvoltage
+            \ifpgf@circuit@bipole@voltage@straight
+                % check for straight
+                \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}
+                \pgfkeysifdefined{\pgf@temp}{%
+                    \edef\labeldist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/straight label distance}}%
+                    % \typeout{ST:ADJUSTED\space for\space \ctikzvalof{bipole/kind} \space at \space \stdist}
+                }{\edef\labeldist{\ctikzvalof{voltage/straight label distance}}}
+                \ifpgf@circ@debugv\edef\whichtypeshift{STR}\fi
+            \else
+                % check for european
+                \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}
+                \pgfkeysifdefined{\pgf@temp}{%
+                    \edef\labeldist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/european label distance}}%
+                    % \typeout{EU:ADJUSTED\space for\space \ctikzvalof{bipole/kind} \space at \space \eudist}
+                }{ \edef\labeldist{\ctikzvalof{voltage/european label distance}}}
+                \ifpgf@circ@debugv\edef\whichtypeshift{EUR}\fi
+            \fi
+        \else
+            % check for american
+            \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/voltage/american label distance}
+            \pgfkeysifdefined{\pgf@temp}{%
+                \edef\labeldist{\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/voltage/american label distance}}%
+                % \typeout{AL:ADJUSTED\space for\space \ctikzvalof{bipole/kind} \space at \space \aldist}
+            }{\edef\labeldist{\ctikzvalof{voltage/american label distance}}}
+            \ifpgf@circ@debugv\edef\whichtypeshift{AME}\fi
+        \fi
         % find the height of the bipole or use a default value
         \edef\pgf@temp{/tikz/circuitikz/bipoles/\ctikzvalof{bipole/kind}/height}
         \pgfkeysifdefined{\pgf@temp}
             {\pgfmathsetmacro{\partheightf}{0.5*\ctikzvalof{bipoles/\ctikzvalof{bipole/kind}/height}}
              \edef\partheight{\partheightf\pgf@circ@scaled@Rlen}}
             {\edef\partheight{(.5\pgf@circ@scaled@Rlen)}} %fallback to fixed value
-        \newdimen{\alshift}
-        % this is more or less the same of the legacy code; we shift the american label a bit
-        % outside the (+) -- (-) line
-        \pgfmathsetlength{\alshift}{(\ctikzvalof{voltage/american label distance}-0.6)*\partheight}
+
+        \ifpgf@circuit@bipole@isvoltage
+            \pgfmathsetlength{\pgfcirc@labelshift}{(\labeldist-1.2)*\partheight}
+        \else
+            \pgfmathsetlength{\pgfcirc@labelshift}{(\labeldist-1.4)*\partheight}
+        \fi
+        % the value for the european was by default 1.4
         \pgfsetcornersarced{\pgfpointorigin}% do not use rounded corners!
         % set the macro for detecting open
         \edef\@@kind{\ctikzvalof{bipole/kind}}\edef\@@open{open}
@@ -506,42 +537,33 @@
     \else
         \pgf@circ@drawvoltagegeneric
     \fi
+    % % debugging
+    % \pgfextra{%
+    %     \typeout{LABEL\space KIND:\@@kind\space EU:\the\pgfcirc@eushift\space AL:\the\pgfcirc@alshift\space
+    %         DIRECTION:\pgf@circ@bipole@voltage@label@where}
+    %     \pgf@circ@debugvtrue}
 
-    % \pgfextra{\typeout{LABEL\space KIND:\@@kind\space OPEN:\@@open}}
+    % move a bit if requested
+    coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vlab) ! \pgfcirc@labelshift ! \pgf@circ@bipole@voltage@label@where :(pgfcirc@Vdir)$)
 
-    \ifpgf@circuit@bipole@voltage@straight
-        coordinate (Vlab) at ($(pgfcirc@Vto)!0.5!(pgfcirc@Vfrom) $)
-        node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
-        \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
-        at (Vlab) {\pgf@circ@finallabels{voltage/label}}
+    % check for the case of american AND open
+    \ifpgf@circuit@europeanvoltage
     \else
-        \ifpgf@circuit@europeanvoltage
-            coordinate (Vlab) at ($(pgfcirc@Vcont1)!0.5!(pgfcirc@Vcont2)$)
-        \else
-            coordinate (Vlab) at ($(pgfcirc@Vfrom)!0.5!(pgfcirc@Vto)$)
-            \ifpgf@circuit@bipole@isvoltage\else
-            % add a bit of space for american labels above their symbols in the normal case. You can avoid that
-            % with voltage/american label distance=0.5 (it's measured from the center of the component, in heights)
-                coordinate (Vlab) at ($(Vlab) ! \alshift ! \pgf@circ@bipole@voltage@label@where :(pgfcirc@Vto)$)
-            \fi
-        \fi
-
-        \ifpgf@circuit@europeanvoltage
-            node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
-            \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
-            at (Vlab) {\pgf@circ@finallabels{voltage/label}}
-        \else % american voltages
-            \ifx\@@kind\@@open
-                coordinate (Vlab) at ($(pgfcirc@Vfrom@flat)!0.5!(pgfcirc@Vto@flat)$)
-                node [anchor=center, inner sep=2pt,
-                \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
-                at (Vlab) {\pgf@circ@finallabels{voltage/label}}
-            \else
-                node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
-                \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
-                at (Vlab) {\pgf@circ@finallabels{voltage/label}}
-            \fi
-        \fi
+        \ifx\@@kind\@@open
+        % override pgfcirc@Vlab
+        coordinate (pgfcirc@Vlab) at ($(pgfcirc@Vfrom@flat)!0.5!(pgfcirc@Vto@flat)$)\fi
     \fi
+
+    \ifpgf@circ@debugv
+            node [odiamondpole, color=blue] at (pgfcirc@Vlab) {}
+            node [odiamondpole, color=red] at (pgfcirc@Vdir) {}
+            node [overlay, red, font=\tiny, anchor=south east, align=right] at(pgfcirc@Vdir)
+            {\whichtypeshift:\the\pgfcirc@labelshift\\ DIR:\pgf@circ@bipole@voltage@label@where}
+    \fi
+
+    node [anchor=\pgf@circ@bipole@voltage@label@anchor, inner sep=2pt,
+    \circuitikzbasekey/bipole voltage style](\ctikzvalof{bipole/name}voltage)
+    at (pgfcirc@Vlab) {\pgf@circ@finallabels{voltage/label}}
+
 }%end drawvoltages
 \endinput

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.1.3-unreleased}
-\def\pgfcircversiondate{2020/05/18}
+\def\pgfcircversion{1.2.0-unreleased}
+\def\pgfcircversiondate{2020/06/17}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Again.

I really would like to rewrite all the voltage-label code, because there are a lot of glitches and the code has grown very complex. But that would be backward-incompatible, or so I think. Maybe a summer project...

Default `RPvoltage` voltages  are here, for all the bipoles:
[voltagepos.pdf](https://github.com/circuitikz/circuitikz/files/4746299/voltagepos.pdf)

