### PR TITLE
Version 1.2.0 (2020-06-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.2.0 (unreleased)
+* Version 1.2.0 (2020-06-21)
 
     In this release, the big change is the rewriting of the voltages output routine. Now all voltage options (american, european, and straight) take into account the shape (square border) of the component. The adjusting parameters are now (at least for passive elements) acting in similar way for all the options, too.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.0-unreleased}
-\def\pgfcircversiondate{2020/06/17}
+\def\pgfcircversion{1.2.0}
+\def\pgfcircversiondate{2020/06/21}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.0-unreleased}
-\def\pgfcircversiondate{2020/06/17}
+\def\pgfcircversion{1.2.0}
+\def\pgfcircversiondate{2020/06/21}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
In this release, the big change is the rewriting of the voltages output
routine. Now all voltage options (american, european, and straight) take
into account the shape (square border) of the component. The adjusting
parameters are now (at least for passive elements) acting in similar way
for all the options, too.

    - Bumped version number to 1.2 (potentially incompatible changes!)
    - Added 1.1.2 checkpoint
    - New path-style not, buffer, and Schmitt logic ports
    - New tutorial (using the "inline not" component)
    - Voltage output routine rewrite; now it takes into account the
    shape of the component also for "american" and "straight" voltages
    - Several fixes in the logic ports: fixed IEEE `invschmitt` name,
    added symmetry to the three-style shorthands for the ports, and so
    on
    - Fixed a gross bug in square poles anchor borders
    - Fixed size of not circles in flip-flops (based on logic ports
    style)
    - Fixed the order of initial options, to avoid "european"
    overwriting single options