### PR TITLE
Rewrite path formation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 1.2.1 (unreleased)
 
+    In this release, there are big changes, potentially dangerous. The macros that implement the path elements (`to[...]`) has been rewritten.
+    Also, a new style of voltages has been added.
+
     - Bumped version number to 1.2.1 to avoid confusion
+    - Added "raised american" voltage style
+    - Rewrite of the path generation macros
 
 * Version 1.2.0 (2020-06-21)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -273,13 +273,14 @@ Nevertheless,  \href{https://tex.stackexchange.com/a/529159/38080}{Schrödinger'
 \end{circuitikz}
 \end{LTXexample}
 
-They \texttt{use fpu reciprocal} key seems to have no side effects, but given that it is patching an internal interface of \TikZ{} it can break any time, so it is advisable to use it only if and when needed.
+The \texttt{use fpu reciprocal} key seems to have no side effects, but given that it is patching an internal interface of \TikZ{} it can break any time, so it is advisable to use it only if and when needed.
 
 
 \subsection{Incompabilities between version}
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item After v1.2.1: the routine that implement the \texttt{to[...]} component positioning has been rewritten. That should enhance the line joins in path, and it's safer, but it can potentially change behavior. One of the changes is that the previous routine did the wrong thing if you used \texttt{(node) to[...]} (you should use an anchor or a coordinate, not a node there --- like \texttt{(node.anchor) to[...]}). The other one was that in the structure \texttt{... to[...] node[pos=\emph{something}]  (coord)} the value of \texttt{pos} was completely wrong (even if you don't use \texttt{pos} explicitly, remeber it's \texttt{pos=0.5} by default).
     \item After v1.2.0: voltage arrows, symbols and label positions are calculated with a rewritten routine. There should be little change, \emph{unless} you touched internal values\dots
     \item After v1.1.3: during the 1.1.0 --- 1.1.2 version, the inverted Schmitt buffer in IEEE style ports was called \texttt{inv schmitt} (with an additional space). The correct name is \texttt{invschmitt port} (the same as the legacy american port).
     \item After v1.1.2: the position of \texttt{american} voltages for the \texttt{open} bipoles (you can revert to old behavior, see section~\ref{sec:sub-voltage-position}).

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -141,23 +141,23 @@
         \draw (C.pin 20) -- ++(0,-8) node[ground](GND){};
         \draw (C.pin 7) to[D, fill=blue] ++(0,-1) -- ++(0.5,0) to[R] ++(2,0)
             coordinate(a1) to[short, -*]
-            node[above left, blue]{Massimo A. Redaelli}
-            node[below left,]{\email{m.redaelli@gmail.com}}
+            node[above left, blue, pos=1]{Massimo A. Redaelli}
+            node[below left, pos=1]{\email{m.redaelli@gmail.com}}
             (a1-|GND);
             \draw (C.pin 5) to[D, fill=red] ++(0,-3)-- ++(0.5,0) to[R] ++(2,0)
             coordinate(a2) to[short, -*]
-            node[above left, blue]{Stefan Lindner}
-            node[below left,]{\email{stefan.lindner@fau.de}}
+            node[above left, blue, pos=1]{Stefan Lindner}
+            node[below left, pos=1]{\email{stefan.lindner@fau.de}}
             (a2-|GND);
             \draw (C.pin 3) to[D, fill=green] ++(0,-5)-- ++(0.5,0) to[R] ++(2,0)
             coordinate(a3) to[short, -*]
-            node[above left, blue]{Stefan Erhardt}
-            node[below left,]{\email{stefan.erhardt@fau.de}}
+            node[above left, blue, pos=1]{Stefan Erhardt}
+            node[below left, pos=1]{\email{stefan.erhardt@fau.de}}
             (a3-|GND);
             \draw (C.pin 1) to[D, fill=yellow] ++(0,-7)-- ++(0.5,0) to[R] ++(2,0)
             coordinate(a4) to[short, -*]
-            node[above left, blue]{Romano Giannetti}
-            node[below left,]{\email{romano.giannetti@gmail.com}}
+            node[above left, blue, pos=1]{Romano Giannetti}
+            node[below left, pos=1]{\email{romano.giannetti@gmail.com}}
             (a4-|GND);
     \end{circuitikz}
     \par\bigskip\vfill}

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -52,22 +52,6 @@
     }
 }
 
-%% Helper function for path-function to ensure using anchors between nodes
-\def\set@explicit@center@anchor#1{
-    \pgfutil@ifundefined{pgf@sh@ns@#1}
-    {
-        %This coordinate is no node(but a relative position or a coordinate), no further handling needed
-        }{
-        \pgfutil@in@.{#1}
-        \ifpgfutil@in@
-            % Anchor is used, do nothing!
-    \else%
-        \let\tikz@moveto@waiting=\relax
-        \pgfpathmoveto{\tikz@last@position}%force movement, because tikz@moveto@waiting
-        \edef#1{#1.center}%ensure using center anchor
-    \fi
-}
-}
 
 %% Generic bipole path
 \def\pgf@circ@bipole@path#1#2{
@@ -111,9 +95,6 @@
     % #4: this will be filled by the argument of the to-path
     %
     \pgfextra{
-        \set@explicit@center@anchor{\tikztostart}
-        \set@explicit@center@anchor{\tikztotarget}
-        \pgfsyssoftpath@getcurrentpath{\myp@th}%% save current path to extend after calculation of correct start/end coordinates
         \ctikzset{bipole/kind = #3}
         \edef\pgf@temp{\ctikzvalof{bipole/name}}
         \def\pgf@circ@temp{}
@@ -122,69 +103,65 @@
             \ctikzset{bipole/name = #3\pgf@circ@rand} % create it (re-usage should not create problem, but...)
         \fi
     }
-
-    (\tikztostart) coordinate (\ctikzvalof{bipole/name}start)%necessary to get correct coordinates in the case of relative start/end or constructions like ((node1)-|(node2))
-    (\tikztotarget) coordinate (\ctikzvalof{bipole/name}end)
+    % save start and stop values
+    % notice that we DO NOT MOVE the path position at all!
+    coordinate (\ctikzvalof{bipole/name}start) at (\tikztostart)
+    coordinate (\ctikzvalof{bipole/name}end) at (\tikztotarget)
     \pgfextra{
+        % find the direction (angle) of the path
         \pgfmathanglebetweenpoints{\pgfpointanchor{\ctikzvalof{bipole/name}start}{center}}
-        {\pgfpointanchor{\ctikzvalof{bipole/name}end}{center}}
-        % DO NOT ROUND HERE! pgfcirclabel.tex will do that when needed
-        % \pgfmathround{\pgfmathresult}
-        \edef\pgf@circ@direction{\pgfmathresult}%Calculate direction(angle) of path
-        % \typeout{DIRECTION:\pgf@circ@direction}
-        \pgfsyssoftpath@setcurrentpath{\myp@th}
+            {\pgfpointanchor{\ctikzvalof{bipole/name}end}{center}}
+        \edef\pgf@circ@direction{\pgfmathresult}
     }
+    % position the component in the middle of the path. We DO NOT MOVE the current position!
+    node[#3#1, rotate=\pgf@circ@direction, yscale=\ctikzvalof{mirror value},
+        xscale=\ctikzvalof{invert value}] (\ctikzvalof{bipole/name})
+        at ($(\tikztostart) ! .5 ! (\tikztotarget)$) {#2}
+    % set start and end labels
+    \ifpgf@circuit@bipole@inverted
+        \ifcsname pgf@anchor@#3#1@pathstart\endcsname%if special path-anchors are defined, use them!
+            coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.pathend)
+            coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.pathstart)
+        \else
+            coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.right)
+            coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.left)
+        \fi
+        \else
+        \ifcsname pgf@anchor@#3#1@pathstart\endcsname%if special path-anchors are defined, use them!
+            coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.pathstart)
+            coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.pathend)
+        \else
+            coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.left)
+            coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.right)
+        \fi
+    \fi
+    % draw the leads unless it's an open circuit
+    % stop at the component
     \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}
-    \ifx\pgf@temp\pgf@circ@temp  % if it is an open
-        \else
-            --($(\ctikzvalof{bipole/name}start) ! .5\pgflinewidth ! (\ctikzvalof{bipole/name}end)$) %ugly workaround to get correct linejoins(node breaks path?)
-        \fi
-        ($(\tikztostart) ! .5 ! (\tikztotarget)$)%%positio of middle node
-        node[#3#1, rotate=\pgf@circ@direction, yscale=\ctikzvalof{mirror value}, xscale=\ctikzvalof{invert value}]
-        (\ctikzvalof{bipole/name}) {#2}
-        \ifpgf@circuit@bipole@inverted
-            \ifcsname pgf@anchor@#3#1@pathstart\endcsname%if special path-anchors are defined, use them!
-                coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.pathend)
-                coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.pathstart)
-            \else
-                coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.right)
-                coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.left)
-            \fi
-            \else
-            \ifcsname pgf@anchor@#3#1@pathstart\endcsname%if special path-anchors are defined, use them!
-                coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.pathstart)
-                coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.pathend)
-            \else
-                coordinate	(anchorstartnode) at (\ctikzvalof{bipole/name}.left)
-                coordinate	(anchorendnode) at (\ctikzvalof{bipole/name}.right)
-            \fi
-        \fi
-        \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}
-        \ifx\pgf@temp\pgf@circ@temp  % if it is an open
-        \else
-            (\ctikzvalof{bipole/name}start.center) -- (anchorstartnode)
-            (anchorendnode)  -- (\ctikzvalof{bipole/name}end.center)
-        \fi
-
-        \drawpoles
-        \pgf@circ@ifkeyempty{bipole/label/name}\else\pgf@circ@drawlabels{label}\fi
-        \pgf@circ@ifkeyempty{bipole/annotation/name}\else\pgf@circ@drawlabels{annotation}\fi
-        \pgf@circ@ifkeyempty{bipole/voltage/label/name}\else\pgf@circ@drawvoltage\fi
-        \pgf@circ@ifkeyempty{bipole/current/label/name}\else\pgf@circ@drawcurrent\fi
-        \pgf@circ@ifkeyempty{bipole/flow/label/name}\else\pgf@circ@drawflow\fi
-        \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}
-        \ifx\pgf@temp\pgf@circ@temp  % if it is an open
-            (\ctikzvalof{bipole/name}end)%Move to end of path
-        \else
-            ($(\ctikzvalof{bipole/name}end) ! .5\pgflinewidth ! (\ctikzvalof{bipole/name}start)$) -- (\ctikzvalof{bipole/name}end)%ugly workaround to get correct linejoins(node breaks path?)
-            %tikztostart and tikztotarget could not be used, because it would break if target coordinate is something like (node1-|node2)
-
-        \fi
-    % reset
-    \pgfextra{
-        \pgfcircresetpath
-    }
-    \tikztonodes%draw pending nodes an path
+    \ifx\pgf@temp\pgf@circ@temp  % if it is an open do nothing
+    \else
+        % it is important to start the path with -- to have correct line joins!
+        -- (\tikztostart) -- (anchorstartnode)
+    \fi
+    % Add all the "ornaments": labels, annotations, voltages, currents and flows
+    \drawpoles
+    \pgf@circ@ifkeyempty{bipole/label/name}\else\pgf@circ@drawlabels{label}\fi
+    \pgf@circ@ifkeyempty{bipole/annotation/name}\else\pgf@circ@drawlabels{annotation}\fi
+    \pgf@circ@ifkeyempty{bipole/voltage/label/name}\else\pgf@circ@drawvoltage\fi
+    \pgf@circ@ifkeyempty{bipole/current/label/name}\else\pgf@circ@drawcurrent\fi
+    \pgf@circ@ifkeyempty{bipole/flow/label/name}\else\pgf@circ@drawflow\fi
+    % finish the path from the component to the final target
+    % you never know --- re-set \pgf@temp to detect open
+    \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}
+    \ifx\pgf@temp\pgf@circ@temp  % if it is an open do nothing
+        (\tikztotarget)
+    \else
+        (anchorendnode)  -- (\tikztotarget)
+    \fi
+    % reset internal circuit keys
+    \pgfextra{\pgfcircresetpath}
+    %draw pending nodes an path
+    \tikztonodes
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This basically removes the patches introduced for issue #58 and #76
    
Reverts these:
-  https://github.com/circuitikz/circuitikz/commit/6efc2ee86fb3b2b479b3039526fcc90d3f9201d2
-  https://github.com/circuitikz/circuitikz/commit/352d2bf34054d6450a0ffe92529876f4e2398ac6
    
Then, it carefully builds the anchors without moving the start of the path, and then join it with a leading `--`

Fixes #417 
Fixes #76 
Fixes #58 