### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.2.1 (unreleased)
+* Version 1.2.1 (2020-07-06)
 
-    In this release, there are big changes, potentially dangerous.
+    Several changes, both internal and user-visible. These are quite risky, although they *should* be backeard-compatible.
 
     From the user point of view:
     - there is now a new style of voltages ("raised American")

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.1-unreleased}
-\def\pgfcircversiondate{2020/06/22}
+\def\pgfcircversion{1.2.1}
+\def\pgfcircversiondate{2020/07/06}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.1-unreleased}
-\def\pgfcircversiondate{2020/06/22}
+\def\pgfcircversion{1.2.1}
+\def\pgfcircversiondate{2020/07/06}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
* Version 1.2.1 (2020-07-06)

In this release, there are big changes, potentially dangerous.

From the user point of view:
- there is now a new style of voltages ("raised American")
- a powerful mechanism for customize voltages, current and flows has been added.

The internal changes are basically the re-implementation of the macros
that draw the path elements (`to[...]`), which have been completely
rewritten. Please be sure to read the possible incompatibilities in the
manual (section 1.9).

- Added access to voltages, currents and flows anchors
- Added "raised american" voltage style
- Rewrite of the path generation macros
- Several small bugs fixed (no one ever used some "f^>" options...)