### PR TITLE
Better name for "american open voltage" flag

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -6136,7 +6136,7 @@ Notes that \texttt{american voltage} also affects batteries.
 \end{circuitikz}
 \end{LTXexample}
 
-When using \texttt{american} or \texttt{straight} voltage style, the \texttt{open} component is treated differently, and the voltage is placed in the middle of the open space\footnote{Since \texttt{v1.1.2}, thank to an \href{https://github.com/circuitikz/circuitikz/issues/374}{issue opened by user \texttt{rhandley} on GitHub}.}:
+Additionally, the \texttt{open} component is treated differently; the voltage is placed in the middle of the open space\footnote{Since \texttt{v1.1.2}, thank to an \href{https://github.com/circuitikz/circuitikz/issues/374}{issue opened by user \texttt{rhandley} on GitHub}.}:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american voltages]
@@ -6148,7 +6148,7 @@ When using \texttt{american} or \texttt{straight} voltage style, the \texttt{ope
 \end{circuitikz}
 \end{LTXexample}
 
-If you want or need to maintain the old behavior for \texttt{open} voltage, you can set the key \texttt{american open voltage} to \texttt{legacy} (the default is the new behavior, which correspond to the value \texttt{center}).
+If you want or need to maintain the old behavior for \texttt{open} voltage, you can set the key \texttt{open voltage position} to \texttt{legacy} (the default is the new behavior, which correspond to the value \texttt{center}).
 
 \subsubsection{American voltages customization}
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -2159,6 +2159,10 @@
 % american open voltage adjusting
 %
 \newif\ifpgf@adjust@open@voltage\pgf@adjust@open@voltagetrue
+\ctikzset{open voltage position/.is choice}
+\ctikzset{open voltage position/center/.code={\pgf@adjust@open@voltagetrue}}
+\ctikzset{open voltage position/legacy/.code={\pgf@adjust@open@voltagefalse}}
+% bad names, kept for compatibility, don't use
 \ctikzset{american open voltage/.is choice}
 \ctikzset{american open voltage/center/.code={\pgf@adjust@open@voltagetrue}}
 \ctikzset{american open voltage/legacy/.code={\pgf@adjust@open@voltagefalse}}


### PR DESCRIPTION
See also https://tex.stackexchange.com/questions/560551/european-voltage-has-different-shifts-for-an-open-path-and-a-component-path-how/560578#560578
