### PR TITLE
add resistive splitter

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2539,6 +2539,8 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
     \circuitdesc*{oscillator}{oscillator}{}( w/180/0.1,s/-90/0.1,e/0/0.1,n/90/0.1 )
     \circuitdesc*{circulator}{circulator}{}( left/180/0.1,down/-90/0.1,right/0/0.1, up/90/0.1 )
     \circuitdesc*{wilkinson}{wilkinson divider}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
+    \circuitdesc*{splitter}{resistive splitter\footnotemark}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
+    \footnotetext{added by \texttt{matthuszagh}}
     \circuitdesc*{gridnode}{gridnode\footnotemark}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
     \footnotetext{added by \texttt{olfline}}
     \circuitdesc*{mzm}{Mach Zehnder Modulator\footnotemark}{}( in/180/0.1, mod/90/0.1, out/0/0.1)

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -1011,6 +1011,9 @@
 \ctikzset{tripoles/wilkinson/height/.initial=1.3}
 \ctikzset{tripoles/wilkinson/width/.initial=1.3}
 
+\ctikzset{tripoles/splitter/height/.initial=1.3}
+\ctikzset{tripoles/splitter/width/.initial=1.3}
+
 \ctikzset{tripoles/mzm/height/.initial=1.3}
 \ctikzset{tripoles/mzm/width/.initial=1.3}
 %%>>>

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -1271,6 +1271,141 @@
     }
 }
 
+%% resistive splitter
+\pgfdeclareshape{splitter}{
+    \savedmacro{\ctikzclass}{\edef\ctikzclass{blocks}}
+    \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}}
+    \savedanchor\northwest{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgf@y=\ctikzvalof{tripoles/wilkinson/height}\pgf@circ@scaled@Rlen
+        \pgf@y=.5\pgf@y
+        \pgf@x= \pgf@circ@scaled@Rlen
+        \pgf@x=.5\pgf@x
+        \pgf@x=-\ctikzvalof{tripoles/wilkinson/width}\pgf@x
+    }
+    \anchor{center}{
+        \northwest
+        \pgf@x=0pt
+        \pgf@y=0pt
+    }
+    \anchor{north}{
+        \northwest
+        \pgf@x=0pt
+    }
+    \anchor{south}{
+        \northwest
+        \pgf@x=0pt
+        \pgf@y=-\pgf@y
+    }
+    \anchor{west}{
+        \northwest
+        \pgf@y=0pt
+    }
+    \anchor{east}{
+        \northwest
+        \pgf@y=0pt
+        \pgf@x=-\pgf@x
+    }
+    \anchor{south west}{
+        \northwest
+        \pgf@y=-\pgf@y
+    }
+    \anchor{north east}{
+        \northwest
+        \pgf@x=-\pgf@x
+    }
+    \anchor{north west}{
+        \northwest
+    }
+    \anchor{south east}{
+        \northwest
+        \pgf@x=-\pgf@x
+        \pgf@y=-\pgf@y
+    }
+    \anchor{in}{
+        \northwest
+        \pgf@y=0pt
+    }
+    \anchor{out1}{
+        \northwest
+        \pgf@x=-\pgf@x
+        \pgf@y=-0.5\pgf@y
+    }
+    \anchor{out2}{
+        \northwest
+        \pgf@x=-\pgf@x
+        \pgf@y=0.5\pgf@y
+    }
+    \anchor{text}{
+        \northwest
+        \advance \pgf@y by 0.5\ht\pgfnodeparttextbox
+        \pgf@x=-.5\wd\pgfnodeparttextbox
+    }
+    \backgroundpath{
+        \pgfsetcolor{\ctikzvalof{color}}
+        \pgf@circ@scaled@Rlen=\scaledRlen
+
+        \northwest
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@right = -\pgf@x
+        \pgf@circ@res@left = \pgf@x
+
+        \pgfstartlinewidth=\pgflinewidth
+
+        % draw outer box
+        \pgf@circ@twoportbox
+
+        % draw inner stuff
+        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        \pgfsetarrows{-} %never draw arrows
+        \pgfsetlinewidth{\pgfstartlinewidth}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{0.5\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
+
+        \pgfusepath{draw}
+
+        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        % draw inner resisitors - european or american style is recognised
+        \foreach \respt/\resang/\linepta/\lineptb in %
+        { \pgfpoint{0.5\pgf@circ@res@right}{0pt}/90/%
+            \pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@up}/\pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@down},%
+          \pgfpoint{0}{0.25\pgf@circ@res@up}/25/%
+            \pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@up}/\pgfpoint{0.5\pgf@circ@res@left}{0},%
+          \pgfpoint{0}{0.25\pgf@circ@res@down}/-25/%
+            \pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@down}/\pgfpoint{0.5\pgf@circ@res@left}{0}}
+        {
+            {
+                \pgftransformshift{\respt}
+                \pgftransformrotate{\resang}
+
+                % calculate size of resistor
+                \ifpgf@circuit@europeanresistor
+                    \pgfmathparse{\pgf@circ@res@up / \pgf@circ@scaled@Rlen / \ctikzvalof{bipoles/generic/width} / 2}
+                    \pgftransformscale{\pgfmathresult}
+                    \pgfnode{genericshape}{center}{}{wilk@int@R}{\pgfusepath{fill}}
+                \else
+                    \pgfmathparse{\pgf@circ@res@up / \pgf@circ@scaled@Rlen / \ctikzvalof{bipoles/resistor/width} / 2}
+                    \pgftransformscale{\pgfmathresult}
+                    \pgfnode{resistorshape}{center}{}{wilk@int@R}{\pgfusepath{fill}}
+                \fi
+            }
+
+            \pgfpathmoveto{\linepta}
+            \pgfpathlineto{\pgfpointanchor{wilk@int@R}{right}}
+
+            \pgfpathmoveto{\pgfpointanchor{wilk@int@R}{left}}
+            \pgfpathlineto{\lineptb}
+            \pgfusepath{draw}
+        }
+    }
+}
+
 %% couplers generics
 \long\def\pgfcircdeclarefourport#1#2{
 


### PR DESCRIPTION
Adds a resistive splitter. I've basically just copied the wilkinson divider code and added two resistors. It looks like this:

![splitter](https://user-images.githubusercontent.com/7377393/94630906-eae45e80-027b-11eb-8e76-3487c446b920.png)

The code could be cleaned up a bit (i.e., put the repeat parts in a loop), but I wanted to get your opinion on adding this node before doing that. I've used a "delta" splitter (see [here](https://www.microwaves101.com/encyclopedias/resistive-power-splitters)) as a generic splitter symbol. We could also use separate delta and wye splitters, which would involve moving some of the internal graphics for the wye splitter, but shouldn't be too tough. Anyway let me know your thoughts.