### PR TITLE
* Version 1.2.4 (2020-10-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.2.4 (unreleased)
+* Version 1.2.4 (2020-10-04)
 
-    - Bumped version number
     - several documentation enhancment
     - added a couple of block elements: allpass filter, generic two-sides block (suggested by user `@myzinsky`)
     - added transmission gate (only IEEE style version) suggested by several users (`@SJulianS` on github, Philipp Birkl on `TeX.SX`)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.4-unreleased}
-\def\pgfcircversiondate{2020/08/08}
+\def\pgfcircversion{1.2.4}
+\def\pgfcircversiondate{2020/10/04}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.4-unreleased}
-\def\pgfcircversiondate{2020/08/08}
+\def\pgfcircversion{1.2.4}
+\def\pgfcircversiondate{2020/10/04}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
    - several documentation enhancment
    - added a couple of block elements: allpass filter, generic two-sides block
      (suggested by user `@myzinsky`)
    - added transmission gate (only IEEE style version) suggested by several users
      (`@SJulianS` on github, Philipp Birkl on `TeX.SX`)
    - added a resistive splitter block symbol by `@matthuszagh`
    - added depletion-type `nmosd` and `pmosd` MOSFET simplified symbols
    - added depletion-type `nfetd` and `pfetd` for plain full-symbol MOSFET