### PR TITLE
Fix a bug in "raised" voltage positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The major changes among the different circuitikz versions are listed here. See <
 * Version 1.2.5 (unreleased)
 
     - added macro to access labels and annotations anchors and direction
+    - fixed a bug in "raised" voltages' positions with `invert` and/or `mirror`
 
 * Version 1.2.4 (2020-10-04)
 

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -177,7 +177,7 @@
         \fi
         \ifpgf@circuit@bipole@voltage@raised
             \def\pgf@circ@bipole@voltage@label@anchor{center}
-            \pgfmathsetlength{\absvshift}{\absvshift+height{"Q"}} % with the current font.
+            \pgfmathsetlength{\absvshift}{\absvshift+sign(\absvshift)*height{"Q"}} % with the current font.
         \fi
     }
     % %\pgf@circ@Rlen/\ctikzvalof{current arrow scale} is equal to the length of the currarrow


### PR DESCRIPTION
There was a (not so) subtle error in `raised` voltage positioning with inverted bipoles:

```latex
\documentclass[border=10pt]{standalone}
\usepackage[siunitx, RPvoltages]{circuitikz}
\begin{document}
\begin{circuitikz}[
    ]
    \ctikzset{voltage=raised}
    \draw (0,1) to[pD*, v_=$v_d$, invert] ++(0,-2) to[R, v^=$v_d$, invert, ] ++(0,-2);
    \draw (1,0) to[pD*, v_=$v_d$, invert, mirror] ++(2,0);
    \draw (1,-2) to[sV, v_=$v_d$, invert] ++(2,0);

    \foreach \ang in {0,45,...,359} {
        \draw (7,0) ++(\ang:1) to[pD*, v_>=$v_{\ang}$, invert] ++(\ang:3);
    };
\end{circuitikz}
\end{document}
```

would compile to

![image](https://user-images.githubusercontent.com/6414907/95898013-b4840480-0d8e-11eb-9297-3a456f0f88e6.png)

(Notice the voltage labels!)

With this patch, this is fixed:

![image](https://user-images.githubusercontent.com/6414907/95898116-d7aeb400-0d8e-11eb-81fc-20b3c1efa751.png)
