### PR TITLE
Prepare release 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.2.5 (unreleased)
+* Version 1.2.5 (2020-10-14)
+
+    Mainly a bugfix release fir `raised` voltage style.
 
     - added macro to access labels and annotations anchors and direction
     - fixed a bug in "raised" voltages' positions with `invert` and/or `mirror`

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.5-unreleased}
-\def\pgfcircversiondate{2020/10/07}
+\def\pgfcircversion{1.2.5}
+\def\pgfcircversiondate{2020/10/14}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.5-unreleased}
-\def\pgfcircversiondate{2020/10/07}
+\def\pgfcircversion{1.2.5}
+\def\pgfcircversiondate{2020/10/14}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
* Version 1.2.5 (2020-10-14)

    Mainly a bugfix release fir `raised` voltage style.

    - added macro to access labels and annotations anchors and direction
    - fixed a bug in "raised" voltages' positions with `invert`
      and/or `mirror`