### PR TITLE
Fix typo in the manual

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -6413,7 +6413,7 @@ Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{
 \end{LTXexample}
 
 
-If you want to have more access to the label positioning algorithm, since \texttt{1.2.5} you can access the label  rotation using with the command \texttt{\textbackslash ctikzgetrotation\{\emph{nodename}\}} (where node name is for example \texttt{L1label} or \texttt{L2annotation}), and the anchor used for positioning the node as \texttt{\textbackslash ctikzgetanchor\{\emph{component label}\}\{\emph{type}\}}, where \emph{component label} is, for example, \texttt{L1} and type is either \texttt{label} or \texttt{annotation} (notice that the syntax is slightly different, for implementation reasons).
+If you want to have more access to the label positioning algorithm, since \texttt{1.2.5} you can access the label  rotation using with the command \texttt{\textbackslash ctikzgetdirection\{\emph{nodename}\}} (where node name is for example \texttt{L1label} or \texttt{L2annotation}), and the anchor used for positioning the node as \texttt{\textbackslash ctikzgetanchor\{\emph{component label}\}\{\emph{type}\}}, where \emph{component label} is, for example, \texttt{L1} and type is either \texttt{label} or \texttt{annotation} (notice that the syntax is slightly different, for implementation reasons).
 Those values are available only if the dipole declares a \texttt{l} or \texttt{a} keys; if you want them without any label you need to declare a blank one (like for example \texttt{l=\textasciitilde}).
 The following example gives an idea of the values of those macro for the three types of label positioning strategies.
 


### PR DESCRIPTION
Thanks to @judober --- Fixes #448 

![image](https://user-images.githubusercontent.com/6414907/97597207-df648e80-1a05-11eb-890d-f1aa5f1197b4.png)
