### PR TITLE
Release version 1.2.6 (2020-12-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.2.6 (unreleased)
+* Version 1.2.6 (2020-12-16)
+
+    The highlight of this release is the option to draw circles around transistors; moreover, a handful of new component and several bug fixes.
 
     - added option to have transistors with circles, suggested by user `@myzinsky`
     - added closed position for normally open button and the other way around (suggested by user `@septatrix`)
@@ -15,7 +17,7 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 1.2.5 (2020-10-14)
 
-    Mainly a bugfix release fir `raised` voltage style.
+    Mainly a bugfix release for `raised` voltage style.
 
     - added macro to access labels and annotations anchors and direction
     - fixed a bug in "raised" voltages' positions with `invert` and/or `mirror`

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.6-unreleased}
-\def\pgfcircversiondate{2020/10/15}
+\def\pgfcircversion{1.2.6}
+\def\pgfcircversiondate{2020/12/16}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.6-unreleased}
-\def\pgfcircversiondate{2020/10/15}
+\def\pgfcircversion{1.2.6}
+\def\pgfcircversiondate{2020/12/16}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
The highlight of this release is the option to draw circles around
transistors; moreover, a handful of new component and several bug fixes.

- added option to have transistors with circles, suggested by user
`@myzinsky`
- added closed position for normally open button and the other way
around (suggested by user `@septatrix`)
- added a `tip` anchor for push buttons
- added text anchor for legacy `linestub` component
- added an option for a different style of european logic xnor port
(suggested by user `@Schlepptop`)
- added dynode tubes electrodes (suggested by user `@ferdymercury`)
- fixed a bug in style-files (thanks to user `@Alex` on
`tex.stackexchange.com`)
- added a comment about relative coords (thanks to user
`@septatrix`)
- several fixes to the manual
