### PR TITLE
Release v1.2.7 (2020/12/27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.2.7 (2020-12-27)
+
+    Bugfix release: you *must* upgrade if you upgrade TikZ.
+
+    - The recent upgrade to TikZ to v3.1.8a to fix `circuitikz` issue 460 uncovered a problem in `circuitikz` itself that _seems_ fixed now.
+
 * Version 1.2.6 (2020-12-16)
 
     The highlight of this release is the option to draw circles around transistors; moreover, a handful of new component and several bug fixes.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1123,9 +1123,17 @@ The above diagram has been obtained with the code:
 As \href{https://github.com/circuitikz/circuitikz/issues/460}{noticed by user \texttt{septatrix}}, although relative coordinates after a component work as expected when using \texttt{++(x,y)}-style coordinates,
 that is not true for the \texttt{+(x,y)}-style coordinates (which are supposed to set a temporary relative coordinate and then going back to the starting point).
 
-This behavior, although not optimal, is shared with complex \texttt{to} operation in plain \TikZ{}, as you can see from the example below (notice the blue curve using a spline line). In the last (green) example, you can see a workaround using local path and the key \texttt{current point is local}.
+This behavior, although not optimal, was standard in \texttt{to} operation in plain \TikZ{} \textbf{before release 3.1.8a}; it was fixed by Henri Menke at this version. Notice that the fix revealed a problem in \Circuitikz{}, so if you use a version of \TikZ{} newer than 3.1.7 you \textbf{must} use a \Circuitikz{} at least at \texttt{v1.2.7}.
+
+
+You can see from the example below (notice the blue curve using a spline line). If all the vertical lines are at the left, the manual has been compiled with a new \Circuitikz{} an \TikZ. Otherwise, the red and/or blue curve will have the vertical line at the right (which in principle is wrong).
+
+In the last (green) example, you can see a workaround using local path and the key \texttt{current point is local} that will work for older (and do not create problem in newer) versions.
+
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily, pos=t]
+Plotted using Ti\emph{k}Z version \pgfversion{} and CircuitTi\emph{k}Z version \pgfcircversion{}.
+
 \begin{tikzpicture}
     \draw[color=red] (0,0) to[R] +(2,0) +(0,0) -- ++(0,-1);
 \end{tikzpicture}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -280,6 +280,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item Due to a bug fix in \TikZ{} that revealed a problem in \Circuitikz, you \textbf{must} upgrade to v1.2.7 or newer if you use a \TikZ{} newer than 3.1.8a.
     \item After v1.2.1: \textbf{Important:} the routine that implement the \texttt{to[...]} component positioning has been rewritten. That should enhance the line joins in path, and it's safer, but it can potentially change behavior.
 
         One of the changes is that the previous routine did the wrong thing if you used \texttt{(node) to[...]} (you should use an anchor or a coordinate, not a node there --- like \texttt{(node.anchor) to[...]}).

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.2.6}
-\def\pgfcircversiondate{2020/12/16}
+\def\pgfcircversion{1.2.7}
+\def\pgfcircversiondate{2020/12/27}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -158,11 +158,11 @@
     \drawpoles
     \pgf@circ@ifkeyempty{bipole/label/name}\else\pgf@circ@drawlabels{label}\fi
     \pgf@circ@ifkeyempty{bipole/annotation/name}\else\pgf@circ@drawlabels{annotation}\fi
-    \ifpgfcirc@has@v\pgf@circ@drawvoltage\fi
-    % \pgf@circ@ifkeyempty{bipole/current/label/name}\else\pgf@circ@drawcurrent\fi
-    \ifpgfcirc@has@i\pgf@circ@drawcurrent\fi
-    % \pgf@circ@ifkeyempty{bipole/flow/label/name}\else\pgf@circ@drawflow\fi
-    \ifpgfcirc@has@f\pgf@circ@drawflow\fi
+    % the following  must be made in their own path scope to avoid crash for TikZ>=3.1.8
+    % it should be logically safe for older version too
+    {\ifpgfcirc@has@v\pgf@circ@drawvoltage\fi}
+    {\ifpgfcirc@has@i\pgf@circ@drawcurrent\fi}
+    {\ifpgfcirc@has@f\pgf@circ@drawflow\fi}
     % finish the path from the component to the final target
     % you never know --- re-set \pgf@temp to detect open
     \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.2.6}
-\def\pgfcircversiondate{2020/12/16}
+\def\pgfcircversion{1.2.7}
+\def\pgfcircversiondate{2020/12/27}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Bugfix release: you *must* upgrade if you upgrade TikZ.
    
- The recent upgrade to TikZ to v3.1.8a to fix `circuitikz` issue #460
   uncovered a problem in `circuitikz` itself that _seems_ fixed now.

Fixes #460 