### PR TITLE
Release v1.2.7 (2020/12/27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ The major changes among the different circuitikz versions are listed here. See <
 
 * Version 1.2.7 (2020-12-27)
 
-    Bugfix release: you *must* upgrade if you upgrade TikZ.
+    Bugfix release.
 
-    - The recent upgrade to TikZ to v3.1.8a to fix `circuitikz` issue 460 uncovered a problem in `circuitikz` itself that _seems_ fixed now.
+    - The recent temporary changes to TikZ to v3.1.8a revealed a problem in corner cases with `circuitikz` that should be fixed (thanks to Henri Menke)
 
 * Version 1.2.6 (2020-12-16)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -280,7 +280,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
-    \item Due to a bug fix in \TikZ{} that revealed a problem in \Circuitikz, you \textbf{must} upgrade to v1.2.7 or newer if you use a \TikZ{} newer than 3.1.8a.
+    \item Due to a bug fix in \TikZ{} that revealed a problem in \Circuitikz, you \textbf{must} upgrade to v1.2.7 or newer if you use a \TikZ{} 3.1.8 or 3.1.8a (the change in \TikZ{} has been reverted later).
     \item After v1.2.1: \textbf{Important:} the routine that implement the \texttt{to[...]} component positioning has been rewritten. That should enhance the line joins in path, and it's safer, but it can potentially change behavior.
 
         One of the changes is that the previous routine did the wrong thing if you used \texttt{(node) to[...]} (you should use an anchor or a coordinate, not a node there --- like \texttt{(node.anchor) to[...]}).
@@ -1124,8 +1124,7 @@ The above diagram has been obtained with the code:
 As \href{https://github.com/circuitikz/circuitikz/issues/460}{noticed by user \texttt{septatrix}}, although relative coordinates after a component work as expected when using \texttt{++(x,y)}-style coordinates,
 that is not true for the \texttt{+(x,y)}-style coordinates (which are supposed to set a temporary relative coordinate and then going back to the starting point).
 
-This behavior, although not optimal, was standard in \texttt{to} operation in plain \TikZ{} \textbf{before release 3.1.8a}; it was fixed by Henri Menke at this version. Notice that the fix revealed a problem in \Circuitikz{}, so if you use a version of \TikZ{} newer than 3.1.7 you \textbf{must} use a \Circuitikz{} at least at \texttt{v1.2.7}.
-
+This behavior, although not optimal, was standard in \texttt{to} operation in plain \TikZ{}; it was shortly changed by Henri Menke in 3.1.8 version but later reverted. Notice that the change revealed a problem in \Circuitikz{} that should hopefully fixed in \texttt{v1.2.7}.
 
 You can see from the example below (notice the blue curve using a spline line). If all the vertical lines are at the left, the manual has been compiled with a new \Circuitikz{} an \TikZ. Otherwise, the red and/or blue curve will have the vertical line at the right (which in principle is wrong).
 

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -59,6 +59,30 @@
     }
 }
 
+%
+% expandable IF for the extra nodes (thanks to Henri Menke)
+% see https://chat.stackexchange.com/transcript/message/56560808#56560808
+%
+\def\pgfcirc@if@has@i{%
+    \ifpgfcirc@has@i
+        \expandafter\pgfutil@firstoftwo
+    \else
+        \expandafter\pgfutil@secondoftwo
+    \fi}
+\def\pgfcirc@if@has@v{%
+    \ifpgfcirc@has@v
+        \expandafter\pgfutil@firstoftwo
+    \else
+        \expandafter\pgfutil@secondoftwo
+    \fi}
+\def\pgfcirc@if@has@f{%
+    \ifpgfcirc@has@f
+        \expandafter\pgfutil@firstoftwo
+    \else
+        \expandafter\pgfutil@secondoftwo
+    \fi}
+
+
 
 %% Generic bipole path
 \def\pgf@circ@bipole@path#1#2{
@@ -158,11 +182,12 @@
     \drawpoles
     \pgf@circ@ifkeyempty{bipole/label/name}\else\pgf@circ@drawlabels{label}\fi
     \pgf@circ@ifkeyempty{bipole/annotation/name}\else\pgf@circ@drawlabels{annotation}\fi
-    % the following  must be made in their own path scope to avoid crash for TikZ>=3.1.8
-    % it should be logically safe for older version too
-    {\ifpgfcirc@has@v\pgf@circ@drawvoltage\fi}
-    {\ifpgfcirc@has@i\pgf@circ@drawcurrent\fi}
-    {\ifpgfcirc@has@f\pgf@circ@drawflow\fi}
+    % the following  must be made in their own path scope to avoid crash in TikZ 3.1.8/3.1.8a
+    % it should be logically safe for older version too --- even if TikZ reverted the change
+    % use explandable ifs too, thanks to Henri Menke
+    {\pgfcirc@if@has@v{\pgf@circ@drawvoltage}{}}%
+    {\pgfcirc@if@has@i{\pgf@circ@drawcurrent}{}}%
+    {\pgfcirc@if@has@f{\pgf@circ@drawflow}{}}%
     % finish the path from the component to the final target
     % you never know --- re-set \pgf@temp to detect open
     \pgfextra{\def\pgf@temp{open}\def\pgf@circ@temp{#3}}


### PR DESCRIPTION
Release v1.2.7
Bugfix release.

    - The recent temporary changes to TikZ to v3.1.8a revealed a problem in corner cases with `circuitikz` that should be fixed (thanks to Henri Menke)


Also, apply the suggested change by Henri Menke
https://chat.stackexchange.com/transcript/message/56560808#56560808