### PR TITLE
Prepare for release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.0 (unreleased)
+* Version 1.3.0 (2021-01-19)
 
-    - Bumped minor version due to the big rewrite
-    - Fixed a long standing problem with labels and similar decoration with equal signs and commas
-    - Fixed a typo in manual (thanks to @muzimuzhi on GitHub)
+    - Fixed a long-standing problem with labels and similar decoration with equal signs and commas
+    - Fixed a typo in the manual (thanks to @muzimuzhi on GitHub)
     - The Mother of All Code Refactoring: no real changes (modulo errors)
+    - Added a rollback point to 1.2.7
 
 * Version 1.2.7 (2020-12-27)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.0-unreleased}
-\def\pgfcircversiondate{2021/01/05}
+\def\pgfcircversion{1.3.0}
+\def\pgfcircversiondate{2021/01/19}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.0-unreleased}
-\def\pgfcircversiondate{2021/01/05}
+\def\pgfcircversion{1.3.0}
+\def\pgfcircversiondate{2021/01/19}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
* Version 1.3.0 (2021-01-19)

- Fixed a long-standing problem with labels and similar decoration with equal signs and commas
- Fixed a typo in the manual (thanks to @muzimuzhi on GitHub)
- The Mother of All Code Refactoring: no real changes (modulo errors)
- Added a rollback point to 1.2.7