### PR TITLE
Simplify circuit for style explanation

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1355,11 +1355,7 @@ You can change the visual appearance of a circuit by using a circuit style diffe
 
 Let's see the effect over a simple circuit\footnote{This is a just an example, the circuit is not intended to be functional.}.
 
-\def\killdepth#1{{\raisebox{0pt}[\height][0pt]{#1}}}
-\newcommand\bjtname[1]{($(#1.C)!0.5!(#1.E)$) node[anchor=west]{\killdepth{#1}} }
 \begin{lstlisting}[basicstyle=\scriptsize\ttfamily]
-\def\killdepth#1{{\raisebox{0pt}[\height][0pt]{#1}}}
-\newcommand\bjtname[1]{($(#1.C)!0.5!(#1.E)$) node[anchor=west]{\killdepth{#1}} }
 \begin{circuitikz}[american, cute inductors]
     \node [op amp](A1){\texttt{OA1}};
     \draw (A1.-) to[short] ++(0,1) coordinate(tmp) to[R, l_=$R$] (tmp -| A1.out) to[short] (A1.out);
@@ -1368,8 +1364,8 @@ Let's see the effect over a simple circuit\footnote{This is a just an example, t
     \draw (A1.-) to [L=$L$] ++(-2,0) coordinate(tmp) to[sV, l=$v_s$, fill=yellow] (tmp |-GND) node[ground]{};
     \draw (A1.out) to[R=$R_s$] ++(2,0) coordinate(bb) to[I, l_=$I_B$, invert] ++(0,2) node[vcc](VCC){};
     \draw (bb) to[D, l=$D$, *-] ++(0,-2) coordinate(bb1) to[R=$R_m$] ++(0,-2) node[vee](VEE){};
-    \draw (bb) --++(1,0) node[npn, anchor=B](Q1){} \bjtname{Q1};
-    \draw (bb1) --++(1,0) node[pnp, anchor=B](Q2){} \bjtname{Q2};
+    \draw (bb) --++(1,0) node[npn, anchor=B](Q1){Q1};
+    \draw (bb1) --++(1,0) node[pnp, anchor=B](Q2){Q2};
     \draw (Q1.E) -- (Q2.E) ($(Q1.E)!0.5!(Q2.E)$) to [short, *-o, name=S]  ++(2.5,0)
     node[right]{$v_{o_Q}$};
     \draw (S.s) to[european resistor, l=$Z_L$, *-] (S.s|-GND) node[ground]{};
@@ -1391,8 +1387,8 @@ This code, with the default parameters, will render like the following image.
     \draw (A1.-) to [L=$L$] ++(-2,0) coordinate(tmp) to[sV, l=$v_s$, fill=yellow] (tmp |-GND) node[ground]{};
     \draw (A1.out) to[R=$R_s$] ++(2,0) coordinate(bb) to[I, l_=$I_B$, invert] ++(0,2) node[vcc](VCC){};
     \draw (bb) to[D, l=$D$, *-] ++(0,-2) coordinate(bb1) to[R=$R_m$] ++(0,-2) node[vee](VEE){};
-    \draw (bb) --++(1,0) node[npn, anchor=B](Q1){} \bjtname{Q1};
-    \draw (bb1) --++(1,0) node[pnp, anchor=B](Q2){} \bjtname{Q2};
+    \draw (bb) --++(1,0) node[npn, anchor=B](Q1){Q1};
+    \draw (bb1) --++(1,0) node[pnp, anchor=B](Q2){Q2};
     \draw (Q1.E) -- (Q2.E) ($(Q1.E)!0.5!(Q2.E)$) to [short, *-o, name=S]  ++(2.5,0)
     node[right]{$v_{o_Q}$};
     \draw (S.s) to[european resistor, l=$Z_L$, *-] (S.s|-GND) node[ground]{};


### PR DESCRIPTION
Basically, now that transistor labels are placed reasonably, avoid
using personal macros to do it.

Thanks to tex.stackexchange.com user @Nicolas for raising it in https://tex.stackexchange.com/questions/581110/explanation-on-an-example-from-the-circuitikz-manual
