### PR TITLE
Remove warning on absence of voltage direction option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The major changes among the different circuitikz versions are listed here. See <
 * Version 1.3.1 (unreleased)
 
     - Fixed a bug in "fuse" and "afuse" fill
+    - Remove the voltage direction warning. Nobody really ever cared
 
 * Version 1.3.0 (2021-01-19)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -280,6 +280,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompabilitys between different version of circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than including a lot of switches and compatibility layers.
 You can check the used version at your local installation using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item Version 1.3.1 removes the warning if you do not specify a voltage direction.
     \item After 1.2.7 a big code reorganization (which by the way fixed some bug) has been made; no changes should be visible, but a fallback point at 1.2.7 has been added.
     \item You \textbf{must} upgrade to v1.2.7 or newer if you use a \TikZ{} 3.1.8 or 3.1.8a (but better upgrade both packages to the current version).
     \item After v1.2.1: \textbf{Important:} the routine that implement the \texttt{to[...]} component positioning has been rewritten. That should enhance the line joins in path, and it's safer, but it can potentially change behavior.
@@ -409,7 +410,7 @@ Feel free to load the package with your own cultural options:
                 \item \texttt{RPvoltages} (meaning Rising Potential voltages): the arrow is in direction of rising potential, like in \texttt{oldvoltagedirection}, but batteries and current sources are fixed to follow the passive/active standard;
                 \item \texttt{EFvoltages} (meaning Electric Field voltages): the arrow is in direction of the electric field, like in \texttt{nooldvoltagedirection}, but batteries are fixed;
             \end{itemize}
-            If none of these option are given, the package will default to \texttt{nooldvoltagedirection}, but will give a warning. The behavior is also selectable circuit by circuit with the \texttt{voltage dir} style.
+            If none of these option are given, the package will default to \texttt{nooldvoltagedirection}. The behavior is also selectable circuit by circuit with the \texttt{voltage dir} style.
         \item \texttt{betterproportions}\footnote{May change in the future!}: nicer proportions of transistors in comparision to resistors;
     \end{itemize}
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -354,17 +354,20 @@
 \fi
 
 %% This should be executed *after* all the options!
-\AtEndOfPackage{%
-\ifpgf@circ@explicitvdir\else
-    \PackageWarningNoLine{circuitikz}{%
-        You did not specify one of the voltage directions:\MessageBreak
-        \space\space    oldvoltagedirection, nooldvoltagedirection, \MessageBreak
-        \space\space    RPvoltages or EFvoltages \MessageBreak
-        Default directions may have changed, \MessageBreak
-        please check the manual%
-    }
-\fi
-}
+%
+% Remove the warning; nobody cares.
+%
+% \AtEndOfPackage{%
+% \ifpgf@circ@explicitvdir\else
+%     \PackageWarningNoLine{circuitikz}{%
+%         You did not specify one of the voltage directions:\MessageBreak
+%         \space\space    oldvoltagedirection, nooldvoltagedirection, \MessageBreak
+%         \space\space    RPvoltages or EFvoltages \MessageBreak
+%         Default directions may have changed, \MessageBreak
+%         please check the manual%
+%     }
+% \fi
+% }
 
 \newenvironment{circuitikz}{\begin{tikzpicture}}{\end{tikzpicture}}
 %override (unused) circuitikz environment for compability to externalization)


### PR DESCRIPTION
Really, nobody gave a^W^W noticed it.