### PR TITLE
Prepare for release 1.3.1 (2021-02-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.1 (unreleased)
+* Version 1.3.1 (2021-02-20)
 
     - Fixed a bug in "fuse" and "afuse" fill
     - Remove the voltage direction warning. Nobody really ever cared
+    - Minor fixes and enhancements to the manual
 
 * Version 1.3.0 (2021-01-19)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -13,7 +13,7 @@
 \NeedsTeXFormat{LaTeX2e}
 
 \def\pgfcircversion{1.3.1}
-\def\pgfcircversiondate{2021/01/22}
+\def\pgfcircversiondate{2021/02/20}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -11,7 +11,7 @@
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
 \def\pgfcircversion{1.3.1}
-\def\pgfcircversiondate{2021/01/22}
+\def\pgfcircversiondate{2021/02/20}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
- Fixed a bug in "fuse" and "afuse" fill
- Remove the voltage direction warning. Nobody really ever cared
- Minor fixes and enhancements to the manual