### PR TITLE
Version 1.3.2 (2021-03-14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different circuitikz versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.2 (unreleased)
+* Version 1.3.2 (2021-03-14)
 
     - Added the simplified (2-waves) highpass and lowpass blocks
     - Added graphene FETs (suggested by Cees Keyer)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.2-unreleased}
-\def\pgfcircversiondate{2021/03/11}
+\def\pgfcircversion{1.3.2}
+\def\pgfcircversiondate{2021/03/14}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.2-unreleased}
-\def\pgfcircversiondate{2021/03/11}
+\def\pgfcircversion{1.3.2}
+\def\pgfcircversiondate{2021/03/14}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
CTAN version 1.3.2 (2021-03-14)

- Added the simplified (2-waves) highpass and lowpass blocks
- Added graphene FETs (suggested by Cees Keyer)
- Added left/right anchors to transistors
- Fixed a bug in flip-flops (https://tex.stackexchange.com/q/587213/38080)