### PR TITLE
Add start and end arrow configurability for varibale bipoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.3.3 (unreleased)
 
-    - Added options to change arrow tips on variable resistors, inductors and capacitors
+    - Added options to change arrow tips on variable resistors, inductors and capacitor as well as in potentiometers
     - Added anchors to inductance to add core lines
-    - Fixed the default direction of tunable arrows (with an option to go back to old ones)
+    - Fixed the default direction of tunable arrows (with an option to go back to the old ones)
 
 * Version 1.3.2 (2021-03-14)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1740,15 +1740,19 @@ For the american style resistors, you can change the number of ``zig-zags'' by s
 \end{circuitikz}
 \end{LTXexample}
 
-\paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \texttt{bipoles/tunable arrow}  and in potentiometers with the key \texttt{bipoles/wiper arrow} (default \texttt{latexslim} for both). You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
+\paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \texttt{bipoles/tunable end arrow}  and in potentiometers with the key \texttt{bipoles/wiper end arrow} (default \texttt{latexslim} for both).
+Also you can change the start arrow with the corresponding \texttt{tunable start arrow} or \texttt{wiper start arrow} (default \texttt{\{\}} for both, which means no arrow).
+
+You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
 
 \begin{LTXexample}[varwidth, basicstyle=\small\ttfamily]
     \begin{circuitikz}[american]
-        % globally all the potentiometers
-        \ctikzset{bipoles/wiper arrow={Kite[open]}}
+        % globally all the potentiometrs
+        \ctikzset{bipoles/wiper end arrow={Kite[open]}}
         \draw (0,0) to[tgeneric] ++(2,0)
         % set locally on this variable resistor
-        to[vR, bipoles/tunable arrow={Bar}] ++(0,-2)
+        to[vR, bipoles/tunable end arrow={Stealth[red]},
+        bipoles/tunable start arrow={Bar}, invert] ++(0,-2)
         to[pR] ++(-2,0);
     \end{circuitikz}
 \end{LTXexample}
@@ -7672,7 +7676,7 @@ Version 1.3.3 fixes the direction of the arrows in tunable elements; before this
         \draw (0,-\i) node[left]{\texttt{\comp}} to[\comp, name=E] ++(2,0);
         \ctikzset{bipoles/fix tunable direction=false}
         \draw (3,-\i) to[\comp, name=E] ++(2,0);
-        \ctikzset{bipoles/fix tunable direction=true, bipoles/tunable arrow={Bar}}
+        \ctikzset{bipoles/fix tunable direction=true, bipoles/tunable end arrow={Bar}}
         \draw (6,-\i) to[\comp, name=E] ++(2,0);
     }
 \end{circuitikz}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -14,9 +14,19 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Generic macro and flags for bipoles %<<<
+% Fixing tunable directions
 \newif\ifpgf@circ@fixtunable@dir
 \ctikzset{bipoles/fix tunable direction/.is if=pgf@circ@fixtunable@dir}
 \ctikzset{bipoles/fix tunable direction=true}
+% tunable arrows
+\ctikzset{bipoles/tunable end arrow/.initial={latexslim}}
+\ctikzset{bipoles/tunable start arrow/.initial={}}
+\ctikzset{bipoles/wiper end arrow/.initial={latexslim}}
+\ctikzset{bipoles/wiper start arrow/.initial={}}
+\def\pgfcirc@set@arrow#1{%
+        \pgfsetarrowsend{\ctikzvalof{bipoles/#1 end arrow}}%
+        \pgfsetarrowsstart{\ctikzvalof{bipoles/#1 start arrow}}%
+}
 %>>>
 
 
@@ -112,9 +122,6 @@
 % crossing wires
 \ctikzset{bipoles/crossing/size/.initial=.2}
 
-% tunable arrows
-\ctikzset{bipoles/tunable arrow/.initial={latexslim}}
-\ctikzset{bipoles/wiper arrow/.initial={latexslim}}
 %%>>>
 
 %% Shapes for generic, resistives and wires components %<<<
@@ -280,7 +287,7 @@
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgf@circ@draworfill
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -509,7 +516,7 @@
     \endpgfscope
     \pgfscope
         %\pgfsetlinewidth{\pgfstartlinewidth}
-        \pgfsetarrowsend{\ctikzvalof{bipoles/wiper arrow}}
+        \pgfcirc@set@arrow{wiper}
         \pgfextractx{\pgf@circ@res@other}{\wiper}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-\pgf@circ@res@down}}
@@ -577,7 +584,7 @@
     \pgf@circ@zigzag{.5}
 
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@other}{\pgf@circ@res@up}}
@@ -615,7 +622,7 @@
 
     \pgfscope
         %\pgfsetlinewidth{\pgfstartlinewidth}
-        \pgfsetarrowsend{\ctikzvalof{bipoles/wiper arrow}}
+        \pgfcirc@set@arrow{wiper}
         \pgfextractx{\pgf@circ@res@other}{\wiper}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-\pgf@circ@res@down}}
@@ -878,7 +885,7 @@
     \pgfusepath{draw}
 
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
@@ -1222,7 +1229,7 @@
     {(\ctikzvalof{bipoles/vcuteinductor/width}*\scaledRlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/vcuteinductor/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/vcuteinductor/coils}/2}
 
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@right}{\pgf@circ@res@up}}
         \pgfusepath{draw}
@@ -1369,7 +1376,7 @@
     \pgfusepath{stroke}
 
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@left}{\pgf@circ@res@up}}
         \pgfusepath{draw}
@@ -1443,7 +1450,7 @@
     \pgfusepath{draw,fill}
 
     \pgfscope
-        \pgfsetarrowsend{\ctikzvalof{bipoles/tunable arrow}}
+        \pgfcirc@set@arrow{tunable}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@up}}


### PR DESCRIPTION
Rework the previous patch --- the `tunable arrows` key is no
longer working (anyway, I didn't release it...)

![image](https://user-images.githubusercontent.com/6414907/113412348-47097600-93b8-11eb-86de-8c250b3672ec.png)
