### PR TITLE
Better internal mechanism to select arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Added options to fine-tune the position of labels and annotations
     - Added options to change arrow tips on variable resistors, inductors and capacitor as well as in potentiometers
+    - Added options to change arrow tips on switches 
     - Added anchors to inductance to add core lines
     - Fixed the default direction of tunable arrows (with an option to go back to the old ones)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1740,19 +1740,19 @@ For the american style resistors, you can change the number of ``zig-zags'' by s
 \end{circuitikz}
 \end{LTXexample}
 
-\paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \texttt{bipoles/tunable end arrow}  and in potentiometers with the key \texttt{bipoles/wiper end arrow} (default \texttt{latexslim} for both).
-Also you can change the start arrow with the corresponding \texttt{tunable start arrow} or \texttt{wiper start arrow} (default \texttt{\{\}} for both, which means no arrow).
+\paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \texttt{tunable end arrow}  and in potentiometers with the key \texttt{wiper end arrow} (by default the key is the word ``\texttt{default}'' to obtain the default arrow, which is \texttt{latexslim} for both).
+Also you can change the start arrow with the corresponding \texttt{tunable start arrow} or \texttt{wiper start arrow} (the default value ``\texttt{default}'' is equivalent to \texttt{\{\}} for both, which means no arrow).
 
 You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
 
 \begin{LTXexample}[varwidth, basicstyle=\small\ttfamily]
     \begin{circuitikz}[american]
         % globally all the potentiometrs
-        \ctikzset{bipoles/wiper end arrow={Kite[open]}}
+        \ctikzset{wiper end arrow={Kite[open]}}
         \draw (0,0) to[tgeneric] ++(2,0)
         % set locally on this variable resistor
-        to[vR, bipoles/tunable end arrow={Stealth[red]},
-        bipoles/tunable start arrow={Bar}, invert] ++(0,-2)
+        to[vR, tunable end arrow={Stealth[red]},
+        tunable start arrow={Bar}, invert] ++(0,-2)
         to[pR] ++(-2,0);
     \end{circuitikz}
 \end{LTXexample}
@@ -7710,7 +7710,7 @@ Version 1.3.3 fixes the direction of the arrows in tunable elements; before this
         \draw (0,-\i) node[left]{\texttt{\comp}} to[\comp, name=E] ++(2,0);
         \ctikzset{bipoles/fix tunable direction=false}
         \draw (3,-\i) to[\comp, name=E] ++(2,0);
-        \ctikzset{bipoles/fix tunable direction=true, bipoles/tunable end arrow={Bar}}
+        \ctikzset{bipoles/fix tunable direction=true, tunable end arrow={Bar}}
         \draw (6,-\i) to[\comp, name=E] ++(2,0);
     }
 \end{circuitikz}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1824,6 +1824,8 @@ For historical reasons, \emph{chokes} comes only in the \texttt{cute}. You can u
 
 You can change the scale of the inductors by setting the key \texttt{inductors/scale}  to something different from the default \texttt{1.0}.
 
+Variable inductors arrow tips follow the settings  of resistors, see section~\ref{sec:tunablearrows}.
+
 You can change the width of these components (all the inductors together, unless you use style or scoping) by setting the key \texttt{inductors/width}  to something different from the default, which is  \texttt{0.8} for american and european inductors, and \texttt{0.6} for cute inductors.
 
 Moreover, you can change the number of ``coils'' drawn by setting the key
@@ -1854,7 +1856,6 @@ Moreover, you can change the number of ``coils'' drawn by setting the key
 \end{circuitikz}
 \end{LTXexample}
 
-Variable inductors arrow tips follow the settings  of resistors, see section~\ref{sec:tunablearrows}.
 
 \subsubsection{Inductors anchors}
 
@@ -4308,6 +4309,7 @@ while the node-style components are the single-pole, double-throw (\texttt{spdt}
     \circuitdesc{cute spdt down arrow}{Cute spdt down with arrow}{}
 \end{groupdesc}
 
+
 \paragraph{Cute switches anchors}
 
 The nodes-style switches have the following anchors:
@@ -4517,6 +4519,45 @@ Finally, the size can be changed using the parameter \texttt{tripoles/spdt/width
     \ctikzset{tripoles/spdt/width=1.6, fill=cyan,
         multipoles/rotary/shape=osquarepole}
     \draw (0,0) node[rotary switch ->](S2){};
+\end{circuitikz}
+\end{LTXexample}
+
+\subsubsection{Switch arrows\label{sec:switcharrows}}
+
+You can change the arrow tips used in all switches (traditional and ``cute'') with the key \texttt{switch end arrow} (by default the key is the word ``\texttt{default}'' to obtain the default arrow, which is \texttt{latexslim}).
+Also you can change the start arrow with the corresponding \texttt{switchable start arrow} or \texttt{wiper start arrow} (the default value ``\texttt{default}'' is equivalent to \texttt{\{\}}, which means no arrow). They keys are settable with \verb|\ctikzset| as with \verb|\tikzset| (to ease their usage in nodes).
+
+You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{circuitikz}
+    \draw (0,2) to[cspst] ++(2,0)
+        node[cute spdt up arrow, anchor=in]{};
+    \draw (0,0) to[cspst] ++(2,0)
+        node[cute spdt up arrow, anchor=in,
+        switch start arrow={Bar[red]},
+        switch end arrow={Triangle[blue]}]{};
+\end{circuitikz}
+\end{LTXexample}
+
+
+\paragraph{Rotary switch arrows.} You can change the rotary switch arrow shape in the same way as you change the ones in regular switches. Notice however that if you set either \texttt{switch end arrow} or \texttt{switch start arrow} they will be followed only if you have set both arrows with \texttt{<->} or equivalent, otherwise just one will be used.
+
+\begin{LTXexample}[varwidth=true, pos=t, basicstyle=\small\ttfamily]
+\begin{circuitikz}
+\ctikzset{multipoles/rotary/arrow=both}
+\draw (0,0) -- ++(1,0) node[rotary switch <-=8 in 120 wiper 40, anchor=in](A){};
+\draw (3,0) -- ++(1,0) node[rotary switch, anchor=in](B){}; % default values
+\draw (B.out 3) -- ++(1,0) node[rotary switch -=5 in 90 wiper 15, anchor=in](C){};
+\draw (C.out 3) -- ++(1,0) node[rotary switch ->, xscale=-1, anchor=out 3](D){};
+\ctikzset{switch end arrow={Triangle[blue]}}
+\ctikzset{switch start arrow={Bar[red]}}
+\begin{scope}[yshift=-2cm]
+    \draw (0,0) -- ++(1,0) node[rotary switch <-=8 in 120 wiper 40, anchor=in](A){};
+    \draw (3,0) -- ++(1,0) node[rotary switch, anchor=in](B){}; % default values
+    \draw (B.out 3) -- ++(1,0) node[rotary switch -=5 in 90 wiper 15, anchor=in](C){};
+    \draw (C.out 3) -- ++(1,0) node[rotary switch ->, xscale=-1, anchor=out 3](D){};
+\end{scope}
 \end{circuitikz}
 \end{LTXexample}
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -125,6 +125,12 @@
         \fi
 }
 
+\def\pgf@circ@declare@family@arrows#1{%
+    \ctikzset{#1 start arrow/.initial={default}}
+    \ctikzset{#1 end arrow/.initial={default}}
+    \tikzset{#1 start arrow/.style={\circuitikzbasekey/#1 start arrow={##1}}}
+    \tikzset{#1 end arrow/.style={\circuitikzbasekey/#1 end arrow={##1}}}
+}
 %%>>>
 
 %% Macros to do things depending on the class%<<<1

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -67,7 +67,9 @@
 \newdimen \pgfstartlinewidth
 %%>>>
 
-% arrow tips, ported over old arrows library (deprecated)%<<<1
+% arrow tips macros and utilities %<<<1
+
+% the default arrow is latexslim, which has been ported over old arrows library (deprecated)
 % see https://tex.stackexchange.com/questions/234084/latex-arrow-tip-with-arrows-meta-library
 % this was the original definition of latex' tips, renamed to avoid clashes
 %
@@ -99,6 +101,30 @@
 }
 
 \pgfarrowsdeclarereversed{latexslim reversed}{latexslim reversed}{latexslim}{latexslim}
+
+% select the arrows using available defaults.
+\def\pgfcirc@arrow@default{default}
+% choose the arrows to use. Use #2 and #3 if the key is equal to "default"
+% arguments: type, default start, default end
+\def\pgfcirc@set@arrows#1#2#3{%
+        \pgfkeysifdefined{\circuitikzbasekey/#1 start arrow}%
+            {\edef\@@start{\ctikzvalof{#1 start arrow}}}%
+            {\edef\@@start{\pgfcirc@arrow@default}}
+        \pgfkeysifdefined{\circuitikzbasekey/#1 end arrow}%
+            {\edef\@@end{\ctikzvalof{#1 end arrow}}}%
+            {\edef\@@end{\pgfcirc@arrow@default}}
+        \ifx\@@start\pgfcirc@arrow@default
+            \pgfsetarrowsstart{#2}%
+        \else
+            \pgfsetarrowsstart{\@@start}%
+        \fi
+        \ifx\@@end\pgfcirc@arrow@default
+            \pgfsetarrowsend{#3}%
+        \else
+            \pgfsetarrowsend{\@@end}%
+        \fi
+}
+
 %%>>>
 
 %% Macros to do things depending on the class%<<<1

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -18,15 +18,13 @@
 \newif\ifpgf@circ@fixtunable@dir
 \ctikzset{bipoles/fix tunable direction/.is if=pgf@circ@fixtunable@dir}
 \ctikzset{bipoles/fix tunable direction=true}
-% tunable arrows
-\ctikzset{bipoles/tunable end arrow/.initial={latexslim}}
-\ctikzset{bipoles/tunable start arrow/.initial={}}
-\ctikzset{bipoles/wiper end arrow/.initial={latexslim}}
-\ctikzset{bipoles/wiper start arrow/.initial={}}
-\def\pgfcirc@set@arrow#1{%
-        \pgfsetarrowsend{\ctikzvalof{bipoles/#1 end arrow}}%
-        \pgfsetarrowsstart{\ctikzvalof{bipoles/#1 start arrow}}%
-}
+% choosing several arrows
+\ctikzset{tunable end arrow/.initial={default}}
+\ctikzset{tunable start arrow/.initial={default}}
+\ctikzset{wiper end arrow/.initial={default}}
+\ctikzset{wiper start arrow/.initial={default}}
+\ctikzset{switch end arrow/.initial={default}}
+\ctikzset{switch start arrow/.initial={default}}
 %>>>
 
 
@@ -287,7 +285,7 @@
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgf@circ@draworfill
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -516,7 +514,7 @@
     \endpgfscope
     \pgfscope
         %\pgfsetlinewidth{\pgfstartlinewidth}
-        \pgfcirc@set@arrow{wiper}
+        \pgfcirc@set@arrows{wiper}{}{latexslim}
         \pgfextractx{\pgf@circ@res@other}{\wiper}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-\pgf@circ@res@down}}
@@ -584,7 +582,7 @@
     \pgf@circ@zigzag{.5}
 
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@other}{\pgf@circ@res@up}}
@@ -622,7 +620,7 @@
 
     \pgfscope
         %\pgfsetlinewidth{\pgfstartlinewidth}
-        \pgfcirc@set@arrow{wiper}
+        \pgfcirc@set@arrows{wiper}{}{latexslim}
         \pgfextractx{\pgf@circ@res@other}{\wiper}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-\pgf@circ@res@down}}
@@ -885,7 +883,7 @@
     \pgfusepath{draw}
 
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
@@ -1229,7 +1227,7 @@
     {(\ctikzvalof{bipoles/vcuteinductor/width}*\scaledRlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/vcuteinductor/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/vcuteinductor/coils}/2}
 
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@right}{\pgf@circ@res@up}}
         \pgfusepath{draw}
@@ -1376,7 +1374,7 @@
     \pgfusepath{stroke}
 
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@left}{\pgf@circ@res@up}}
         \pgfusepath{draw}
@@ -1450,7 +1448,7 @@
     \pgfusepath{draw,fill}
 
     \pgfscope
-        \pgfcirc@set@arrow{tunable}
+        \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}
             \pgfpathlineto{\pgfpoint{-.5\pgf@circ@res@left}{\pgf@circ@res@up}}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -19,12 +19,9 @@
 \ctikzset{bipoles/fix tunable direction/.is if=pgf@circ@fixtunable@dir}
 \ctikzset{bipoles/fix tunable direction=true}
 % choosing several arrows
-\ctikzset{tunable end arrow/.initial={default}}
-\ctikzset{tunable start arrow/.initial={default}}
-\ctikzset{wiper end arrow/.initial={default}}
-\ctikzset{wiper start arrow/.initial={default}}
-\ctikzset{switch end arrow/.initial={default}}
-\ctikzset{switch start arrow/.initial={default}}
+\pgf@circ@declare@family@arrows{tunable}
+\pgf@circ@declare@family@arrows{wiper}
+\pgf@circ@declare@family@arrows{switch}
 %>>>
 
 
@@ -3852,7 +3849,7 @@
         \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
         \pgfpathmoveto{\pgfpointpolar{90}{1.2\pgf@circ@res@right}}
         \pgfpatharc{90}{-20}{1.2\pgf@circ@res@right}
-        \pgfsetarrowsend{latexslim}
+        \pgfcirc@set@arrows{switch}{}{latexslim}
         \pgfsetbeveljoin
         \pgfusepath{draw}
     \endpgfscope
@@ -3876,7 +3873,7 @@
         \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}}
         \pgfpathmoveto{\pgfpointpolar{-10}{1.2\pgf@circ@res@right}}
         \pgfpatharc{-10}{90}{1.2\pgf@circ@res@right}
-        \pgfsetarrowsend{latexslim}
+        \pgfcirc@set@arrows{switch}{}{latexslim}
         \pgfsetbeveljoin
         \pgfusepath{draw}
     \endpgfscope
@@ -4134,7 +4131,7 @@
     \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % in node
     \pgfpathmoveto{\pgfpointpolar{70}{1.2\pgf@circ@res@right}}
     \pgfpatharc{70}{-10}{1.2\pgf@circ@res@right}
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{switch}{}{latexslim}
     \pgfusepath{draw}
     }
 
@@ -4146,7 +4143,7 @@
     \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % in node
     \pgfpathmoveto{\pgfpointpolar{-10}{1.2\pgf@circ@res@right}}
     \pgfpatharc{-10}{60}{1.2\pgf@circ@res@right}
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{switch}{}{latexslim}
     \pgfusepath{draw}
     }
 
@@ -4433,7 +4430,7 @@
     \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % in node
     \pgfpathmoveto{\pgfpointpolar{70}{1.5\pgf@circ@res@right}}
     \pgfpatharc{70}{-50}{1.5\pgf@circ@res@right}
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{switch}{}{latexslim}
     \pgfusepath{draw}
 }
 
@@ -4442,10 +4439,9 @@
 {
     \pgf@circ@setlinewidth{bipoles}{\pgflinewidth}
     \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % in node
-    \pgfsetarrowsstart{latexslim}
+    \pgfcirc@set@arrows{switch}{latexslim}{latexslim}
     \pgfpathmoveto{\pgfpointpolar{-60}{1.5\pgf@circ@res@right}}
     \pgfpatharc{-60}{60}{1.5\pgf@circ@res@right}
-    \pgfsetarrowsend{latexslim}
     \pgfusepath{draw}
 }
 
@@ -4456,7 +4452,7 @@
     \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % in node
     \pgfpathmoveto{\pgfpointpolar{-50}{1.5\pgf@circ@res@right}}
     \pgfpatharc{-50}{70}{1.5\pgf@circ@res@right}
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{switch}{}{latexslim}
     \pgfusepath{draw}
 }
 % %>>>

--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -730,13 +730,29 @@
 
         \ifpgf@circ@rotaryarrow
             \pgfscope % arrow
-                \ifpgf@circ@rotaryarrow@ccw\pgfsetarrowsstart{latexslim}\fi
+                \pgfcirc@set@arrows{switch}{\ifpgf@circ@rotaryarrow@ccw latexslim\fi}{\ifpgf@circ@rotaryarrow@cw latexslim\fi}
                 \pgf@circ@setlinewidth{bipoles}{\pgflinewidth}
                 \pgftransformshift{\pgfpoint{\pgf@circ@res@left}{0pt}} % center of cin node
                 \pgftransformrotate{\wiper}
                 \pgfpathmoveto{\pgfpointpolar{50}{1.0\pgf@circ@res@right}}
                 \pgfpatharc{50}{-50}{1.0\pgf@circ@res@right}
-                \ifpgf@circ@rotaryarrow@cw\pgfsetarrowsend{latexslim}\fi
+                \ifpgf@circ@rotaryarrow@ccw
+                    \ifpgf@circ@rotaryarrow@cw
+                        % both here, maintain values
+                        \relax
+                    \else
+                        % only ccw: remove end arrow
+                        \pgfsetarrowsend{}
+                    \fi
+                \else
+                    \ifpgf@circ@rotaryarrow@cw
+                        % only cw: remove start arrow
+                        \pgfsetarrowsstart{}
+                    \else
+                        % none: shouldn't happen
+                        \relax
+                    \fi
+                \fi
                 \pgfusepath{draw}
             \endpgfscope
         \fi


### PR DESCRIPTION
This allows for different categories default; for example, switches
can have different defaults for up/down/up&down arrows.
Generalize the macro and move it to pgfcirc.defines.tex

![image](https://user-images.githubusercontent.com/6414907/113475671-5b607800-9477-11eb-9e85-cd4bab236964.png)
