### PR TITLE
Prepare for CTAN release 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.3 (unreleased)
+* Version 1.3.3 (2021-04-04)
+
+    Several usability additions in this version, and one small fix that could
+    change the look of your circuit (without affecting correctness). Some of the
+    arrow shapes are now configurable.
 
     - Added options to fine-tune the position of labels and annotations
-    - Added options to change arrow tips on variable resistors, inductors and capacitor as well as in potentiometers
-    - Added options to change arrow tips on switches 
+    - Added options to change arrow tips on variable resistors, inductors and
+      capacitors as well as in potentiometers
+    - Added options to change arrow tips on switches
     - Added anchors to inductance to add core lines
-    - Fixed the default direction of tunable arrows (with an option to go back to the old ones)
+    - Fixed the default direction of tunable arrows (with an option to go back to
+      the old ones)
 
 * Version 1.3.2 (2021-03-14)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.3-unreleased}
-\def\pgfcircversiondate{2021/03/17}
+\def\pgfcircversion{1.3.3}
+\def\pgfcircversiondate{2021/04/04}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.3-unreleased}
-\def\pgfcircversiondate{2021/03/17}
+\def\pgfcircversion{1.3.3}
+\def\pgfcircversiondate{2021/04/04}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
First release in TeXLive 2021!

* Version 1.3.3 (2021-04-04)

Several usability additions in this version, and one small fix that could
change the look of your circuit (without affecting correctness). Some of the
arrow shapes are now configurable.

- Added options to fine-tune the position of labels and annotations
- Added options to change arrow tips on variable resistors, inductors and
  capacitors as well as in potentiometers
- Added options to change arrow tips on switches
- Added anchors to inductance to add core lines
- Fixed the default direction of tunable arrows (with an option to go back to
  the old ones)
