### PR TITLE
Add "modifier thickness" to R, L, and C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.3.4 (unreleased)
+
+    - Added separate configuration for the line thickness of resistors, capacitors, and inductors modifiers
+    - Fixed a bug in thermistor not respecting their class line thickness
+
 * Version 1.3.3 (2021-04-04)
 
     Several usability additions in this version, and one small fix that could

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1734,6 +1734,20 @@ For the american style resistors, you can change the number of ``zig-zags'' by s
 \end{circuitikz}
 \end{LTXexample}
 
+\paragraph{Thickness.}\label{sec:resistor-thickness} The line thickness of the resistive components is governed by the class thickness; you can change it assigning a value to the key \texttt{resistors/thickness} (default \texttt{none}, that means \texttt{bipoles/thickness} is used, and that defaults to \texttt{2.0}; the value is relative to the base line thickness).
+
+We can call \emph{modifiers} the elements that are added to the basic shape to express some characteristics of the component; for example the arrows for the variable resistors or the bar for the sensors. Normally the thickness of this elements is the same as the one chosen for the component\footnote{Due to a bug in versions before 1.3.4, that didn't happen for thermistors}. You can change their thickness with the class key \texttt{modifier thickness} which is relative to the main component thickness.
+
+\begin{LTXexample}[varwidth, basicstyle=\small\ttfamily]
+\begin{circuitikz}[american]
+    \draw (0,2) to[vR] ++(2,0) to[sR] ++(2,0);
+    \ctikzset{resistors/thickness=4}
+    \draw (0,1) to[vR] ++(2,0) to[sR] ++(2,0);
+    \ctikzset{resistors/modifier thickness=0.5}
+    \draw (0,0) to[vR] ++(2,0) to[sR] ++(2,0);
+\end{circuitikz}
+\end{LTXexample}
+
 \paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \texttt{tunable end arrow}  and in potentiometers with the key \texttt{wiper end arrow} (by default the key is the word ``\texttt{default}'' to obtain the default arrow, which is \texttt{latexslim} for both).
 Also you can change the start arrow with the corresponding \texttt{tunable start arrow} or \texttt{wiper start arrow} (the default value ``\texttt{default}'' is equivalent to \texttt{\{\}} for both, which means no arrow).
 
@@ -1777,7 +1791,7 @@ For capacitive sensors, see section~\ref{sec:sensors-anchors}.
 
 \subsubsection{Capacitors customizations}
 
-You can change the scale of the capacitors by setting the key \texttt{capacitors/scale}  to something different from the default \texttt{1.0}.
+You can change the scale of the capacitors by setting the key \texttt{capacitors/scale}  to something different from the default \texttt{1.0}. For thickness, you can use the same keys (applied to the \texttt{capacitors} class) as for resistors in~\ref{sec:resistor-thickness}.
 
 Variable capacitors arrow tips follow the settings  of resistors, see section~\ref{sec:tunablearrows}.
 
@@ -1816,7 +1830,7 @@ For historical reasons, \emph{chokes} comes only in the \texttt{cute}. You can u
 
 \subsubsection{Inductors customizations}\label{sec:tweak-l}
 
-You can change the scale of the inductors by setting the key \texttt{inductors/scale}  to something different from the default \texttt{1.0}.
+You can change the scale of the inductors by setting the key \texttt{inductors/scale}  to something different from the default \texttt{1.0}. For thickness, you can use the same keys (applied to the \texttt{inductors} class) as for resistors in~\ref{sec:resistor-thickness}.
 
 Variable inductors arrow tips follow the settings  of resistors, see section~\ref{sec:tunablearrows}.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.3}
-\def\pgfcircversiondate{2021/04/04}
+\def\pgfcircversion{1.3.4-unreleased}
+\def\pgfcircversiondate{2021/04/13}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -208,6 +208,17 @@
 }
 % use \pgf@circ@setlinewidth{none}{\pgflinewidth} if there is no legacy case
 \ctikzset{none/thickness/.initial=1.0} % do not touch
+
+% set thickness relative to current thickness if exists class and key
+\def\pgf@circ@set@relative@thickness#1{%
+    \ifdefined\ctikzclass
+        \pgfkeysifdefined{\circuitikzbasekey/\ctikzclass/#1}
+        {% yes, it's defined
+            \pgfsetlinewidth{\ctikzvalof{\ctikzclass/#1}\pgflinewidth}%
+        }{}
+    \fi
+}
+
 %%>>>
 
 %% font changes compatible with plain/LaTeX/ConTeXt%<<<1
@@ -635,14 +646,17 @@
 \ctikzset{resistors/scale/.initial=1.0}
 \ctikzset{resistors/fill/.initial=none}
 \ctikzset{resistors/thickness/.initial=none}
+\ctikzset{resistors/modifier thickness/.initial=1}% relative to main thickness
 
 \ctikzset{capacitors/scale/.initial=1.0}
 \ctikzset{capacitors/fill/.initial=none}
 \ctikzset{capacitors/thickness/.initial=none}
+\ctikzset{capacitors/modifier thickness/.initial=1}
 
 \ctikzset{inductors/scale/.initial=1.0}
 \ctikzset{inductors/fill/.initial=none}
 \ctikzset{inductors/thickness/.initial=none}
+\ctikzset{inductors/modifier thickness/.initial=1}
 
 \ctikzset{diodes/scale/.initial=1.0}
 \ctikzset{diodes/fill/.initial=none}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -22,6 +22,7 @@
 \pgf@circ@declare@family@arrows{tunable}
 \pgf@circ@declare@family@arrows{wiper}
 \pgf@circ@declare@family@arrows{switch}
+
 %>>>
 
 
@@ -282,6 +283,7 @@
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgf@circ@draworfill
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}
@@ -370,6 +372,8 @@
     \endpgfscope
 }
 
+
+
 %% Thermistor
 \pgfcircdeclarebipolescaled{resistors}
 {% anchor for labelling the type of dependency
@@ -385,18 +389,14 @@
 {\ctikzvalof{bipoles/thermistor/height}}
 {\ctikzvalof{bipoles/thermistor/width}}
 {
-    \pgfscope
     \pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\ctikzvalof{bipoles/thermistor/main}\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{-\ctikzvalof{bipoles/thermistor/main}\pgf@circ@res@up}}
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgf@circ@draworfill
-    \endpgfscope
-
-    %\pgfscope
+    \pgf@circ@set@relative@thickness{modifier thickness}
     \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{1.2\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{1.2\pgf@circ@res@down}}
     \pgfusepath{draw}
-    %\endpgfscope
 }
 
 %% Thermistor PTC
@@ -411,11 +411,12 @@
         \pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\ctikzvalof{bipoles/thermistorptc/main}\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{-\ctikzvalof{bipoles/thermistorptc/main}\pgf@circ@res@up}}
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgf@circ@draworfill
+        \pgf@circ@set@relative@thickness{modifier thickness}
+        \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{-\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@up}}
+        \pgfusepath{draw}
     \endpgfscope
-    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{-\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@up}}
-    \pgfusepath{draw}
 
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgftext[top,x=.85\pgf@circ@res@left,y=.75\pgf@circ@res@down]{\pgf@circ@font@tiny$\vartheta$}
@@ -440,12 +441,12 @@
         \pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\ctikzvalof{bipoles/thermistorntc/main}\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{-\ctikzvalof{bipoles/thermistorntc/main}\pgf@circ@res@up}}
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgf@circ@draworfill
+        \pgf@circ@set@relative@thickness{modifier thickness}
+        \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{-\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@up}}
+        \pgfusepath{draw}
     \endpgfscope
-
-    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{-\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{-\pgf@circ@res@up}}
-    \pgfusepath{draw}
 
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgftext[top,x=.85\pgf@circ@res@left,y=.75\pgf@circ@res@down]{\pgf@circ@font@tiny$\vartheta$}
@@ -472,12 +473,12 @@
         \pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\ctikzvalof{bipoles/varistor/main}\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{-\ctikzvalof{bipoles/varistor/main}\pgf@circ@res@up}}
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgf@circ@draworfill
+        \pgf@circ@set@relative@thickness{modifier thickness}
+        \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+        \pgfusepath{draw}
     \endpgfscope
-
-    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
-    \pgfusepath{draw}
 
     \pgftext[top,x=.65\pgf@circ@res@left,y=1.2\pgf@circ@res@down]{{\pgf@circ@font@tiny\textsf{U}}}
 }
@@ -579,6 +580,7 @@
     \pgf@circ@zigzag{.5}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
@@ -617,6 +619,7 @@
 
     \pgfscope
         %\pgfsetlinewidth{\pgfstartlinewidth}
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{wiper}{}{latexslim}
         \pgfextractx{\pgf@circ@res@other}{\wiper}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@up}}
@@ -642,6 +645,7 @@
     \pgf@circ@zigzag{.5}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@other}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-.9\pgf@circ@res@other}{\pgf@circ@res@down}}
@@ -770,6 +774,7 @@
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
     \pgfusepath{draw}
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfpathmoveto{\pgfpoint{2.6\pgf@circ@res@right}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-2.6\pgf@circ@res@right}{1.2\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-4.4\pgf@circ@res@right}{1.2\pgf@circ@res@down}}
@@ -880,6 +885,7 @@
     \pgfusepath{draw}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
@@ -1125,6 +1131,7 @@
     \pgfsetbeveljoin
     \pgfusepath{stroke}
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfpathmoveto{\pgfpoint{.8\pgf@circ@res@right}{2\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-.8\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-1.6\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
@@ -1224,6 +1231,7 @@
     {(\ctikzvalof{bipoles/vcuteinductor/width}*\scaledRlen+\pgfhorizontaltransformationadjustment\pgflinewidth+(\ctikzvalof{bipoles/vcuteinductor/coils}-1)*2*\pgf@circ@res@other)/\ctikzvalof{bipoles/vcuteinductor/coils}/2}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@right}{\pgf@circ@res@up}}
@@ -1320,6 +1328,7 @@
     \pgfsetbeveljoin
     \pgfusepath{stroke}
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfpathmoveto{\pgfpoint{.8\pgf@circ@res@right}{2\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-.8\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-1.6\pgf@circ@res@right}{2.6\pgf@circ@res@down}}
@@ -1371,6 +1380,7 @@
     \pgfusepath{stroke}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \pgfpathmoveto{\pgfpoint{.4\pgf@circ@res@left}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-.4\pgf@circ@res@left}{\pgf@circ@res@up}}
@@ -1412,12 +1422,13 @@
     \pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfusepath{draw,fill}
-    %\pgfscope
-    \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-2\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{2\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{2\pgf@circ@res@down}}
-    \pgfusepath{draw}
-    %\endpgfscope
+    \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
+        \pgfpathmoveto{\pgfpoint{-\pgf@circ@res@left}{-2\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{.4\pgf@circ@res@left}{2\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{2\pgf@circ@res@down}}
+        \pgfusepath{draw}
+    \endpgfscope
 }
 
 %% Generic full tunable
@@ -1445,6 +1456,7 @@
     \pgfusepath{draw,fill}
 
     \pgfscope
+        \pgf@circ@set@relative@thickness{modifier thickness}
         \pgfcirc@set@arrows{tunable}{}{latexslim}
         \ifpgf@circ@fixtunable@dir
             \pgfpathmoveto{\pgfpoint{.5\pgf@circ@res@left}{\pgf@circ@res@down}}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.3}
-\def\pgfcircversiondate{2021/04/04}
+\def\pgfcircversion{1.3.4-unreleased}
+\def\pgfcircversiondate{2021/04/13}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Also: Bumped version to 1.3.4-unreleased.

The thickness of the `thermistor*` components did not respect the class style. Corrected.

![image](https://user-images.githubusercontent.com/6414907/114555280-d25ff280-9c67-11eb-8fa5-2b84b5c96437.png)
