### PR TITLE
Fix clash of "label distance" with circuits.*

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -5874,7 +5874,7 @@ Notice though that in active component (sources of either voltage or current) th
 
 \paragraph{Adjust label and annotation position.}\label{sec:adjust-label-position}
 Normally the package will guess a good position for the label or annotation; if you do not like it,
-you can add\footnote{Since version \texttt{1.3.3}} (or remove, with negative values) distance using the keys \texttt{label position} and \texttt{annotation distance}.
+you can add\footnote{Since version \texttt{1.3.3}} (or remove, with negative values) distance using the \verb|\ctikzset| keys \texttt{label distance} and \texttt{annotation distance}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}

--- a/tex/pgfcirclabel.tex
+++ b/tex/pgfcirclabel.tex
@@ -32,8 +32,6 @@
 
 \ctikzset{label distance/.initial={0pt}}
 \ctikzset{annotation distance/.initial={0pt}}
-\tikzset{label distance/.code={\ctikzset{label distance={#1}}}}
-\tikzset{annotation distance/.code={\ctikzset{annotation distance={#1}}}}
 
 %% Options
 \ctikzset{label/.style = { l={#1} } }


### PR DESCRIPTION
Although compatibility is not guaranteed, that was an abuse
of the name space. Restrict the labels to the circuitikz/
subdomain only.

Fixes #519 