### PR TITLE
Really fix the copy-n-paste of example

### DIFF
--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -48,7 +48,7 @@
 \lstset{frameround=fttt}
 \lstloadlanguages{TeX}
 \lstset{pos=l,
-    % width=-99pt,
+    width=-99pt,
     overhang=0pt,
     hsep=\columnsep,
     vsep=\bigskipamount,
@@ -62,6 +62,10 @@
     numbersep=.3em,
     numberstyle=\tiny\emptyaccsupp,
     tabsize=3}
+% override explpreset to add the \emptyaccsupp macro
+\lstset{explpreset={numbers=left,numberstyle=\tiny\emptyaccsupp,numbersep=.3em,
+  xleftmargin=1em,columns=flexible,language=[LaTeX]TEX},pos=l,width=-99pt,
+  overhang=0pt,hsep=\columnsep,vsep=\bigskipamount,rframe=single}
 
 \newcommand{\email}[1]{\href{mailto:#1}{#1}}
 \long\def\comment#1{}


### PR DESCRIPTION
showexpl uses an "explpreset" setting that was resetting the
changes to "numberstyle".