### PR TITLE
CTAN release 1.3.5 (2021-05-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.5 (unreleased)
+* Version 1.3.5 (2021-05-02)
 
-    Power electronics devices are the main characters in this release: PUT, GTOs, a new style for thyristors.
-    Additionally, an **experimental** support for subcircuits has been added; it could change in future.
+    Power electronics devices are the main characters in this release: PUT, GTOs, a new style for thyristors, and a photovoltaic module.
+    Additionally, an **experimental** support for subcircuits has been added;
+    it could change in the future.
     Fixed a nasty bug in rotary switches "in" anchor positioning in some cases.
 
     - Added support for creating and using sub-circuits

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.5-unreleased}
-\def\pgfcircversiondate{2021/04/22}
+\def\pgfcircversion{1.3.5}
+\def\pgfcircversiondate{2021/05/02}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.5-unreleased}
-\def\pgfcircversiondate{2021/04/22}
+\def\pgfcircversion{1.3.5}
+\def\pgfcircversiondate{2021/05/02}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Power electronics devices are the main characters in this release: PUT,
GTOs, a new style for thyristors, and a photovoltaic module.
Additionally, an **experimental** support for subcircuits has been
added; it could change in the future.
Fixed a nasty bug in rotary switches "in" anchor positioning in some cases.

- Added support for creating and using sub-circuits
- Added UJT transistors and GTO devices
- Added (as an option) a different, more compact style for thyristor-type
  devices.
- Added a photovoltaic module
- Added a DC/DC converter block for symmetry
- Added the possibility to change the waveforms shown in the oscilloscope
- In the manual, separate the component usage chapter from the big
  component list
- Fix wrong rotary switch "in" anchors for switches with more
  than 180 degrees coverage