### PR TITLE
CTAN release 1.3.6 (2021-05-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* version 1.3.6 (unreleased)
+* version 1.3.6 (2021-05-09)
 
-    Mainly a bugfix release; fixing a bug in the `l2` stacked labels means that old constructs that were failing silently can give an error now. Sorry. To componsate, I added stacked annotation (for symmetry).
+    Mainly a bugfix release; fixing a bug in the `l2` stacked labels means that old constructs that were failing silently can give an error now. Sorry.
+    To compensate, I added stacked annotation (for symmetry).
 
     - Added stacked annotations for symmetry with stacked labels.
     - Fixed a bug in the plotting of `inst amp ra` terminals.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.6-unreleased}
-\def\pgfcircversiondate{2021/05/03}
+\def\pgfcircversion{1.3.6}
+\def\pgfcircversiondate{2021/05/09}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.6-unreleased}
-\def\pgfcircversiondate{2021/05/03}
+\def\pgfcircversion{1.3.6}
+\def\pgfcircversiondate{2021/05/09}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Mainly a bugfix release; fixing a bug in the `l2` stacked labels
means that old constructs that were failing silently can give an
error now. Sorry.
To compensate, I added stacked annotation (for symmetry).

- Added stacked annotations for symmetry with stacked labels.
- Fixed a bug in the plotting of `inst amp ra` terminals.
- Fixed a bug in managing stacked labels (`l2=...`); possibly it
  will be mildly backward-incompatible (please see the manual about
  incompatible changes)