### PR TITLE
* version 1.3.7 (2021-06-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* version 1.3.7 (unreleased)
+* version 1.3.7 (2021-06-01)
+
+    Minor release, mainly documentation upgrades.
 
     - New options for the line thickness, rotation and size of symbols drawn in sources
     - New tutorial:  drawing a circuit around an operational amplifier

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.7-unreleased}
-\def\pgfcircversiondate{2021/05/10}
+\def\pgfcircversion{1.3.7}
+\def\pgfcircversiondate{2021/06/01}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.7-unreleased}
-\def\pgfcircversiondate{2021/05/10}
+\def\pgfcircversion{1.3.7}
+\def\pgfcircversiondate{2021/06/01}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Minor release, mainly documentation upgrades.

- New options for the line thickness, rotation and size of symbols drawn in sources
- New tutorial:  drawing a circuit around an operational amplifier
- Documentation fixes and small enhancements