### PR TITLE
use pgfqkeys instead of pgfkeys

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -31,7 +31,7 @@
 
 \pgfkeys{\circuitikzbasekey/.is family}
 
-\def\circuitikzset#1{\pgfkeys{\circuitikzbasekey,#1}}
+\def\circuitikzset{\expandafter\pgfqkeys\expandafter{\circuitikzbasekey}}
 \let\ctikzset\circuitikzset
 \def\ctikzvalof#1{\pgfkeysvalueof{\circuitikzbasekey/#1}}
 \def\ctikzsetvalof#1#2{\pgfkeyssetvalue{\circuitikzbasekey/#1}{#2}}


### PR DESCRIPTION
This is just a one-line change, using `\pgfqkeys` instead of `\pgfkeys` for `\ctikzset`, making it considerably faster.