### PR TITLE
Make the PR tests more ecological

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ warnings_are_errors: false
 
 before_install:
   - sudo apt-get install -y build-essential texlive-xetex texlive-pictures texlive-science pandoc context
-  
+
 install: echo Installation step #do not remove this line!
 
-script: make manual-git
+script: tools/check.sh
 
 after_success: tools/deploy.sh
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ help:
 	@echo make manual: compile manual
 	@echo make ctan: create zip for ctan-upload
 
+# to check if it compiles, we do not need to fully build the manual; we save 2 compilation steps
+test-compile: changelog
+	cd doc; TEXINPUTS=.:../tex/: context circuitikz-context.tex
+	cd doc; TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) compatibility.tex
+	cd doc; TEXINPUTS=.:../tex/: xelatex $(XELATEXOPTIONS) circuitikzmanual.tex
+
+
 manual-git: flat
 	cp $(CTIKZ_GIT_FILENAME) doc/
 	#sed should only match first occurence in file, therefore the strange pattern

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+
+# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+	echo "Will skip deploy; just do a compile check."
+        make test-compile
+	exit 0
+fi
+#
+# if we arrive here, go on with full build
+#
+echo "Pushing to master, doing a full build"
+make manual-git
+exit 0
+
+


### PR DESCRIPTION
There is no need to do the full compilation of the manual
(three passes) if we do not pretend to deploy it.