### PR TITLE
CTAN release 1.3.8 (2021-06-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.8 (unreleased)
+* Version 1.3.8 (2021-06-15)
 
     The big news of this release is the ability to selectively draw the pins of the integrated circuit and mux-demuxes symbols.
 
     - Add `draw only pins` feature to `dipchip` and `qfpchip`, thanks to [Jonathan P. Spratte](https://github.com/circuitikz/circuitikz/pull/550), and a similar option to control the pins of `muxdemux`
     - Make `dipchip` and `qfpchip` respect `no input leads` option
+    - Several corrections to the manual
 
 * version 1.3.7 (2021-06-01)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.8-unreleased}
-\def\pgfcircversiondate{2021/06/05}
+\def\pgfcircversion{1.3.8}
+\def\pgfcircversiondate{2021/06/15}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.8-unreleased}
-\def\pgfcircversiondate{2021/06/05}
+\def\pgfcircversion{1.3.8}
+\def\pgfcircversiondate{2021/06/15}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
The big news of this release is the ability to selectively draw the pins
of the integrated circuit and mux-demuxes symbols.

- Add `draw only pins` feature to `dipchip` and `qfpchip`,
  thanks to Jonathan P. Spratte, and a similar option to control
  the pins of `muxdemux`
- Make `dipchip` and `qfpchip` respect `no input leads` option
- Several corrections to the manual