### PR TITLE
Preparation for CTAN release 1.3.9 (2012-06-27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.3.9 (unreleased)
+* Version 1.3.9 (2021-06-27)
+
+    Bugfix release: `open poles opacity` was not working in most of the cases.
 
     - minor fixes to the manual
+    - fix bug with `open poles opacity`; see [this question by Florian H.](https://tex.stackexchange.com/questions/602251/circuitikz-redefine-open-nodes-fill-key-to-fill-none-so-that-open-circuit) for details.
 
 * Version 1.3.8 (2021-06-15)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.9-unreleased}
-\def\pgfcircversiondate{2021/06/18}
+\def\pgfcircversion{1.3.9}
+\def\pgfcircversiondate{2021/06/27}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]


### PR DESCRIPTION
Bugfix release: `open poles opacity` was not working

- minor fixes to the manual
- fix bug with `open poles opacity`; for details see
  https://tex.stackexchange.com/a/602369/38080