### PR TITLE
Remove a wrong movement in the path implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.4.0 (unreleased)
+
+    A small but important change in the path (`to`) construction.
+
+    - bump version tp 1.4.0 (because I hate 1.3.10)
+    - remove a wrong movement in the path construction (potentially dangerous)
+
 * Version 1.3.9 (2021-06-27)
 
     Bugfix release: `open poles opacity` was not working in most of the cases.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -12,8 +12,8 @@
 
 \NeedsTeXFormat{LaTeX2e}
 
-\def\pgfcircversion{1.3.9}
-\def\pgfcircversiondate{2021/06/27}
+\def\pgfcircversion{1.4.0-unreleased}
+\def\pgfcircversiondate{2021/07/03}
 
 \ProvidesPackage{circuitikz}%
 [\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion]

--- a/tex/pgfcircpath.tex
+++ b/tex/pgfcircpath.tex
@@ -160,7 +160,7 @@
     \ifx\pgf@temp\pgf@circ@temp  % if it is an open do nothing
     \else
         % it is important to start the path with -- to have correct line joins!
-        -- (\tikztostart) -- (pgfcirc@anchorstartnode)
+        -- (pgfcirc@anchorstartnode)
     \fi
     % Add all the "ornaments": labels, annotations, voltages, currents and flows
     \drawpoles

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.3.9}
-\def\pgfcircversiondate{2021/06/27}
+\def\pgfcircversion{1.4.0-unreleased}
+\def\pgfcircversiondate{2021/07/03}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
This is quite scary, but the new Ti*k*Z reported:

        Package pgf Warning: Returning node center instead of a point on node
        border. Did you specify a point identical to the center of node ``a''?

...and it's right; removing the false movement fixes it.

Also bumped the version to 1.4.0