### PR TITLE
CTAN release 1.4.0 (2021-07-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.4.0 (unreleased)
+* Version 1.4.0 (2021-07-06)
 
     The main news is that *package rollback* for `circuitikz` has been implemented (LaTeX-only, of course).
-    Additionally, a small but important change in the path (`to`) construction.
+    Additionally, a small but important change in the path (`to`) construction that should fix some warning from Ti*k*Z
+    and give better line joins in wire corners.
 
     - bump version to 1.4.0
     - implement the version rollback: time travel to 0.4!

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -263,11 +263,19 @@ If you have older projects that show compatibility problems, you have two option
         \begin{lstlisting}[numbers=none]
             \usepackage[]{circuitikz}[=v0.8.3] % or v0.4, v0.6, ...
         \end{lstlisting}
-        If for whatever reasons your kernel is older, you can still use The old method of loading the \emph{package-version} package (like for example:
+        You can also specify a date instead of a version number: if you write
+        \begin{lstlisting}[numbers=none]
+            \usepackage[]{circuitikz}[=2020/02/05]
+        \end{lstlisting}
+        the rollback system will load the version that was current on February 5th,~2020 (in this case it will be \texttt{v1.0} which was released the day before).
+
+        If for whatever reasons your kernel is older, you can still use the old method of loading the \emph{package-version} package; for example:
         \begin{lstlisting}[numbers=none]
             \usepackage[]{circuitikz-0.8.3} % or circuitikz-0.4, 0.6...
         \end{lstlisting}
-        which is an inferior solution because it can fool any package you use that depend on `circuitikz`. Both ways, you have to take care of the options that may have changed between versions (and sometime syles, if you use them).
+        which is an inferior solution because it can fool any package you use that depend on \texttt{circuitikz}.
+
+        Both ways, you have to take care of the options that may have changed between versions (and sometime syles, if you use them).
     \item   if you are using  \ConTeXt, only versions \texttt{0.8.3}, \texttt{0.9.3},  \texttt{0.9.6}, \texttt{1.0}, \texttt{1.1.2} and \texttt{1.2.7} are packaged; if can use it with
         \begin{lstlisting}[numbers=none]
             \usemodule[circuitikz-0.8.3]

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.0-unreleased}
-\def\pgfcircversiondate{2021/07/03}
+\def\pgfcircversion{1.4.0}
+\def\pgfcircversiondate{2021/07/06}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.0-unreleased}
-\def\pgfcircversiondate{2021/07/03}
+\def\pgfcircversion{1.4.0}
+\def\pgfcircversiondate{2021/07/06}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
The main news is that *package rollback* for `circuitikz` has been
implemented (LaTeX-only, of course).  Additionally, a small but
important change in the path (`to`) construction that should fix some
warning from Ti*k*Z and give better line joins in wire corners.

- bump version to 1.4.0
- implement the version rollback: time travel to 0.4!
- remove a wrong movement in the path construction