### PR TITLE
Correction to the manual (doh!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.4.2 (unreleased)
+
+    - correct minor errors in the manual (capacitor's fill) and in the code.
+
 * Version 1.4.1 (2021-07-14)
 
     This version has an important bug fix for label positioning when once-relative style coordinates are used (the ones with a single `+`, like `+(1,1)`.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2087,11 +2087,11 @@ You can change that globally or locally, as ever. The tip specification is the o
 \subsubsection{Capacitors}
 
 \begin{groupdesc}
-    \circuitdescbip{capacitor}{Capacitor}{C}
-    \circuitdescbip[ccapacitor]{curved capacitor}{Curved (polarized) capacitor}{cC}
+    \circuitdescbip*{capacitor}{Capacitor}{C}
+    \circuitdescbip*[ccapacitor]{curved capacitor}{Curved (polarized) capacitor}{cC}
     \circuitdescbip*{ecapacitor}{Electrolytic capacitor}{eC,elko}
-    \circuitdescbip[vcapacitor]{variable capacitor}{Variable capacitor}{vC}
-    \circuitdescbip[capacitivesens]{capacitive sensor}{Capacitive sensor}{sC}(label/0/0.3)
+    \circuitdescbip*[vcapacitor]{variable capacitor}{Variable capacitor}{vC}
+    \circuitdescbip*[capacitivesens]{capacitive sensor}{Capacitive sensor}{sC}(label/0/0.3)
     \circuitdescbip*{piezoelectric}{Piezoelectric Element}{PZ}
     \circuitdescbip*[ferrocap]{feC}{Ferroelectric capacitor\footnotemark}{ferrocap}(kink left/180/0.2, kink right/0/0.2, curve left/160/0.3, curve right/-20/0.2, center/45/0.3)
     \footnotetext{suggested by \href{https://github.com/circuitikz/circuitikz/issues/515}{Mayeul Cantan}}

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.1}
-\def\pgfcircversiondate{2021/07/14}
+\def\pgfcircversion{1.4.2-unreleased}
+\def\pgfcircversiondate{2021/07/15}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/pgfcircutils.tex
+++ b/tex/pgfcircutils.tex
@@ -96,7 +96,7 @@
 %% changes suggested by Jonathan P. Spratte
 %%
 \newbox\ctikz@scratchbox
-\long\def\ctikzsubcircuitdef#1#2#3{%
+\pgfutil@protected\def\ctikzsubcircuitdef#1#2#3{%
     \expandafter\gdef\csname #1@Anchor\endcsname{}%
     \expandafter\gdef\csname #1@setanchors\endcsname{%
         \setbox\ctikz@scratchbox=\hbox{%

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.1}
-\def\pgfcircversiondate{2021/07/14}
+\def\pgfcircversion{1.4.2-unreleased}
+\def\pgfcircversiondate{2021/07/15}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Also, `\protect` (thanks Jonathan P. Spratte) `\ctikzsubcircuitdef`