### PR TITLE
Version 1.4.2 (2021-07-26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.4.2 (unreleased)
+* Version 1.4.2 (2021-07-26)
+
+    This is a minor release, containing just a new component and a
+    small set of fixes (mainly in the documentation).
 
     - add the `cpe` (constant phase element)
-    - correct minor errors in the manual (capacitor's fill, spaces) and in the code.
+    - correct minor errors in the manual (capacitor's fill, spaces)
+      and the code.
 
 * Version 1.4.1 (2021-07-14)
 
@@ -13,7 +17,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Added the generic tunable macro
     - Added `no v symbols` (and also for `i` and `f`), thanks to a [head-up by user judober on GitHub](https://github.com/circuitikz/circuitikz/issues/567), see also [issue 448](https://github.com/circuitikz/circuitikz/issues/448)
-    - Fixed [label position for +() style coordinates](https://github.com/circuitikz/circuitikz/issues/569) 
+    - Fixed [label position for +() style coordinates](https://github.com/circuitikz/circuitikz/issues/569)
 
 * Version 1.4.0 (2021-07-06)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.2-unreleased}
-\def\pgfcircversiondate{2021/07/15}
+\def\pgfcircversion{1.4.2}
+\def\pgfcircversiondate{2021/07/26}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.2-unreleased}
-\def\pgfcircversiondate{2021/07/15}
+\def\pgfcircversion{1.4.2}
+\def\pgfcircversiondate{2021/07/26}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
This is a minor release, containing just a new component and a
small set of fixes (mainly in the documentation).

- add the `cpe` (constant phase element)
- correct minor errors in the manual (capacitor's fill, spaces)
  and the code.