### PR TITLE
Fix a bug in `ooosource`: wrong anchor scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.4.3 (unreleased)
+
+    - added hidden anchors of `ooosource` to the manual
+    - fix a bug in anchors of `ooosource` (they did not respect class scaling)
+
 * Version 1.4.2 (2021-07-26)
 
     This is a minor release, containing just a new component and a

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2545,9 +2545,13 @@ Notice that if you choose the dashed style, the noise sources are fillable:
 		\footnotetext{Added by André Alves in \texttt{v1.3.5}}
     \circuitdescbip*[oosource]{ioosource}{Double Zero style current source}{}
     \circuitdescbip*[oosource]{voosource}{Double Zero style voltage source}{}
-    \circuitdescbip*[oosourcetrans]{oosourcetrans}{transformer source\footnotemark}{}
+    \circuitdescbip*[oosourcetrans]{oosourcetrans}{transformer source\footnotemark}{}(centerprim/90/0.3, centersec/-90/0.3)
         \footnotetext{The \texttt{oosourcetrans} and \texttt{ooosource} componentes have benn added by \href{https://github.com/circuitikz/circuitikz/pull/397}{user \texttt{@olfline} on GitHub}}.
-    \circuitdescbip*[ooosource]{ooosource}{transformer with three windings}{}(left/175/0.2, right/5/0.5, prim1/130/.2, prim2/-130/.2, sec1/45/.2, sec2/60/.2, sec3/90/.2, tert1/0/.2, tert2/-45/.2, tert3/-90/.2)
+    \begingroup
+        \ctikzset{sources/scale=1.5}
+        \circuitdescbip*[ooosource]{ooosource}{transformer with three windings\footnotemark}{}(left/175/0.2, right/5/0.7, prim1/130/.2, prim2/-130/.2, sec1/35/.2, sec2/60/.2, sec3/90/.2, tert1/0/.2, tert2/-45/.2, tert3/-90/.2, centerprim/92/0.8, centersec/35/0.9, centertert/-35/0.8)
+        \footnotetext{The component here is scaled up 1.5 times to better show the anchors.}
+    \endgroup
 \end{groupdesc}
 
 The transformer shapes vector group options can be specified for the primary (\texttt{prim=\emph{value}}), the secondary (\texttt{sec=\emph{value}}) and tertiary (\texttt{tert=\emph{value}}) three-phase vector groups: the value can be one of \texttt{delta}, \texttt{wye} and \texttt{zig}.
@@ -2582,7 +2586,7 @@ The size of the broken part of the DC current source is configurable by changing
 \paragraph{Size.}
 You can change the scale of the batteries by setting the key \texttt{batteries/scale}, for the controlled (dependent) sources with \texttt{csources/scale}, and for all the other independent sources and generators with \texttt{sources/scale}, to something different from the default \texttt{1.0}.
 
-Notice that the size of the double-circle sources (and of the triple-circle one) are tuned so that the full source occupy more or less the same horizontal space than one of the single-circle one; obviously, the circle are much smaller. If you want to have the same circle radius, you have to scale (locally!) those sources by one factor that is \texttt{1.5384} ($1/0.65$) for \texttt{oosource}, \texttt{1.6667} ($1/0.6$) for \texttt{oosourcetrans}, and \texttt{1.8182} ($1/0.55$) for \texttt{ooosource}.
+Notice that the size of the double-circle sources (and of the triple-circle one) are tuned so that the full source occupy more or less the same horizontal space than one of the single-circle one; as a consequence, the circles are much smaller. If you want to have the same circle radius, you have to scale (locally!) those sources by one factor that is \texttt{1.5384} ($1/0.65$) for \texttt{oosource}, \texttt{1.6667} ($1/0.6$) for \texttt{oosourcetrans}, and \texttt{1.8182} ($1/0.55$) for \texttt{ooosource}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.2}
-\def\pgfcircversiondate{2021/07/26}
+\def\pgfcircversion{1.4.3-unreleased}
+\def\pgfcircversiondate{2021/07/29}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2164,7 +2164,18 @@
 
 %% Independent double oo source
 \pgfcircdeclarebipolescaled{sources}
-{}
+{
+    \anchor{centerprim}{
+        \northeast
+        \pgf@y=0pt\relax
+        \pgf@x=-\ctikzvalof{bipoles/oosource/circleoffset}\pgf@x
+    }
+    \anchor{centersec}{
+        \northeast
+        \pgf@y=0pt\relax
+        \pgf@x=\ctikzvalof{bipoles/oosource/circleoffset}\pgf@x
+    }
+}
 {\ctikzvalof{bipoles/oosource/height}}
 {oosource}
 {\ctikzvalof{bipoles/oosource/height}}
@@ -2248,7 +2259,18 @@
 
 % % % % round three-phase transformer
 \pgfcircdeclarebipolescaled{sources}
-{}
+{
+    \anchor{centerprim}{
+        \northeast
+        \pgf@y=0pt\relax
+        \pgf@x=-\ctikzvalof{bipoles/oosourcetrans/circleoffset}\pgf@x
+    }
+    \anchor{centersec}{
+        \northeast
+        \pgf@y=0pt\relax
+        \pgf@x=\ctikzvalof{bipoles/oosourcetrans/circleoffset}\pgf@x
+    }
+}
 {\ctikzvalof{bipoles/oosourcetrans/height}}
 {oosourcetrans}
 {\ctikzvalof{bipoles/oosourcetrans/height}}
@@ -2330,18 +2352,20 @@
             \pgf@y=0pt
     }
     \savedanchor{\centerprim}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@scaled@Rlen
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@other
             \pgf@y=0pt
-            \pgf@x=.5\pgf@circ@scaled@Rlen
+            \pgf@x=.5\pgf@circ@res@other
     }
     \anchor{centerprim}{
             \centerprim
     }
     \savedanchor{\centersec}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@scaled@Rlen
-            \pgfpointpolar{60}{.5\pgf@circ@scaled@Rlen}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@other
+            \pgfpointpolar{60}{.5\pgf@circ@res@other}
             \pgf@y=-\pgf@y
             \pgf@x=-\pgf@x
     }
@@ -2349,9 +2373,10 @@
             \centersec
     }
     \savedanchor{\centertert}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@scaled@Rlen
-            \pgfpointpolar{60}{.5\pgf@circ@scaled@Rlen}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=-\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@other
+            \pgfpointpolar{60}{.5\pgf@circ@res@other}
             \pgf@y=\pgf@y
             \pgf@x=-\pgf@x
     }
@@ -2361,44 +2386,52 @@
 
     % add some anchors in case the are needed :)
     \anchor{prim1}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centerprim}{\pgfpointpolar{135}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centerprim}{\pgfpointpolar{135}{.5\pgf@circ@res@other}}
     }
     \anchor{prim2}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centerprim}{\pgfpointpolar{-135}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centerprim}{\pgfpointpolar{-135}{.5\pgf@circ@res@other}}
     }
     \anchor{sec1}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centersec}{\pgfpointpolar{0}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centersec}{\pgfpointpolar{0}{.5\pgf@circ@res@other}}
     }
     \anchor{sec2}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centersec}{\pgfpointpolar{45}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centersec}{\pgfpointpolar{45}{.5\pgf@circ@res@other}}
     }
     \anchor{sec3}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centersec}{\pgfpointpolar{90}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centersec}{\pgfpointpolar{90}{.5\pgf@circ@res@other}}
     }
     \anchor{tert1}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centertert}{\pgfpointpolar{0}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centertert}{\pgfpointpolar{0}{.5\pgf@circ@res@other}}
     }
     \anchor{tert2}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centertert}{\pgfpointpolar{-45}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centertert}{\pgfpointpolar{-45}{.5\pgf@circ@res@other}}
     }
     \anchor{tert3}{
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@Rlen
-            \pgf@circ@scaled@Rlen=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@scaled@Rlen
-            \pgfpointadd{\centertert}{\pgfpointpolar{-90}{.5\pgf@circ@scaled@Rlen}}
+            \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/height}\pgf@circ@scaled@Rlen
+            \pgf@circ@res@other=\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@other
+            \pgfpointadd{\centertert}{\pgfpointpolar{-90}{.5\pgf@circ@res@other}}
     }
 }
 {\ctikzvalof{bipoles/ooosource/height}}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.2}
-\def\pgfcircversiondate{2021/07/26}
+\def\pgfcircversion{1.4.3-unreleased}
+\def\pgfcircversiondate{2021/07/29}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Also: bump version, fix manual adding hidden anchors.
Add a couple of anchors to `ooosourcetrans`.

@olfline --- there was a misunderstanding on the usage of class scaling.
