### PR TITLE
Prepare for release 1.4.3 (2021-09-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.4.3 (unreleased)
+* Version 1.4.3 (2021-09-06)
+
+    Minor release, mainly a single bugfix.
 
     - added hidden anchors of `ooosource` to the manual
     - fix a bug in anchors of `ooosource` (they did not respect class scaling)
+    - faster `use fpu reciprocal` (thanks to Henri Menke)
 
 * Version 1.4.2 (2021-07-26)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.3-unreleased}
-\def\pgfcircversiondate{2021/07/29}
+\def\pgfcircversion{1.4.3}
+\def\pgfcircversiondate{2021/09/06}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.3-unreleased}
-\def\pgfcircversiondate{2021/07/29}
+\def\pgfcircversion{1.4.3}
+\def\pgfcircversiondate{2021/09/06}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Minor release, mainly a single bugfix.

- added hidden anchors of `ooosource` to the manual
- fix a bug in anchors of `ooosource` (they did not respect class scaling)
- faster `use fpu reciprocal` (thanks to Henri Menke)