### PR TITLE
Fix a typo in the manual

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -5872,8 +5872,8 @@ As you can see, in a void flip flop no external pins are drawn: you have to defi
 To define a specific flip-flop, you have to set a series of keys under the \verb|\ctikzset| directory \texttt{multipoles/flipflop/}, corresponding to pins \texttt{1}\dots \texttt{6}, \texttt{u} for ``up'' and \texttt{d} for ``down'':
 \begin{itemize}
     \item a \emph{text} value \texttt{t0}, \texttt{t1}, \dots \texttt{t6}, and \texttt{tu} and \texttt{td} (the last ones for up and down) which will set a label on the pin;
-    \item a \emph{clock wedge} flag (\texttt{c0}, \dots  \texttt{c6}, \texttt{cu}, \texttt{cd}), with value \texttt{0} or \texttt{1}, which will draw a triangle shape on the border of the correspondig pin;
-    \item a \emph{negation} flag (\texttt{n0}, \dots  \texttt{n6}, \texttt{nu}, \texttt{nd}),  with value \texttt{0} or \texttt{1}, which will put and \texttt{ocirc} shape on the outer border of the correspondig pin.
+    \item a \emph{clock wedge} flag (\texttt{c0}, \dots  \texttt{c6}, \texttt{cu}, \texttt{cd}), with value \texttt{0} or \texttt{1}, which will draw a triangle shape on the border of the corresponding pin;
+    \item a \emph{negation} flag (\texttt{n0}, \dots  \texttt{n6}, \texttt{nu}, \texttt{nd}),  with value \texttt{0} or \texttt{1}, which will put and \texttt{ocirc} shape on the outer border of the corresponding pin.
 \end{itemize}
 
 To set all this keys, an auxiliary style \texttt{flipflop def} is defined, so that you can do the following thing:


### PR DESCRIPTION
Just a small typo I notice while reading the manual. Didn't try running a typo checker through the whole file (although it may produce a lot of false positive)