### PR TITLE
Remove spurious character in TikZ environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     Important fix for ConTeXt users, thanks to @TeXnician for reporting.
 
     - Fixed a (silly) incompatibility introduced (by Romano) that made compilation in ConTeXt fail sometimes.
+    - Fixed stray characters in some Ti*k*Z environment 
 
 * Version 1.4.4 (2021-10-31)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -935,7 +935,8 @@ and you will obtain the following diagram with the exact same code (I just remov
         % and connect it
         % (not up) -- (#1-NOT.in) (#1-NOT.out) |- (#1-AND2.in 2)
         % with the new path-style not
-        to[inline not] (#1-in |- #1-AND2.in 2) -- (#1-AND2.in 2);
+        to[inline not] (#1-in |- #1-AND2.in 2) -- (#1-AND2.in 2)
+        % no ; to end the path, must add in usage!
 }
 \newcommand*{\fullcirc}[1][]{%
 \begin{circuitikz}
@@ -1070,7 +1071,7 @@ We will change the names of the nodes and the coordinates to be different for an
         (#1-FF.pin 3) -- (#1-FF.pin 3 -| #1-AND1.out)
         node[and port, anchor=out](#1-AND2){}
         (#1-AND1.in 1) to[short, -*] ++(-1,0) coordinate(#1-in)
-        to[inline not] (#1-in |- #1-AND2.in 2) -- (#1-AND2.in 2);
+        to[inline not] (#1-in |- #1-AND2.in 2) -- (#1-AND2.in 2)
 }
 \end{lstlisting}
 
@@ -4000,7 +4001,7 @@ For syntactical convenience standard transistors (not multi-terminal ones) can b
 \begin{circuitikz} \draw
   (0,0) node[njfet] {1}
   (-1,2) to[Tnjfet=2] (1,2)
-    to[Tnjfet=3, mirror] (3,2);
+    to[Tnjfet=3, mirror] (3,2)
 ;\end{circuitikz}
 \end{LTXexample}
 

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -158,7 +158,7 @@
 %                                    1 2 3 4   5 6 7   8
 \NewDocumentCommand{\circuitdescbip}{s o m d<> m m d() d[]}
 {%
-\index{#3} \tikz\foreach \i in {#6} {\index{\i|see{#3}} };
+\index{#3} \tikz{\foreach \i in {#6} {\index{\i|see{#3}} }}%
     \twopartbox{%
         \begin{circuitikz}
         \IfBooleanTF{#1}{%

--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -885,7 +885,7 @@
             \noexpand\pgf@circ@rotaryanchor{\the\pgf@circ@count@a}{0}{1}%
         }
         \expandafter\xdef\csname pgf@anchor@rotaryswitch@sqout\space\the\pgf@circ@count@a\endcsname{%
-            \noexpand\pgf@circ@rotarysqanchor{\the\pgf@circ@count@a}{0}%
+            \noexpand\pgf@circ@rotarysqanchor{\the\pgf@circ@count@a}%
         }
         \advance\pgf@circ@count@a by -1\relax%
         \repeatpgfmathloop%


### PR DESCRIPTION
They are creating warnings of "nullfont missing characters"