### PR TITLE
* Version 1.4.5 (2021-12-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.4.5 (unreleased)
+* Version 1.4.5 (2021-12-06)
 
     Important fix for ConTeXt users, thanks to @TeXnician for reporting.
 
-    - Fixed a (silly) incompatibility introduced (by Romano) that made compilation in ConTeXt fail sometimes.
+    - Fixed an incompatibility introduced with subcircuits that made compilation in ConTeXt fail
+    - Added `\ctikzflip[x][y]` utility macros for ConTeXt too
     - Fixed stray characters in some Ti*k*Z environment 
 
 * Version 1.4.4 (2021-10-31)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.4.5-unreleased}
-\def\pgfcircversiondate{2021/12/03}
+\def\pgfcircversion{1.4.5}
+\def\pgfcircversiondate{2021/12/06}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.4.5-unreleased}
-\def\pgfcircversiondate{2021/12/03}
+\def\pgfcircversion{1.4.5}
+\def\pgfcircversiondate{2021/12/06}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Important fix for ConTeXt users, thanks to @TheTeXnician  for reporting.

- Fixed an incompatibility introduced with subcircuits that made
  compilation in ConTeXt fail
- Added `\ctikzflip[x][y]` utility macros for ConTeXt too
- Fixed stray characters in some Ti*k*Z environment