### PR TITLE
Remove transparency groups from legacy TLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     Bump release version
 
+    - Fix bug with legacy transmission lines in `overlay`s ([noticed by Benedikt Wilde](https://github.com/circuitikz/circuitikz/issues/604))
+
 * Version 1.4.5 (2021-12-06)
 
     Important fix for ConTeXt users, thanks to @TeXnician for reporting.
 
     - Fixed an incompatibility introduced with subcircuits that made compilation in ConTeXt fail
     - Added `\ctikzflip[x][y]` utility macros for ConTeXt too
-    - Fixed stray characters in some Ti*k*Z environment 
+    - Fixed stray characters in some Ti*k*Z environment
 
 * Version 1.4.4 (2021-10-31)
 

--- a/tex/pgfcircmonopoles.tex
+++ b/tex/pgfcircmonopoles.tex
@@ -417,17 +417,18 @@
 {\ctikzvalof{bipoles/tline/width}}
 {
     \pgf@circ@res@step=.2\pgf@circ@res@right % half x axis
-    \begin{pgftransparencygroup}
+    \pgfscope
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+\pgf@circ@res@step}{\pgf@circ@res@up}}
         \pgfpatharc{-90}{90}{-\pgf@circ@res@step and -\pgf@circ@res@up}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{\pgf@circ@res@down}}
+        \pgfpatharc{-90}{90}{\pgf@circ@res@step and \pgf@circ@res@up}
         \pgf@circ@draworfill
-        \pgfpathellipse{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{0pt}}
-        {\pgfpoint{\pgf@circ@res@step}{0pt}}{\pgfpoint{0pt}{-\pgf@circ@res@up}}
-        \pgf@circ@draworfill
-    \end{pgftransparencygroup}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{\pgf@circ@res@up}}
+        \pgfpatharc{-90}{90}{-\pgf@circ@res@step and -\pgf@circ@res@up}
+        \pgfusepath{stroke}
+    \endpgfscope
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{0pt}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
@@ -488,18 +489,18 @@
         \pgf@circ@scaled@Rlen=\scaledRlen
         \pgf@circ@res@step=\ctikzvalof{bipoles/tline/width}\pgf@circ@scaled@Rlen
 
-        \pgfscope\begin{pgftransparencygroup}
-            \pgfpathellipse{\pgfpoint{0.5\pgf@circ@res@step}{0\pgf@circ@res@step}}{\pgfpoint{0.125\pgf@circ@res@step}{0\pgf@circ@res@step}}{\pgfpoint{0\pgf@circ@res@step}{0.25\pgf@circ@res@step}}
-            \pgf@circ@maybefill
+        \pgfscope
             \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@step}{0.25\pgf@circ@res@step}}
             \pgfpathlineto{\pgfpoint{1.5\pgf@circ@res@step}{0.25\pgf@circ@res@step}}
             \pgfpatharc{90}{-90}{0.125\pgf@circ@res@step and 0.25\pgf@circ@res@step}
             \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@step}{-0.25\pgf@circ@res@step}}
             \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
+            \pgfpatharc{90}{-90}{-0.125\pgf@circ@res@step and -0.25\pgf@circ@res@step}
             \pgf@circ@draworfill
-            \pgfpathellipse{\pgfpoint{0.5\pgf@circ@res@step}{0\pgf@circ@res@step}}{\pgfpoint{0.125\pgf@circ@res@step}{0\pgf@circ@res@step}}{\pgfpoint{0\pgf@circ@res@step}{0.25\pgf@circ@res@step}}
-            \pgfusepath{draw}
-        \end{pgftransparencygroup} \endpgfscope
+            \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@step}{0.25\pgf@circ@res@step}}
+            \pgfpatharc{90}{-90}{0.125\pgf@circ@res@step and 0.25\pgf@circ@res@step}
+            \pgfusepath{stroke}
+        \endpgfscope
         \pgfpathmoveto{\pgfpointorigin}
         \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@step}{0pt}}
         \pgfusepath{draw}


### PR DESCRIPTION
Transparency groups have strange interactions when used in `overlay` `tikzpictures`
You can see examples in https://tex.stackexchange.com/questions/577822/tikz-transparency-group-breaks-with-overlay and https://tex.stackexchange.com/questions/631395/circuitikz-doesnt-draw-transmission-line-with-overlay-option .
Remove them, they are not really needed.
Fixes #604