### PR TITLE
Fix position of "generic tunable arrows"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added connectors shapes, and included the BNC into that class; thanks to [Alexander Sauter for suggesting them and helping in the design](https://github.com/circuitikz/circuitikz/issues/611)
     - Added nullator and norator shapes, suggested by [user atticus-sullivan on GitHub](https://github.com/circuitikz/circuitikz/issues/615)
     - Fixed block/input arrow connection, thanks to [Laurenz Preindl for reporting](https://github.com/circuitikz/circuitikz/issues/613)
+    - Fixed a problem with generic tunable arrows, noticed thanks to [this question on TeX.SX](https://tex.stackexchange.com/q/637182/38080)
 
     Internal changes:
 

--- a/tex/pgfcircutils.tex
+++ b/tex/pgfcircutils.tex
@@ -397,7 +397,9 @@
         \n1 = {veclen(\x1,\y1)},
         \n2 = {atan2(\y2,\x2)} in
         % node[above]{\n1, \n2}
-        (#5.center) ++({\n2+(#4)}:{-0.5*(\n1)*(#3)}) -- ++({\n2+(#4)}:{(\n1)*(#3)});
+        % notice that some node has the "center" on one side, so
+        % midway from east to west is a safer bet for the center
+        ($(#5.west)!0.5!(#5.east)$) ++({\n2+(#4)}:{-0.5*(\n1)*(#3)}) -- ++({\n2+(#4)}:{(\n1)*(#3)});
     \endscope
 }
 \endinput


### PR DESCRIPTION
When the "center" anchor of the shape is not on the geometrical
center, the arrow was misplaced.