### PR TITLE
Modify example so that KCL box includes labels for all branch currents.

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -524,7 +524,7 @@ And finally, this is still \TikZ, so that you can freely mix other graphics elem
     \draw (2,3) -- (4,3)
     to[R=$R_2$, f>_=$i_2$]
     (4,0) to[short, -*] (2,0);
-    \draw[red, thick] (1.5,2.5) rectangle (4.5,3.5)
+    \draw[red, thick] (0.6,2.1) rectangle (4.2,3.8)
     node[pos=0.5, above]{KCL};
 \end{circuitikz}
 \end{LTXexample}


### PR DESCRIPTION
This proposed change really has nothing to do with circuitikz, but
with the intent of the example I propose modifying.

Since the whole point of KCL is to account for all currents
flowing into a node, expanding the box to include the current
labels seems pedagogically sound.