### PR TITLE
CTAN release 1.5.3 (2022-07-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.5.3 (unrelease)
+* Version 1.5.3 (2022-07-02)
+
+    Minor release: fixes to the manual, and a new component (Shockley diodes).
 
     - Merging changes to fix the language in the manual (thanks to Charles B. Cameron, user `@cameroncb1` on GitHub).
     - Added Shockley diode (suggested by [@dauph](https://tex.stackexchange.com/questions/646039/creating-a-shockley-diode-in-circuitikz)).

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.5.3-unreleased}
-\def\pgfcircversiondate{2022/05/29}
+\def\pgfcircversion{1.5.3}
+\def\pgfcircversiondate{2022/07/02}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.5.3-unreleased}
-\def\pgfcircversiondate{2022/05/29}
+\def\pgfcircversion{1.5.3}
+\def\pgfcircversiondate{2022/07/02}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Minor release: fixes to the manual, and a new component (Shockley diodes).

- Merging changes to fix the language in the manual
  (thanks to Charles B. Cameron, user `@cameroncb1` on GitHub).
- Added Shockley diode (suggested by
  [@dauph](https://tex.stackexchange.com/questions/646039/creating-a-shockley-diode-in-circuitikz)).