### PR TITLE
CTAN release 1.5.4 (2022-09-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.5.4 (unreleased)
+* Version 1.5.4 (2022-09-09)
+
+    New components and enhancement for old ones in this version.
 
     - Added jumpers, inspired by a question [on TeX.stackexchange](https://tex.stackexchange.com/questions/652494/drawing-jumper-pinhead-bridge-with-circuitikz)
     - Added generic double bipoles, inspired by user `@erwinderboer` [on GitHub](https://github.com/circuitikz/circuitikz/issues/641)
     - Added styling for the transistor bodydiode, suggested by user [Alex Ghilas on TeX.stackexchange](https://tex.stackexchange.com/questions/653348/drawing-mosfet-bodydiode-dashed)
-    - Addition to the manual (how to remove pins on amplifiers, for example)
+    - Additions to the manual (how to remove pins on amplifiers)
 
 * Version 1.5.3 (2022-07-02)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.5.4-unreleased}
-\def\pgfcircversiondate{2022/07/03}
+\def\pgfcircversion{1.5.4}
+\def\pgfcircversiondate{2022/09/09}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.5.4-unreleased}
-\def\pgfcircversiondate{2022/07/03}
+\def\pgfcircversion{1.5.4}
+\def\pgfcircversiondate{2022/09/09}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
New components and enhancements for old ones in this version.

- New components: jumpers, generic double bipoles
- Added styling for the transistor body diode
- Additions to the manual (how to remove pins on amplifiers)