### PR TITLE
Added styling for the "opto" arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.5.5 (unreleased)
 
+    - Added styling of arrows on opto devices, thanks to a suggestion by [Dr Matthias Jung](https://github.com/circuitikz/circuitikz/issues/655)
     - Documentation updates (rotating and flipping for path components)
 
 * Version 1.5.4 (2022-09-09)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2500,6 +2500,31 @@ You can change the direction of the LEDs and photodiodes' arrows by using the bi
     \end{circuitikz}
 \end{LTXexample}
 
+Since version \texttt{v1.5.5}\footnote{Thanks to the idea by \href{https://github.com/circuitikz/circuitikz/issues/655}{Dr. Matthias Jung on GitHub}.}, you can change the arrows used for LEDs, photodiodes and laser diodes with the generic arrows options shown in~\ref{sec:tunablearrows}, using the name \texttt{opto}, like in the following (overdone) example. Normally you want just to change the \texttt{end arrow}\dots
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{tikzpicture}[scale=0.8]
+\newcommand{\optos}{%
+    to[leD] ++(2,0) to[pD] ++(2,0)
+    to[lasD] ++(2,0)}
+\begin{scope}
+    \draw (0,2) \optos;
+    \ctikzset{led arrows from cathode}
+    \ctikzset{pd arrows to cathode}
+    \draw (0,0) \optos;
+\end{scope}
+\begin{scope}[color=blue, yshift=-4cm]
+    \ctikzset{opto end arrow={Triangle[angle'=45]}}
+    \ctikzset{opto start arrow={Hooks[red]}}
+    \draw (0,2) \optos;
+    \ctikzset{led arrows from cathode}
+    \ctikzset{pd arrows to cathode}
+    \draw (0,0) \optos;
+\end{scope}
+\end{tikzpicture}
+\end{LTXexample}
+
+
 \subsection{Sources and generators}
 
 Notice that source and generators are divided in three classes that can be styled independently: traditional battery symbols (class \texttt{batteries}), independent generators (class \texttt{sources}) and dependent generators (class \texttt{csources}). This is because they are often treated differently, and so you can choose to, for example, fill the dependent sources but not the independent ones.
@@ -3734,6 +3759,16 @@ If the option \texttt{arrowmos} is used (or after the command \verb!\ctikzset{tr
 You can go back to the no-arrows mos with \texttt{noarrowmos} locally or with
 \texttt{\textbackslash ctikzset\{tripoles/mos style/no arrows\}}.
 
+You can also change\footnote{Thanks to the idea by \href{https://github.com/circuitikz/circuitikz/issues/655}{Dr. Matthias Jung on GitHub}.} the type of the arrow for the ``light rays'' of the phototransistors with the generic arrows options shown in~\ref{sec:tunablearrows}, using the name \texttt{opto}, like in the following (overdone) example.
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{tikzpicture}
+    \draw (0,2) node[npn, photo]{} ++(2,0) node[pnp, photo]{};
+    \ctikzset{opto end arrow={Triangle[angle'=60]}}
+    \ctikzset{opto start arrow={Hooks[red]}}
+    \draw (0,0) node[npn, photo]{} ++(2,0) node[pnp, photo]{};
+\end{tikzpicture}
+\end{LTXexample}
 
 \paragraph{Circles.} Since \texttt{1.2.6}, you can add a circle\footnote{Suggested by Matthias Jung \href{https://github.com/circuitikz/circuitikz/issues/442}{on GitHub}} to most of the transistor shapes --- with the exception of multi-terminal (\texttt{bjtnpn} and \texttt{bjtpnp}, where it would be awkward anyway) and graphene FETs. The circle is intended in some case as the component's housing, and used to distinguish discrete components from integrated ones.
 

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -23,6 +23,7 @@
 \pgf@circ@declare@family@arrows{wiper}
 \pgf@circ@declare@family@arrows{switch}
 \pgf@circ@declare@family@arrows{gto gate}
+\pgf@circ@declare@family@arrows{opto}
 
 %>>>
 
@@ -3441,7 +3442,7 @@
 \def\pgf@circ@draw@ledarrows{%
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgf@circ@fill@strokecolor
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{opto}{}{latexslim}
     \ifpgf@led@fliparrows
         \pgfpathmoveto{\pgfpoint{0pt}{0.8\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-0.6\pgf@circ@res@right}{1.8\pgf@circ@res@up}}
@@ -3464,20 +3465,20 @@
 \def\pgf@circ@draw@pdarrows{%
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgf@circ@fill@strokecolor
-    \pgfsetarrowsstart{latexslim}
+    \pgfcirc@set@arrows{opto}{}{latexslim}
     \ifpgf@pd@fliparrows
-        \pgfpathmoveto{\pgfpoint{0pt}{0.8\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint{-0.6\pgf@circ@res@right}{1.8\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{-0.6\pgf@circ@res@right}{1.8\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0pt}{0.8\pgf@circ@res@up}}
         \pgfusepath{draw}
-        \pgfpathmoveto{\pgfpoint{0.6\pgf@circ@res@right}{0.6\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint{0pt}{1.6\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0pt}{1.6\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{0.6\pgf@circ@res@up}}
         \pgfusepath{draw}
     \else
-        \pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0.6\pgf@circ@res@right}{2\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{-0.4\pgf@circ@res@right}{\pgf@circ@res@up}}
         \pgfusepath{draw}
-        \pgfpathmoveto{\pgfpoint{0.2\pgf@circ@res@right}{0.8\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint{1.2\pgf@circ@res@right}{1.8\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{1.2\pgf@circ@res@right}{1.8\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0.2\pgf@circ@res@right}{0.8\pgf@circ@res@up}}
         \pgfusepath{draw}
     \fi
 }
@@ -3487,7 +3488,7 @@
 \def\pgf@circ@draw@laserarrows{%
     \pgfsetlinewidth{\pgfstartlinewidth}
     \pgf@circ@fill@strokecolor
-    \pgfsetarrowsend{latexslim}
+    \pgfcirc@set@arrows{opto}{}{latexslim}
     \pgfpathmoveto{\pgfpoint{-0.4\pgf@circ@res@right}{1.1\pgf@circ@res@up}}
     \pgfpathlineto{\pgfpoint{-0.4\pgf@circ@res@right}{2.1\pgf@circ@res@up}}
     \pgfusepath{draw}

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -4114,7 +4114,7 @@
         \ifpgf@circuit@bpt@drawphoto
             \pgfscope
                 \pgf@circ@fill@strokecolor
-                \pgfsetarrowsstart{latexslim}
+                \pgfcirc@set@arrows{opto}{}{latexslim}
                 \pgfpathmoveto{\pgfpointadd{\pgfpoint
                         {\ctikzvalof{tripoles/#1/base width}\pgf@circ@res@left}
                     {\pgf@circ@res@up+\pgf@circ@res@down}}


### PR DESCRIPTION
Now you can change the tips of LEDs, photodiodes, laser diodes and phototransistors.

Thanks to @myzinsky for the idea.
Fixes #655

![image](https://user-images.githubusercontent.com/6414907/196048720-08ecb997-9bba-4fc1-9bf4-c3f7e1f75b7b.png)
