### PR TITLE
Fix shape for long TL component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.5.6 (unreleased)
+
+    - Fix deformed shape for legacy `TL` component ([issue on GitHub](https://github.com/circuitikz/circuitikz/issues/664))
+
 * Version 1.5.5 (2022-11-12)
 
     New features for optoelectronic devices: a new component, arrow styling,

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.5.5}
-\def\pgfcircversiondate{2022/11/12}
+\def\pgfcircversion{1.5.6-unreleased}
+\def\pgfcircversiondate{2022/11/16}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -6509,8 +6509,6 @@
 \ctikzset{bipoles/lamp/width/.initial=.60}
 \ctikzset{bipoles/bulb/height/.initial=.8}
 \ctikzset{bipoles/bulb/width/.initial=.8}
-\ctikzset{bipoles/tline/height/.initial=.3}
-\ctikzset{bipoles/tline/width/.initial=.6}
 \ctikzset{bipoles/squid/height/.initial=.60}
 \ctikzset{bipoles/squid/width/.initial=.60}
 \ctikzset{bipoles/barrier/height/.initial=.60}

--- a/tex/pgfcircmonopoles.tex
+++ b/tex/pgfcircmonopoles.tex
@@ -410,6 +410,8 @@
 %>>>
 
 %% Node shapes for RF bipoles%<<<
+\ctikzset{bipoles/tline/height/.initial=.3}
+\ctikzset{bipoles/tline/width/.initial=.6}
 
 \pgfcircdeclarebipolescaled{RF}
 {}
@@ -418,7 +420,7 @@
 {\ctikzvalof{bipoles/tline/height}}
 {\ctikzvalof{bipoles/tline/width}}
 {
-    \pgf@circ@res@step=.2\pgf@circ@res@right % half x axis
+    \pgf@circ@res@step=.4\pgf@circ@res@up % the size of the ellipsis is proportional to the height
     \pgfscope
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right-\pgf@circ@res@step}{\pgf@circ@res@up}}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.5.5}
-\def\pgfcircversiondate{2022/11/12}
+\def\pgfcircversion{1.5.6-unreleased}
+\def\pgfcircversiondate{2022/11/16}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
Fixes #664

![image](https://user-images.githubusercontent.com/6414907/202152090-8093ef60-2fad-4b5b-89d7-c5426f1ddf60.png)

```latex
\documentclass[margin=2.178mm]{standalone}
\usepackage[RPvoltages]{circuitikz}
\usepackage{tikz}

\begin{document}
    \begin{circuitikz}[european]
        \draw (0,2) to[TL, bipoles/tline/width=0.2, l=TL\textsubscript{0.2}] ++(3,0);
        \draw (0,1) to[TL, l=TL] ++(3,0);
        \draw (0,0) to[TL, bipoles/tline/width=2, l=TL\textsubscript{2}] ++(3,0);
    \end{circuitikz}
\end{document}
```