### PR TITLE
Add `genericspliter` component and scale splitter using `/tripoles/splitter/*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added double gate MOS transistors (by Romano Giannetti)
     - Fix deformed shape for legacy `TL` component ([issue on GitHub](https://github.com/circuitikz/circuitikz/issues/664))
     - Added several anchors on variable components, suggested by [Dr Matthias Jung](https://github.com/circuitikz/circuitikz/issues/663)
+    - Added genericsplitter component (by [frankplow](github.com/frankplow))
 
 * Version 1.5.5 (2022-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added double gate MOS transistors (by Romano Giannetti)
     - Fix deformed shape for legacy `TL` component ([issue on GitHub](https://github.com/circuitikz/circuitikz/issues/664))
     - Added several anchors on variable components, suggested by [Dr Matthias Jung](https://github.com/circuitikz/circuitikz/issues/663)
-    - Added genericsplitter component (by [frankplow](github.com/frankplow))
+    - Added `genericsplitter` component (by [frankplow](github.com/frankplow))
+    - Fix - reshape `splitter` using `/tripoles/splitter/width` and `/tripoles/splitter/height` rather than `/tripoles/wilkinson/width` and `/tripoles/wilkinson/height`.
 
 * Version 1.5.5 (2022-11-12)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3431,7 +3431,7 @@ You can use the \texttt{plug center} anchor to add the IEC ``multiplier'':
     \circuitdesc*{wilkinson}{wilkinson divider}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
     \circuitdesc*{splitter}{resistive splitter\footnotemark}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
     \footnotetext{added by \texttt{matthuszagh}}
-    \circuitdesc*{genericsplitter}{generic splitter\footnotemark}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
+    \circuitdesc*{genericsplitter}{generic splitter\footnotemark}{$\SI{-3}{\deci\bel}$}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
     \footnotetext{added by \texttt{frankplow}}
     \circuitdesc*{gridnode}{gridnode\footnotemark}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
     \footnotetext{added by \texttt{olfline}}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3431,6 +3431,8 @@ You can use the \texttt{plug center} anchor to add the IEC ``multiplier'':
     \circuitdesc*{wilkinson}{wilkinson divider}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
     \circuitdesc*{splitter}{resistive splitter\footnotemark}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
     \footnotetext{added by \texttt{matthuszagh}}
+    \circuitdesc*{genericsplitter}{generic splitter\footnotemark}{}( in/180/0.1, out2/45/0.1, out1/-45/0.1 )
+    \footnotetext{added by \texttt{frankplow}}
     \circuitdesc*{gridnode}{gridnode\footnotemark}{}(left/135/0.2, right/45/0.2, center/-100/0.4, up/90/0.2, down/-45/.2)
     \footnotetext{added by \texttt{olfline}}
     \circuitdesc*{mzm}{Mach Zehnder Modulator\footnotemark}{}( in/180/0.1, mod/90/0.1, out/0/0.1)

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -1803,11 +1803,11 @@
     \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}}
     \savedanchor\northwest{%
         \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
-        \pgf@y=\ctikzvalof{tripoles/wilkinson/height}\pgf@circ@scaled@Rlen
+        \pgf@y=\ctikzvalof{tripoles/splitter/height}\pgf@circ@scaled@Rlen
         \pgf@y=.5\pgf@y
         \pgf@x= \pgf@circ@scaled@Rlen
         \pgf@x=.5\pgf@x
-        \pgf@x=-\ctikzvalof{tripoles/wilkinson/width}\pgf@x
+        \pgf@x=-\ctikzvalof{tripoles/splitter/width}\pgf@x
     }
     \pgfcirc@northwest@symmetric@geoanchors
     \anchor{center}{\pgfpointorigin}

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -564,6 +564,9 @@
 \ctikzset{tripoles/splitter/height/.initial=1.3}
 \ctikzset{tripoles/splitter/width/.initial=1.3}
 
+\ctikzset{tripoles/genericsplitter/height/.initial=1.3}
+\ctikzset{tripoles/genericsplitter/width/.initial=1.3}
+
 \ctikzset{tripoles/mzm/height/.initial=1.3}
 \ctikzset{tripoles/mzm/width/.initial=1.3}
 
@@ -1881,6 +1884,76 @@
             \pgfpathmoveto{\linepta}
             \pgfpathlineto{\pgfpointanchor{wilk@int@R}{right}}
             \pgfpathmoveto{\pgfpointanchor{wilk@int@R}{left}}
+            \pgfpathlineto{\lineptb}
+            \pgfusepath{draw}
+        }
+    }
+}
+
+%% generic splitter
+\pgfdeclareshape{genericsplitter}{
+    \savedmacro{\ctikzclass}{\edef\ctikzclass{blocks}}
+    \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}}
+    \savedanchor\northwest{%
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgf@y=\ctikzvalof{tripoles/genericsplitter/height}\pgf@circ@scaled@Rlen
+        \pgf@y=.5\pgf@y
+        \pgf@x= \pgf@circ@scaled@Rlen
+        \pgf@x=.5\pgf@x
+        \pgf@x=-\ctikzvalof{tripoles/genericsplitter/width}\pgf@x
+    }
+    \pgfcirc@northwest@symmetric@geoanchors
+    \anchor{center}{\pgfpointorigin}
+    \anchor{up}{\northwest\pgf@x=0pt}
+    \anchor{down}{\northwest\pgf@x=0pt\pgf@y=-\pgf@y}
+    \anchor{right}{\northwest\pgf@y=0pt\pgf@x=-\pgf@x}
+    \anchor{left}{\northwest\pgf@y=0pt}
+    \anchor{in}{\northwest\pgf@y=0pt}
+    \anchor{out1}{\northwest\pgf@x=-\pgf@x\pgf@y=-0.5\pgf@y}
+    \anchor{out2}{\northwest\pgf@x=-\pgf@x\pgf@y=0.5\pgf@y}
+    \anchor{left down}{\northwest\pgf@y=-0.5\pgf@y}
+    \anchor{right down}{\northwest\pgf@x=-\pgf@x\pgf@y=-0.5\pgf@y}
+    \anchor{right up}{\northwest\pgf@x=-\pgf@x\pgf@y=0.5\pgf@y}
+    \anchor{left up}{\northwest\pgf@y=0.5\pgf@y}
+    \anchor{text}{
+        \northwest
+        \pgf@y=-.5\ht\pgfnodeparttextbox
+        \pgf@x=-.2\wd\pgfnodeparttextbox
+    }
+    \pgf@circ@draw@component{
+        \pgf@circ@setcolor
+        \pgf@circ@scaled@Rlen=\scaledRlen
+        %
+        \northwest
+        \pgf@circ@res@up = \pgf@y
+        \pgf@circ@res@down = -\pgf@y
+        \pgf@circ@res@right = -\pgf@x
+        \pgf@circ@res@left = \pgf@x
+        %
+        \pgfstartlinewidth=\pgflinewidth
+        % draw outer box
+        \pgf@circ@twoportbox
+        \pgf@circ@inputarrow
+        % draw inner stuff
+        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        \pgfsetarrows{-} %never draw arrows
+        \pgfsetlinewidth{\pgfstartlinewidth}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+        \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{0.5\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@left}{0pt}}
+        \pgfpathmoveto{\pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0.5\pgf@circ@res@down}}
+        \pgfusepath{draw}
+        %
+        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        % draw inner resisitors - european or american style is recognised
+        \foreach \linepta/\lineptb in %
+        { \pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@up}/\pgfpoint{0.5\pgf@circ@res@left}{0},%
+          \pgfpoint{0.5\pgf@circ@res@right}{0.5\pgf@circ@res@down}/\pgfpoint{0.5\pgf@circ@res@left}{0}}
+        {
+            \pgfpathmoveto{\linepta}
             \pgfpathlineto{\lineptb}
             \pgfusepath{draw}
         }


### PR DESCRIPTION
This PR does two things:
1. (a64bcbcc0543ca0b1f2094255e92965d54897538) It adds a simpler splitter component, the `genericsplitter`. It looks like this:
<img width="165" alt="Screenshot 2022-12-07 at 18 43 59" src="https://user-images.githubusercontent.com/6375868/206270526-b9c3efd0-256f-480b-b9c3-342b635d953b.png">

2. (54c2c3984dabcf5d191fd58c9bdf9810d5497903) It scales the `splitter` component using the `/tripoles/splitter/width` and `/tripoles/splitter/height` rather than `/tripoles/wilkinson/width` and `/tripoles/splitter/height`. The `/tripoles/splitter/*` keys had already been added, so I think this was just a mistake left over from adapting the wilkinson component when creating the splitter component.