### PR TITLE
Prepare for CTAN release 1.6.0 (2022-12-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.0 (unreleased)
+* Version 1.6.0 (2022-12-10)
 
     The big change is the refactoring (and enhancement) of the block's code. In addition, double gate MOSes, several fixes all over the map, and quite a lot of anchors were added into the mix.
 
-    - Big change (most without effects, minus a couple of bug fixes) to the block's code.
+    - Big change (mostly backward compatible, minus a couple of bug fixes) to the block's code.
         - Now `vco` can be `box`ed
         - enabled more short-name geographical anchors
         - generic blocks can be made rectangular

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -215,6 +215,8 @@ Arrows with \texttt{to[]} components don't work, anyway, so basically avoid this
 
 Lastly, voltage styles interacts in strange ways with general (such as \texttt{american}, \texttt{european} style), in the sense that sometimes the order in which you enact them is important. That should be arguably fixed, but it will change (read break) a lot of existing code, so it'll stay;  more information and workarounds in section~\ref{sec:mixing-voltage-styles}.
 
+As a final notice, if you want to use the \texttt{externalize} library, do not use the \texttt{circuitikz} environment: use \texttt{tikzpicture} (which is really the same thing, see the FAQ~\ref{faqs:externalize}).
+
 \subsection{Scale factor inaccuracies}\label{sec:usefpu}
 
 Sometimes, when using fractional scaling factors and big values for the coordinates, the basic layer inaccuracies from \TeX{} can bite you, producing results like the following one:
@@ -247,6 +249,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompabilities between different version of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
 If unsure, you can check the version in your local installation by using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item Version \texttt{1.6.0} has a big rewrite of the block's code. In principle the changes are backward-compatible, but there were several bugs (wrong anchors, errors with rotations, and so on) that have been fixed in the process.
     \item Since \texttt{v1.5.1}\footnote{Do not use \texttt{v1.5.0}, it's buggy.} color management (see section~\ref{sec:colors}) and the details of how the shapes are drawn and protected by the external drawing options has changed. There should be no substantial changes to the circuits, though.
     \item The \TikZ{} fix for \texttt{to[...] +(x,y)} behavior (see~\ref{sec:path-relative-coordinates}) uncovered a bug in the positioning of the labels in \Circuitikz{} that had been present since \texttt{v0.8}. So you \textbf{must} upgrade to \texttt{v1.4.1} or better if you have \TikZ{} newer than \texttt{3.1.8} (and you want/need to use the \texttt{+(x,y)} syntax).
     \item There have been changes in (internal) parameters for capacitors in \texttt{v1.4.1}; now to change them you should use the style interface (see~\ref{sec:capacitors-styling}).

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.0-unreleased}
-\def\pgfcircversiondate{2022/12/04}
+\def\pgfcircversion{1.6.0}
+\def\pgfcircversiondate{2022/12/10}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.6.0-unreleased}
-\def\pgfcircversiondate{2022/12/04}
+\def\pgfcircversion{1.6.0}
+\def\pgfcircversiondate{2022/12/10}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
The big change is the refactoring (and enhancement) of the block's code. In addition, double gate MOSes, several fixes all over the map, and quite a lot of anchors were added into the mix.

- Big change (mostly backward compatible, minus a couple of bug fixes) to the block's code. 
    - Now `vco` can be `box`ed 
    - enabled more short-name geographical anchors 
    - generic blocks can be made rectangular 
    - mid-way lateral anchors for all blocks, as well as up/down 
    - renamed converters anchors (old ones retained for backward compatibility) 
    - new ac/ac blocks, both single- and three-phase
- Added double gate MOS transistors (by Romano Giannetti)
- Fix deformed shape for legacy `TL` component ([issue on GitHub](https://github.com/circuitikz/circuitikz/issues/664))
- Added several anchors on variable components, suggested by [Dr Matthias Jung](https://github.com/circuitikz/circuitikz/issues/663)
- Added `genericsplitter` component (by [frankplow](github.com/frankplow))
- Fix - `splitter` used the wrong parameters (from `wilkinson`)