### PR TITLE
Add configurable dashes to the dc symbols in converter blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.6.1 (unreleased)
+
+    - Add configurable dashes to the dc symbols in converter blocks (suggested by [user \texttt{@dbstf} on GitHub](https://github.com/circuitikz/circuitikz/issues/680))
+
 * Version 1.6.0 (2022-12-10)
 
     The big change is the refactoring (and enhancement) of the block's code. In addition, double gate MOSes, several fixes all over the map, and quite a lot of anchors were added into the mix.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3713,7 +3713,22 @@ Moreover, the key \texttt{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|), 
 \end{circuitikz}
 \end{LTXexample}
 
+\paragraph{Dashing the DC symbol in blocks.}
+The symbol for the DC side can be different across countries,\footnote{Head-up from \href{https://github.com/circuitikz/circuitikz/issues/680}{user \texttt{@dbstf} on GitHub}} with different kind of dashing on the bottom line.
+Moreover, sometimes the dashing is used to convey different meaning (like rectified sinusoidal or stabilized DC).
+You can change the general style for the DC symbol using the key \texttt{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \texttt{blocks dc in segments} and \texttt{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} option overrides these ones.
 
+\begin{LTXexample}[varwidth=true]
+\begin{tikzpicture}[scale=0.9]
+    \ctikzset{blocks dc segments=3}
+    \draw (0,2) to[sacdc] ++(2,0) to[sdcdc]
+        ++(2,0) to[sdcac] ++(2,0);
+    \ctikzset{blocks dc segments=1}
+    \draw (0,0) to[sacdc, blocks dc out segments=2]
+        ++(2,0) to[sdcdc, blocks dc in segments=2]
+        ++(2,0) to[sdcac] ++(2,0);
+\end{tikzpicture}
+\end{LTXexample}
 
 \subsection{Transistors}
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.0}
-\def\pgfcircversiondate{2022/12/10}
+\def\pgfcircversion{1.6.1}
+\def\pgfcircversiondate{2022/12/18}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -1065,12 +1065,30 @@
 }
 
 %% converters help function
+%% definition for styling the DC symbols (GitHub issue #680)
+\ctikzset{blocks dc in segments/.initial=1}
+\ctikzset{blocks dc out segments/.initial=1}
+\ctikzset{blocks dc segments/.code={%
+        \ctikzset{blocks dc in segments=#1}%
+        \ctikzset{blocks dc out segments=#1}%
+    }
+}
 \def\pgf@circ@twoport@converter@dc#1#2{%
     \pgfscope
     \pgftransformshift{\pgfpoint{#1\pgf@circ@res@step}{#2\pgf@circ@res@step}}
     \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfusepath{draw}
+    \ifpgf@circuit@full@dashed\else % do not apply the specific dash if fully dashing
+        \edef\@@up{\ctikzvalof{blocks dc in segments}}
+        \edef\@@down{\ctikzvalof{blocks dc out segments}}
+        \ifdim\dimexpr#1\pgf@circ@res@step\relax<0pt
+            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@up-2)}
+        \else
+            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@down-2)}
+        \fi
+        \pgfsetdash{{\pgf@circ@res@other}{\pgf@circ@res@other}}{0pt}
+    \fi
     \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
     \pgfusepath{draw}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -10,8 +10,8 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-\def\pgfcircversion{1.6.0}
-\def\pgfcircversiondate{2022/12/10}
+\def\pgfcircversion{1.6.1}
+\def\pgfcircversiondate{2022/12/18}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
suggested by user @dbstf on GitHub
Fixes #680

![image](https://user-images.githubusercontent.com/6414907/208318663-7ff69783-7029-4078-be9b-90ff45e1d0a0.png)
