### PR TITLE
Fix a typo (voilá -> voilà)

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -395,7 +395,7 @@ Feel free to load the package with your own cultural options:
         \item \texttt{compatibility}: makes it possibile to load \Circuitikz\ and \TikZ\ circuit library together.
         \item Voltage directions: until v0.8.3, there was an error in the coherence between american and european voltages styles (see section~\ref{curr-and-volt}) for the batteries. This has been fixed, but to guarantee backward compatibility and to avoid nasty surprises, the fix is available with new options:
             \begin{itemize}
-                \item \texttt{oldvoltagedirection}: Use old way of voltage direction having a difference between european and american direction, with wrong default labelling for batteries;
+                \item \texttt{oldvoltagedirection}: Use old way of voltage direction having a difference between european and american direction, with wrong default labeling for batteries;
                 \item \texttt{nooldvoltagedirection}: The standard from 0.5 onward, utilizes the (German?) standard of voltage arrows in the  direction of electric fields (without fixing batteries);
                 \item \texttt{RPvoltages} (meaning Rising Potential voltages): the arrow is in the direction of rising potential, like in \texttt{oldvoltagedirection}, but batteries and current sources are fixed to follow the passive/active standard;
                 \item \texttt{EFvoltages} (meaning Electric Field voltages): the arrow is in the direction of the electric field, like in \texttt{nooldvoltagedirection}, but batteries are fixed;
@@ -2721,7 +2721,7 @@ These are special elements used in some approaches to model ideal amplifiers\foo
 \circuitdescbip*{norator}{Norator element (admits any combination of V and I)}{}
 \end{groupdesc}
 
-They are in the \texttt{sources} class, but they are not treated like sources in the labelling sense (they have both \texttt{bipoles/is voltage=false} and \texttt{bipoles/is current=false}, see~\ref{sec:source-vif}).
+They are in the \texttt{sources} class, but they are not treated like sources in the labeling sense (they have both \texttt{bipoles/is voltage=false} and \texttt{bipoles/is current=false}, see~\ref{sec:source-vif}).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american]
@@ -4151,7 +4151,7 @@ You can create completely ``bare'' transistors (without the connection leads to 
 \subsubsection{Transistor circle customization}\label{sec:trans-circle-custom}
 
 \paragraph{Position and size.} You can see in the following diagram where the circle is positioned --- when there is no bodydiode, it will pass through the anchors for the body diode and near the base connection. The dimension of the circle is bigger when the bodydiode is in, to encompass it.
-The anchors are present even there is no circle, so you can use them to draw different kind of circles (say, encompassing two transistors) in a coherent way.
+The anchors are present even if there is no circle, so you can use them to draw different kinds of circles (say, encompassing two transistors) in a coherent way.
 
 \circuitdesc{npn, tr circle}{npn with a circle}{}(circle base/90/0.5, circle C/30/0.2, circle E/-30/0.2, circle center/0/0.5)
 \circuitdesc{npn, tr circle, bodydiode}{npn with a circle}{}(circle base/90/0.6, circle C/30/0.2, circle E/-30/0.2, circle center/0/0.5 )
@@ -4212,7 +4212,7 @@ Finally, using the class style you can do quite interesting things.
 
 \paragraph{Partially drawn circle borders}
 
-In some circuits, transistor are drawn with partial or dashed border (to convey the meaning of several active components encased in the same physical package, or to signify thermal contact). To achieve this effect, you can use the \texttt{transistor circle/partial border}\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/602}{Jether Fernandes Reis} for tubes, implemented by Romano in \texttt{v1.5.2}.} key (default \texttt{none}). This key can be set to \texttt{none}, or must be a sequence of \textbf{exactly} 4 numbers, that can have value \texttt{0}, \texttt{1}, or \texttt{2}. Each number define the style of a part of the border to be not drawn, solid or dashed respectively.
+In some circuits, transistors are drawn with partial or dashed border (to convey the meaning of several active components encased in the same physical package, or to signify thermal contact). To achieve this effect, you can use the \texttt{transistor circle/partial border}\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/602}{Jether Fernandes Reis} for tubes, implemented by Romano in \texttt{v1.5.2}.} key (default \texttt{none}). This key can be set to \texttt{none}, or must be a sequence of \textbf{exactly} 4 numbers, that can have value \texttt{0}, \texttt{1}, or \texttt{2}. Each number defines the style of a part of the border to be not drawn, solid or dashed respectively.
 
 The part of the border are numbered from 1 to 4 as shown below:
 \begin{quote}
@@ -4349,7 +4349,7 @@ For \textsc{npn}, \textsc{pnp}, \textsc{nigbt} and \textsc{pigbt} transistors, t
 \end{LTXexample}
 
 
-Notice that the geographical anchors of transistors are \emph{not} affected by either the bodydiode and the circle options; the label text is also outside of them. This is to permit to align the components independently from that features. On the other hand, that can sometimes create problems because that element are outside the bounding box automatically calculated by \TikZ{}.
+Notice that the geographical anchors of transistors are \emph{not} affected by either the bodydiode and the circle options; the label text is also outside of them. This is to permit aligning the components independently from those features. On the other hand, this can sometimes create problems because that element is outside the bounding box automatically calculated by \TikZ{}.
 
 The exception is the \texttt{right} anchor which, when a circle is present, indicates the edge of the circle itself (since \texttt{v1.3.2})
 
@@ -4386,7 +4386,7 @@ Transistor circles also have several anchors on them:
 \showanchors{pigfete, bodydiode, tr circle}{}(circle center/-135/0.6, circle top/90/0.3, circle left/180/0.2, circle right/0/0.2, circle bottom/-90/0.3, circle C/-45/0.2, circle E/45/0.2)
 \end{quote}
 
-The multi-terminal transistors have all the geographical anchors; note though that the \texttt{center} anchor is not the geometrical center of the component, but the logical one (at the same height than the base).
+The multi-terminal transistors have all the geographical anchors; note though that the \texttt{center} anchor is not the geometrical center of the component, but the logical one (at the same height as the base).
 The additional anchors \texttt{vcenter} (vertical geometric center of the collector--emitter zone) and \texttt{gcenter} (graphical center) are provided, as shown in the following picture. They have no bodydiode anchors nor \texttt{inner \emph{up/down}} ones.
 
 \begin{quote}
@@ -4464,7 +4464,7 @@ For UJT transistors anchors, see section~\ref{sec:ujt}.
 
 \subsubsection{Transistor paths}\label{sec:transasbip}
 
-For syntactical convenience standard transistors (not multi-terminal ones) can be placed using the normal path notation used for bipoles. The transitor type can be specified by  simply adding a ``T'' (for transistor) in front of the node name of the transistor. It will be placed with the base/gate orthogonal to the direction of the path:
+For syntactical convenience standard transistors (not multi-terminal ones) can be placed using the normal path notation used for bipoles. The transistor type can be specified by  simply adding a ``T'' (for transistor) in front of the node name of the transistor. It will be placed with the base/gate orthogonal to the direction of the path:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
@@ -4488,7 +4488,7 @@ Access to the gate and/or base nodes can be gained by naming the transistors wit
 ;\end{circuitikz}
 \end{LTXexample}
 
-Transistor used in path are fully path-style components, so to flip and rotate them you should use  \texttt{mirror} and \texttt{invert} as shown in section~\ref{sec:mirror-flip-path}.
+Transistors used in path are fully path-style components, so to flip and rotate them you should use  \texttt{mirror} and \texttt{invert} as shown in section~\ref{sec:mirror-flip-path}.
 
 Transistor paths have the possibility to use the poles syntax (see section~\ref{sec:bipole-nodes}) but they have \textbf{no} voltage, current, flow, annotation options.
 Also, the positioning of the labels is very simple and is not foolproof for all rotations; if you need to control them more please name the node and position them by hand, or use the more natural node style for transistors.
@@ -4637,7 +4637,7 @@ tube right center/30/0.4, tube left center/-120/0.4)
 
 \subsubsection{Partially drawn tube borders}\label{sec:partial-tube-borders}
 
-In some circuits, tubes are drawn with partial or dashed border (to convey the meaning of several active components encased in the same physical tube). To achieve this effect, you can use the \texttt{tubes/partial border}\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/602}{Jether Fernandes Reis}, implemented by Romano in \texttt{v1.5.2}.} key (default \texttt{none}). This key can be set to \texttt{none}, or must be a sequence of \textbf{exactly} 6 numbers, that can have value \texttt{0}, \texttt{1}, or \texttt{2}. Each number define the style of a part of the border to be not drawn, solid or dashed respectively.
+In some circuits, tubes are drawn with partial or dashed border (to convey the meaning of several active components encased in the same physical tube). To achieve this effect, you can use the \texttt{tubes/partial border}\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/602}{Jether Fernandes Reis}, implemented by Romano in \texttt{v1.5.2}.} key (default \texttt{none}). This key can be set to \texttt{none}, or must be a sequence of \textbf{exactly} 6 numbers, which can have value \texttt{0}, \texttt{1}, or \texttt{2}. Each number defines the style of a part of the border to be not drawn, solid or dashed respectively.
 
 The part of the border are numbered from 1 to 6 as shown below:
 \begin{quote}
@@ -4770,7 +4770,7 @@ Notes that in the transmission and receiving antennas, the ``waves'' are outside
     \circuitdesc*{mslstub}{Microstrip linear stub}{text}(left/135/0.2, right/45/0.2, center/-45/0.3)
     \circuitdesc*{msport}{Microstrip port}{T}(left/135/0.2, right/45/0.2, center/-45/0.3)
     \circuitdesc*{msrstub}{Microstrip radial stub}{}(left/135/0.2, right/45/0.2, center/-45/0.3)
-    \footnotetext{This four components were suggested by \texttt{@tcpluess} on GitHub}
+    \footnotetext{These four components were suggested by \texttt{@tcpluess} on GitHub}
     \circuitdesc{antenna}{Legacy antenna (with tails)}{}( center/0/0.3 )
     \circuitdesc{rxantenna}{Legacy receiving antenna (with tails)}{}
     \circuitdesc{txantenna}{Legacy transmitting antenna (with tails)}{}
@@ -4804,7 +4804,7 @@ For the length parameter of the transmission line there is a shortcut in the for
 
 \subsection{Electro-Mechanical Devices}
 
-The internal part of the motor and generator are, by default, filled white (to avoid compatibility problems with older versions of the package).
+The internal part of the motor and generator are, by default, filled with white (to avoid compatibility problems with older versions of the package).
 
 \begin{groupdesc}
     \circuitdesc*{elmech}{Motor}{M}(bottom/-90/0.2, left/180/0.2, right/0/0.2, top/90/0.4, 45/45/0.2)
@@ -4901,7 +4901,7 @@ You can also build generic double bipoles\footnote{The idea of generic double bi
 All the double bipoles/quadrupoles have the four anchors, two for each port.
 The first port, to the left, is port \texttt{A}, having the anchors \texttt{A1} (up) and \texttt{A2} (down); same for port \texttt{B}.
 
-They also expose the \texttt{base} anchor, for labelling, and anchors for setting dots or signs to specify polarity.
+They also expose the \texttt{base} anchor, for labeling, and anchors for setting dots or signs to specify polarity.
 The set of anchors, to which the standard ``geographical'' \texttt{north}, \texttt{north east}, etc. is here:
 
 \medskip
@@ -5008,7 +5008,7 @@ You can change the aspect of a quadpole using the corresponding parameters \text
 \end{circuitikz}
 \end{LTXexample}
 
-Transformers also inherits the \texttt{inductors/scale} (see~\ref{sec:tweak-l}) and similar parameters. It's your responsibility to set the aforementioned parameters if you change the scale or width of inductors.
+Transformers also inherit the \texttt{inductors/scale} (see~\ref{sec:tweak-l}) and similar parameters. It's your responsibility to set the aforementioned parameters if you change the scale or width of inductors.
 
 Transformers core line distance is specified by the parameter \texttt{quadpoles/transformer core/core width} (default \texttt{0.05}) and the thickness of the lines follows the choke one; in other words, you can set it changing \texttt{bipoles/cutechoke/cthick}.
 
@@ -5260,7 +5260,7 @@ The instrumentation amplifier inst amp defines also references (normally you use
 ;\end{circuitikz}
 \end{LTXexample}
 
-The fully diffential instrumentation amplifier inst amp defines two outputs:
+The fully differential instrumentation amplifier inst amp defines two outputs:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
   (0,0) node[fd inst amp] (opamp) {}
@@ -5275,7 +5275,7 @@ The fully diffential instrumentation amplifier inst amp defines two outputs:
 ;\end{circuitikz}
 \end{LTXexample}
 
-The instrumentation amplifier with resistance terminals (\texttt{inst amp ra}) defines also terminals to add an amplification resistor:
+The instrumentation amplifier with resistance terminals (\texttt{inst amp ra}) also defines terminals to add an amplification resistor:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
   (0,0) node[inst amp ra] (opamp) {}
@@ -5290,7 +5290,7 @@ The instrumentation amplifier with resistance terminals (\texttt{inst amp ra}) d
 ;\end{circuitikz}
 \end{LTXexample}
 
-Amplifiers have also ``border'' anchors (just add \texttt{b}, without space, to the anchor, like \texttt{b+} or \texttt{bin up} and so on). These can be useful to add ``internal components''  or to modify the component. Also the \texttt{leftedge} anchors (on the border midway between input) is available.
+Amplifiers also have ``border'' anchors (just add \texttt{b}, without space, to the anchor, like \texttt{b+} or \texttt{bin up} and so on). These can be useful to add ``internal components''  or to modify the component. Also the \texttt{leftedge} anchor (on the border midway between input) is available.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[]
@@ -5310,7 +5310,7 @@ Amplifiers have also ``border'' anchors (just add \texttt{b}, without space, to 
 You can scale the amplifiers using the key \texttt{amplifiers/scale} and setting it to something different from \texttt{1.0}. The font used for symbols will not scale, so it's your responsibility to change it if the need arises.
 
 \paragraph{Input polarity.}
-All these amplifier have the possibility to flip input and output (if needed) polarity. You can change polarity of the input with the
+All these amplifiers have the possibility to flip input and output (if needed) polarity. You can change polarity of the input with the
 \texttt{noinv input down} (default) or \texttt{noinv input up} key; and the output with \texttt{noinv output up} (default) or \texttt{noinv output down} key:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
@@ -5328,7 +5328,7 @@ All these amplifier have the possibility to flip input and output (if needed) po
 ;\end{circuitikz}
 \end{LTXexample}
 
-When you use the \texttt{noinv input/output ...} keys the anchors (\texttt{+}, \texttt{-}, \texttt{out +}, \texttt{out -}) will change with the effective position of the terminals. You have also the anchors \texttt{in up}, \texttt{in down}, \texttt{out up}, \texttt{out down} that will not change with the positive or negative sign.
+When you use the \texttt{noinv input/output ...} keys the anchors (\texttt{+}, \texttt{-}, \texttt{out +}, \texttt{out -}) will change with the effective position of the terminals. You also have the anchors \texttt{in up}, \texttt{in down}, \texttt{out up}, \texttt{out down} that will not change with the positive or negative sign.
 
 \paragraph{Input and output pins symbols.}
 You can change the symbols ``$+$'' or ``$-$'' appearing in the amplifiers if you want, both globally and on component-by-component basis. The plus and minus symbols can be changed with \verb|\ctikzset| of the keys \texttt{amplifiers/plus} and \texttt{amplifiers/minus} (which defaults to the math mode plus or minus cited before), or using the styles \texttt{amp plus} and \texttt{amp minus}.
@@ -5368,7 +5368,7 @@ If you want different symbols for input and output you can use a null symbol and
 \end{circuitikz}
 \end{LTXexample}
 
-\paragraph{Input and output pins length.} The length of the wires that extends outside the main amplifier shape are not easily changed globally. You can use a trick\footnote{See the discussion with \href{https://github.com/circuitikz/circuitikz/issues/645}{user @erwindenboer on GitHub};notice that this method is using internal keys and can stop working in the future.} though if you want to remove them completely:
+\paragraph{Input and output pins length.} The length of the wires that extends outside the main amplifier shape is not easily changed globally. You can use a trick\footnote{See the discussion with \href{https://github.com/circuitikz/circuitikz/issues/645}{user @erwindenboer on GitHub};notice that this method is using internal keys and can stop working in the future.} though if you want to remove them completely:
 the size of an amplifier (included the pins) is set by the \texttt{circuitikz} key \texttt{tripoles/\emph{amplifier style}/width} and the size of the body of the amplifier, relative to it, is set by the key\texttt{tripoles/\emph{amplifier style}/port width}.
 Making the latter equal to one will set the length of the pin to zero; if you want to maintain the same aspect ratio of the shape you need to compensate with the width.
 
@@ -5523,7 +5523,7 @@ and \texttt{1.3.8} for the \texttt{draw only...} option).
 
 \subsection{Switches, buttons and jumpers}
 
-Switches and button come in to-style (the simple ones and the pushbuttons), and as nodes.
+Switches and buttons come in to-style (the simple ones and the pushbuttons), and as nodes.
 
 The switches can be scaled with the key \texttt{switches/scale} (default \texttt{1.0}). Notice that scaling the switches will not scale the poles, which are controlled with their own parameters (see section~\ref{sec:terminals}).
 
@@ -5608,7 +5608,7 @@ The nodes-style switches have the following anchors:
 \end{circuitikz}
 
 Please notice the position of the normal anchors at the border of the \texttt{ocirc} shape for the cute switches; they are thought to be compatible with an horizontal wire going out.
-Additionaly, you have the \texttt{cin}, \texttt{cout 1} y \texttt{cout 2} which are anchors on the center of the contacts.
+Additionally, you have the \texttt{cin}, \texttt{cout 1} y \texttt{cout 2} which are anchors on the center of the contacts.
 
 For more complex situations, the contact nodes are available\footnote{Thanks to \texttt{@marmot} on \href{https://tex.stackexchange.com/a/492599/38080}{tex.stackexchange.com}.} using the syntax \emph{name of the node}\texttt{-in}, \dots\texttt{-out 1} and \dots\texttt{-out 2}, with all their anchors.
 
@@ -5828,7 +5828,7 @@ Finally, the size can be changed using the parameter \texttt{tripoles/spdt/width
 \subsubsection{Switch arrows\label{sec:switcharrows}}
 
 You can change the arrow tips used in all switches (traditional and ``cute'') with the key \texttt{switch end arrow} (by default the key is the word ``\texttt{default}'' to obtain the default arrow, which is \texttt{latexslim}).
-Also you can change the start arrow with the corresponding \texttt{switchable start arrow} or \texttt{wiper start arrow} (the default value ``\texttt{default}'' is equivalent to \texttt{\{\}}, which means no arrow). They keys are settable with \verb|\ctikzset| as with \verb|\tikzset| (to ease their usage in nodes).
+Also you can change the start arrow with the corresponding \texttt{switchable start arrow} or \texttt{wiper start arrow} (the default value ``\texttt{default}'' is equivalent to \texttt{\{\}}, which means no arrow). The keys are settable with \verb|\ctikzset| as with \verb|\tikzset| (to ease their usage in nodes).
 
 You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
 
@@ -5905,7 +5905,7 @@ The kind of poles used in the diagram can be changed with the \verb!\ctikzset! k
 
 \paragraph{Two-ways (three-pins) jumpers.} In this case, the symbol represent two-ways jumpers (normally, three pins that can be connected in a couple of ways).
 
-To maintain flexibility, every possible combination of bare, open or closed is available; but to avoid to have to define too much different bipoles, a different approach is used here. You have to specify the style using a different key, namely \texttt{tjumper connections}.
+To maintain flexibility, every possible combination of bare, open or closed is available; but to avoid having to define too much different bipoles, a different approach is used here. You have to specify the style using a different key, namely \texttt{tjumper connections}.
 
 \begin{groupdesc}
     \circuitdescbip*[tjumper]{three-pins jumper}{Three-pins jumper (see later for connections)}{}(in/135/0.6, out/45/0.6, tap/-90/0.2)[out.n/90/0.2]
@@ -5915,7 +5915,7 @@ To maintain flexibility, every possible combination of bare, open or closed is a
     \circuitdescbip*[tjumper]{three-pins jumper}{Three-pins jumper (connections \texttt{\ctikzvalof{tjumper connections}})}{}(top arc left/135/0.6, top arc right/45/0.6, tap/-145/0.2)[out.n/-90/0.2]
 \end{groupdesc}
 
-The option is used as shown in the following example, or by setting the key using \verb!\ctikzset!. The value \textbf{must} be two character, either two numbers (where \texttt{0} means ``bare'', \texttt{1} means ``open'', and \texttt{2} means ``closed'') or the letter \texttt{S} (for ``span'') and one number. In the latter case, the arc will connect the fist and last pole\footnote{Although really I never saw an example of this use\dots You never know.}
+The option is used as shown in the following example, or by setting the key using \verb!\ctikzset!. The value \textbf{must} be two characters, either two numbers (where \texttt{0} means ``bare'', \texttt{1} means ``open'', and \texttt{2} means ``closed'') or the letter \texttt{S} (for ``span'') and one number. In the latter case, the arc will connect the fist and last pole\footnote{Although really I never saw an example of this use\dots You never know.}
 
 \begin{LTXexample}[varwidth=true, pos=t, basicstyle=\small\ttfamily]
 \begin{circuitikz}
@@ -6039,7 +6039,7 @@ The one-input, one-output ports have a handy path-style equivalent; they are the
     \circuitdescbip*{inline double tgate}<double tgate>{double transmission gate}{}(bgate/-90/0.2, bnotgate/90/0.2)
 \end{groupdesc}
 
-Those ports follows the current selected style, although you can change it on the fly (even if it has not a lot of sense); you can apply labels, annotations and (again, not a lot of sense) voltages to them. The assigned value is typeset as if it were the main text of the node.
+Those ports follow the current selected style, although you can change it on the fly (even if it does not have a lot of sense); you can apply labels, annotations and (again, not a lot of sense) voltages to them. The assigned value is typeset as if it were the main text of the node.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american]
@@ -6065,7 +6065,7 @@ you have to use the border pins to connect the gates.
 
 \subsubsection{American ports usage}
 
-Since version \texttt{1.0.0}, the default shape of the family of american ``or'' ports has changed to a more ``pointy'' one, for better distinguish them from the ``and''-type ports. You can still going back to the previous aspect with the key \texttt{american or shape} that can be set to \texttt{pointy} or \texttt{roundy}. The \texttt{legacy} style will enact the old, roundy style also.
+Since version \texttt{1.0.0}, the default shape of the family of american ``or'' ports has changed to a more ``pointy'' one, for better distinguish them from the ``and''-type ports. You can still go back to the previous aspect with the key \texttt{american or shape} that can be set to \texttt{pointy} or \texttt{roundy}. The \texttt{legacy} style will enact the old, roundy style also.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[
@@ -6123,7 +6123,7 @@ with the parameter \texttt{number inputs} :
 \end{circuitikz}
 \end{LTXexample}
 
-You can suppress the drawing of the logic ports input leads by using the boolean key \texttt{logic ports draw input leads}  (default \texttt{true}) or, locally, with the style \texttt{no inputs leads} (that can be reverted with \texttt{input leads}),  like in the following example. The anchors do not change and you have to take responsibility do do the connection to the ``border''-anchors.
+You can suppress the drawing of the logic ports input leads by using the boolean key \texttt{logic ports draw input leads}  (default \texttt{true}) or, locally, with the style \texttt{no inputs leads} (that can be reverted with \texttt{input leads}),  like in the following example. The anchors do not change and you have to take responsibility to make the connection to the ``border''-anchors.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -6152,7 +6152,7 @@ This is useful if you need to draw a generic port, like the one following here:
 
 In an analogous manner, there is a setting \texttt{logic ports draw output leads} (and a corresponding style \texttt{no output leads}) that suppresses the drawing of the output lead. A shortcut boolean key \texttt{logic ports draw leads} will suppress or enable all leads (the corresponding styles are \texttt{no leads} and \texttt{all leads}).
 
-You can tweak the appearance of american ``or'' family (\texttt{or}, \texttt{nor}, \texttt{xor}  and \texttt{xnor}) ports, too, with the parameters \texttt{inner} (how much the base circle go ``into'' the shape, default 0.3) and \texttt{angle} (the angle at which the base starts, default 70).
+You can tweak the appearance of american ``or'' family (\texttt{or}, \texttt{nor}, \texttt{xor}  and \texttt{xnor}) ports, too, with the parameters \texttt{inner} (how much the base circle goes ``into'' the shape, default 0.3) and \texttt{angle} (the angle at which the base starts, default 70).
 
 \begin{LTXexample}[varwidth=true]
 \tikz \draw (0,0) node[xnor port] {};
@@ -6185,7 +6185,7 @@ These are the anchors for logic ports:
 \end{circuitikz}
 \bigskip
 
-You have also ``border pin anchors'':
+You also have ``border pin anchors'':
 
 \bigskip
 \begin{circuitikz} [american]
@@ -6281,7 +6281,7 @@ This last circuit could be drawn also (and probably in a more natural manner) us
 The rest of this section will assume you have issued the command \verb|\ctikzset{logic ports=ieee}|, so that the short form of the names is used.
 \ctikzset{logic ports=ieee}
 
-IEEE standard logic gates have a basic difference with the legacy ones: the proportions of their shapes does not change when you change the size, so you can't have a ``tall'' port or a ``squatty'' ones. The two-inputs gates, by default, have their default size designed so that they match the chips component (see~\ref{sec:chips}).
+IEEE standard logic gates have a basic difference with the legacy ones: the proportions of their shapes do not change when you change the size, so you can't have a ``tall'' port or a ``squatty'' one. The two-inputs gates, by default, have their default size designed so that they match the chips component (see~\ref{sec:chips}).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -6314,7 +6314,7 @@ The first one is to scale the port; if you set the port height so that it has th
 \end{circuitikz}
 \end{LTXexample}
 
-But then the size of the port is quite ``unusual''. The solution in technical literature is to use what we can call a ``rack'' for the inputs; basically, only a certain number of pins are kept on the port, and the other are put on an extended input line.
+But then the size of the port is quite ``unusual''. The solution in technical literature is to use what we can call a ``rack'' for the inputs; basically, only a certain number of pins are kept on the port, and the others are put on an extended input line.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -6404,7 +6404,7 @@ Notice the key \texttt{component text=left} that moves the label near to the lef
 
 The length of the external leads can be changed by the user, but notice that if you use a too small value you can jeopardize that property.
 
-The single input ports (\texttt{not port}, \texttt{buffer port} and their Schmitt equivalent) are smaller that the six standard ports, so they are not kept aligned by default; the just have the same distance at the input side. For the not ports, the \texttt{left} position of the text results often in a better look (the centered text in the triangle seems to be much more at the right).
+The single input ports (\texttt{not port}, \texttt{buffer port} and their Schmitt equivalent) are smaller than the six standard ports, so they are not kept aligned by default; the just have the same distance at the input side. For the not ports, the \texttt{left} position of the text results often in a better look (the centered text in the triangle seems to be much more at the right).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -6521,7 +6521,7 @@ In one-input ports (\texttt{not port}, the buffer, and Schmitt-type ports) you c
 
 On the output, \texttt{out} is on the tip of the lead, and \texttt{bout} on the rightmost border (so, if there is a negation circle, it is on it); \texttt{right} is the same as \texttt{bout}.
 
-The main body of the port is marked with \texttt{body left} and \texttt{body right} anchors (as seen in the middle port in the diagram above); you have also an \texttt{up} and \texttt{down} anchors centered on the body (you can use them as enable signals or similar things).
+The main body of the port is marked with \texttt{body left} and \texttt{body right} anchors (as seen in the middle port in the diagram above); you also have an \texttt{up} and \texttt{down} anchors centered on the body (you can use them as enable signals or similar things).
 
 Finally, the internal \texttt{notcirc} node used for the output negation is accessible with the name \texttt{\emph{nodename}-not}, where \emph{nodename} is the name given to the logic port node.
 
@@ -6651,7 +6651,7 @@ To define a specific flip-flop, you have to set a series of keys under the \verb
     \item a \emph{negation} flag (\texttt{n0}, \dots  \texttt{n6}, \texttt{nu}, \texttt{nd}),  with value \texttt{0} or \texttt{1}, which will put and \texttt{ocirc} shape on the outer border of the corresponding pin.
 \end{itemize}
 
-To set all this keys, an auxiliary style \texttt{flipflop def} is defined, so that you can do the following thing:
+To set all these keys, an auxiliary style \texttt{flipflop def} is defined, so that you can do the following thing:
 
 \begingroup
 \tikzset{flipflop AB/.style={flipflop,
@@ -6742,7 +6742,7 @@ The standard definition of the default flip-flops are the following (in the file
 
 \subsubsection{Flip-flops anchors}
 
-Flip-flops have all the standard geometrical anchors, although it should be noticed that the external pin are \emph{outside} them. The pins are accessed by the number \texttt{1} to \texttt{6} for the lateral ones (like in DIP chips), and with the \texttt{up} and \texttt{down} anchors for the top and bottom one. All the pins have the ``border'' variant (add a \texttt{b} in front of them, no spaces).
+Flip-flops have all the standard geometrical anchors, although it should be noticed that the external pins are \emph{outside} them. The pins are accessed by the number \texttt{1} to \texttt{6} for the lateral ones (like in DIP chips), and with the \texttt{up} and \texttt{down} anchors for the top and bottom one. All the pins have the ``border'' variant (add a \texttt{b} in front of them, no spaces).
 
 \begin{quote}
         \geocoord{flipflop JK}\qquad
@@ -6771,7 +6771,7 @@ As in chips, you can change the length of the external pin with the key \texttt{
     \circuitdesc*{flipflop JK, add async SR, external pins width=0}{synchronous flip-flop JK}{}
 \end{groupdesc}
 
-Notice however that negated pins when the pins width is zero has to be handled with care. As explained in the poles sections, the \texttt{ocirc} shape is drawn at the end of the shape to cancel out the wires below; so if you use a pinless flipflop when you do the connection you should take care of connecting the symbol correctly. To this end, the shapes of the negation circles are made available as \texttt{\textsl{<nodename>}-N\textsl{<pin number>}}, as you can see in the next (contrived) example.
+Notice however that negated pins when the pins width is zero has to be handled with care. As explained in the poles sections, the \texttt{ocirc} shape is drawn at the end of the shape to cancel out the wires below; so if you use a pinless flipflop when you make the connection you should take care of connecting the symbol correctly. To this end, the shapes of the negation circles are made available as \texttt{\textsl{<nodename>}-N\textsl{<pin number>}}, as you can see in the next (contrived) example.
 
 
 \begin{LTXexample}[varwidth=true]
@@ -6846,7 +6846,7 @@ will generate the following shape (the definition above is already defined in th
     \circuitdesc*[0.7]{demux}{Demultiplexer $1\to2^3$ with \texttt{Lh=4, Rh=8, NL=1, NB=3, NR=8} }{MD2}
 \end{groupdesc}
 
-The shape can be also defined with an inset. For example it can be used like this to define a 1-bit adder (also already available):
+The shape can also be defined with an inset. For example it can be used like this to define a 1-bit adder (also already available):
 
 \begin{lstlisting}
 \tikzset{one bit adder/.style={muxdemux,
@@ -6911,7 +6911,7 @@ The default values are $\texttt{Lh}=8$, $\texttt{Rh}=6$, $\texttt{w}=3$ and no i
     If you do not want a pin in one side, use \texttt{0} as number of pins.
     \item [square pins]: set to \texttt{0} (default) if you want the square pins to stick out following the slope of the bottom or top side, \texttt{1} if you want them to stick out in a square way (see the example above for the ALU).
 \end{description}
-All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a numbers of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- (\texttt{inset Lh})$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
+All the distances are multiple of \texttt{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a number of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- (\texttt{inset Lh})$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -6945,7 +6945,7 @@ You can draw only selected pins and leave out the rest by setting the keys
 \texttt{multipoles/draw only \emph{side} pins} and the corresponding style
 \texttt{draw only \emph{side} pins} where \texttt{\emph{side}} can be \texttt{left}, \texttt{right},
 \texttt{top}, \texttt{bottom}.
-Those key accept a comma separated list of
+Those key accept a comma-separated list of
 pin numbers or ranges of pin numbers (a range is given as
 \texttt{$\langle$start$\rangle$ - $\langle$end$\rangle$}, ends are inclusive).
 The numbers will not be expanded in any way, except those given as ends of
@@ -7159,7 +7159,7 @@ The font used for the pins is adjustable with the key \texttt{multipoles/font} (
 You can draw only selected pins and leave out the rest by setting
 \texttt{multipoles/draw only pins}\footnote{Added by
 \href{https://github.com/circuitikz/circuitikz/pull/550}{Jonathan P. Spratte in \texttt{v1.3.8}}}.
-This key accepts a comma separated list of
+This key accepts a comma-separated list of
 pin numbers or ranges of pin numbers (a range is given as
 \texttt{$\langle$start$\rangle$ - $\langle$end$\rangle$}, ends are inclusive).
 The numbers will not be expanded in any way, except those given as ends of
@@ -7272,7 +7272,7 @@ Look at the following example, which is easily put into a macro.
     \circuitdesc*{bare7seg}{Seven segment display}{}
 \end{groupdesc}
 
-The seven segment display lets you show values as if they were displayed in a classical seven segment display.\footnote{This component has been loosely inspired by the package \texttt{SevenSeg} by Germain Gondor, 2009, see \href{http://www.texample.net/tikz/examples/seven-segment-display/}{\TeX{}example.net}.}
+The seven-segment display lets you show values as if they were displayed in a classical seven-segment display.\footnote{This component has been loosely inspired by the package \texttt{SevenSeg} by Germain Gondor, 2009, see \href{http://www.texample.net/tikz/examples/seven-segment-display/}{\TeX{}example.net}.}
 
 The main ``bare'' component is the one shown above, but for simplicity a couple of style interfaces are defined:
 
@@ -7298,7 +7298,7 @@ You can use these option with the ``bare'' object \texttt{bare7seg} and the keys
 
 \subsubsection{Seven segments anchors}
 
-These are the anchors for the seven segment displays; notice that when the \texttt{dot} parameter is not \texttt{none}, the cell is a bit wider at the right side.
+These are the anchors for the seven-segment displays; notice that when the \texttt{dot} parameter is not \texttt{none}, the cell is a bit wider at the right side.
 
 \begingroup
 \ctikzset{seven seg/color off=gray, multipoles/thickness=1}
@@ -7400,7 +7400,7 @@ Long names/styles for the bipoles can be used, of course, and there is a special
 \label{sec:labels-and-annotations}
 Since Version 0.7, beside the original label (\texttt{l})  option, there is a new option to place a second label, called annotation (\texttt{a}) at each bipole.
 
-\subsubsection{Label and annotation position.}
+\subsubsection{Label and annotation position}
 When drawing a component left-to-right, the label \texttt{l} is by default above the component, and the annotation \texttt{a} is by default below it. The position of annotations and labels can be adjusted adding the characters \verb|_| or \verb|^| to the key.
 
 \begin{LTXexample}[varwidth=true]
@@ -7510,7 +7510,7 @@ The default orientation of labels is controlled by the options \texttt{smartlabe
 
 \subsubsection{Stacked (two lines) labels.}
 
-When using \texttt{circuitikz} in LaTeX, you can use stacked (two lines) labels.  The example should be self-explanatory: the two lines are specified as \texttt{l2=}\emph{line1}\texttt{ and }\emph{line2}. You can use the keys \texttt{l2 halign} to control horizontal position (\texttt{l}eft, \texttt{c}enter, \texttt{r}ight) and \texttt{l2 valign} to control the vertical one (\texttt{b}ottom, \texttt{c}enter, \texttt{t}op). The default values for alignement are thought for vertical components (where the stacke labels are more natural), in other positions you have to force them.
+When using \texttt{circuitikz} in LaTeX, you can use stacked (two lines) labels.  The example should be self-explanatory: the two lines are specified as \texttt{l2=}\emph{line1}\texttt{ and }\emph{line2}. You can use the keys \texttt{l2 halign} to control horizontal position (\texttt{l}eft, \texttt{c}enter, \texttt{r}ight) and \texttt{l2 valign} to control the vertical one (\texttt{b}ottom, \texttt{c}enter, \texttt{t}op). The default values for alignments are thought for vertical components (where the stacke labels are more natural), in other positions you have to force them.
 
 Notice that you \textbf{can't use} the compact \texttt{<...>} notation for \texttt{siunitx} with stacked labels. Before \texttt{v1.3.6} the label was ignored, but that has been converted into an error.
 
@@ -7551,16 +7551,16 @@ The default direction/sign for currents and voltages in the components is, unfor
 This unfortunate situation created a bit of confusion in \texttt{circuitikz} across the versions, with several incompatible changes starting from version 0.5.
 From version 0.9.0 onward, the maintainers agreed a new policy for the directions of bipoles' voltages and currents, depending on 4 different possible options:
 \begin{itemize}
-    \item \texttt{oldvoltagedirection}, or the key style \texttt{voltage dir=old}: Use old way of voltage direction having a difference between european and american direction, with wrong default labelling for batteries (it was the default before version 0.5);
+    \item \texttt{oldvoltagedirection}, or the key style \texttt{voltage dir=old}: Use old way of voltage direction having a difference between european and american direction, with wrong default labeling for batteries (it was the default before version 0.5);
     \item \texttt{nooldvoltagedirection}, or the key style \texttt{voltage dir=noold}: The standard from version 0.5 onward, utilize the (German?) standard of voltage arrows in the  direction of electric fields (without fixing batteries);
     \item \texttt{RPvoltages} (meaning Rising Potential voltages), or the key style \texttt{voltage dir=RP}: the arrow is in direction of rising potential, like in \texttt{oldvoltagedirection}, but batteries and current sources are fixed so that they follow the passive/active standard: the default direction of \texttt{v} and \texttt{i} are chosen so that, when both values are positive:
         \begin{itemize}
             \item in passive component, the element is \emph{dissipating power};
             \item in active components (generators), the element is \emph{generating power}.
         \end{itemize}
-    \item \texttt{EFvoltages} (meaning Electric Field voltages), or the key style \texttt{voltage dir=EF}: the arrow is in direction of the electric field, like in \texttt{nooldvoltagedirection}, but batteries are fixed;
+    \item \texttt{EFvoltages} (meaning Electric Field voltages), or the key style \texttt{voltage dir=EF}: the arrow is in the direction of the electric field, like in \texttt{nooldvoltagedirection}, but batteries are fixed;
 \end{itemize}
-Notice that the four styles are designed to be used at the environment level: that is, you should use them at the start of your environment as in \verb|\begin{circuitikz}[voltage dir=old] ...| and not as a key for single components, in which case the behaviour is not guaranteed.
+Notice that the four styles are designed to be used at the environment level: that is, you should use them at the start of your environment as in \verb|\begin{circuitikz}[voltage dir=old] ...| and not as a key for single components, in which case the behavior is not guaranteed.
 
 The standard direction of currents, flows and voltages are changed by these options; notice that the default drops in case of passive and active elements is normally different. Take care that in the case of \texttt{noold} and \texttt{EFvoltages} also the currents can switch directions. It is much easier to understand the several behaviors by looking at the following examples, that have been generated by the code:
 
@@ -7620,7 +7620,7 @@ The standard direction of currents, flows and voltages are changed by these opti
 }
 
 Obviously, you normally use just one between current and flows, but anyway you can
-change direction of the voltages,
+change the direction of the voltages,
 currents and flows using the complete keys \verb|i_>|, \verb|i^<|, \verb|i>_|, \verb|i>^|,
 as shown in the following examples.
 
@@ -7662,7 +7662,7 @@ Notice also that normally \texttt{distance from node} is a relative displacement
 \end{circuitikz}
 \end{LTXexample}
 
-The value of \texttt{distance from node} can be also an absolute distance; in that case is measured from the start of the connection toward the component on the left (and symmetrically on the right), so this will put the start and end point to \SI{0.25}{\cm} from the start of the node:
+The value of \texttt{distance from node} can also be an absolute distance; in that case is measured from the start of the connection toward the component on the left (and symmetrically on the right), so this will put the start and end point to \SI{0.25}{\cm} from the start of the node:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -7693,9 +7693,9 @@ If you want to change those parameters by defining a component-specific key you 
        to[C, v=2<\volt>] (3,0); \par
 \end{LTXexample}
 
-Note the \texttt{.initial}; you have to create such key the first time you use it. These kind of adjustments are not guaranteed to work in future upgrades, though; if you have to create a key you are somehow touching the internal structure of the package; it's much safer to create a style.
+Note the \texttt{.initial}; you have to create such key the first time you use it. These kinds of adjustments are not guaranteed to work in future upgrades, though; if you have to create a key you are somehow touching the internal structure of the package; it's much safer to create a style.
 
-One common request is to change the style of the arrows (both head and line) of these elements. Voltages, currents and flows are part of the same path of the component, so this is not possible in simple way; you have to drawn your own with \TikZ{} commands using the facilities explained in section~\ref{sec:vif-anchors}.
+One common request is to change the style of the arrows (both head and line) of these elements. Voltages, currents and flows are part of the same path of the component, so this is not possible in simple way; you have to draw your own with \TikZ{} commands using the facilities explained in section~\ref{sec:vif-anchors}.
 
 \subsubsection{Special treatment for generators}\label{sec:source-vif}
 
@@ -7785,7 +7785,7 @@ On the other way around, you could use styles to set \texttt{is voltage=false} o
 
 \subsection{Currents}\label{sec:currents}
 
-Inline (along the wire) currents are selected with \verb|i_>|, \verb|i^<|, \verb|i>_|, \verb|i>^|, and various combination; the default position and direction is obtained with the simple key \verb|i=...|.
+Inline (along the wire) currents are selected with \verb|i_>|, \verb|i^<|, \verb|i>_|, \verb|i>^|, and various combinations; the default position and direction is obtained with the simple key \verb|i=...|.
 
 Basically, \verb|^| and \verb|_| control if the label is above or below the line (above and below \textbf{do} depend on the direction of the component path), and \verb|<| and \verb|>| the direction of the arrow; swapping them (from for example from \verb|i^>| to \verb|i>^|) will switch the side of the component where the symbol is drawn. See the following examples:
 
@@ -7882,7 +7882,7 @@ Current generators with the direct label (the one obtained by, for example, \tex
 \end{LTXexample}
 
 If you use the option \texttt{americancurrent} or using the style \texttt{[american currents]}
-you can changhe the style of current generators.
+you can change the style of current generators.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american currents]

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -197,7 +197,7 @@ Neither will it work with angle-changing scaling (when \texttt{xscale} is differ
 
 Correcting this will need a big rewrite of the path routines, and although the authors are thinking about solving it, don't hold your breath; it will need changing a lot of interwoven code (labels, voltages, currents and so on). Contributions and help would be highly appreciated.
 
-This same issue creates a lot of problems with compatibility between \Circuitikz{} and the new \texttt{pic} Ti\emph{k}Z feature, so basically don't put components into \texttt{pic}s.
+This same issue creates a lot of problems with compatibility between \Circuitikz{} and the new \texttt{pic} \TikZ\  feature, so basically don't put components into \texttt{pic}s.
 
 Also, notice that several components will interact in a funny way with global path options. Depending on the specific component, some parameters are inherited by the internal shape, and some others are reset. This is not easy to fix in general. We want some options to go through --- fill color, dashed pattern for example --- and some others to stay only in the outer path; and if the background shape needs some option for drawing the internal shape, like for example a rounded corner, it \emph{must} reset the external option. So there is no perfect solution, although since \texttt{v1.5.0} the shapes have been ``robustified'', so that by default arced corners and arrows parameters will \emph{not} be propagated into the shape.
 Arrows with \texttt{to[]} components don't work, anyway, so basically avoid this situation.
@@ -1300,7 +1300,7 @@ You can see from the example below (notice the blue curve using a spline line). 
 In the last (green) example, you can see a workaround using local path and the key \texttt{current point is local} that will work for older (and do not create problems in newer) versions.
 
 \begin{LTXexample}[varwidth=true, pos=t]
-Plotted using Ti\emph{k}Z version \pgfversion{} and CircuiTi\emph{k}Z version \pgfcircversion{}.
+Plotted using \TikZ\ version \pgfversion{} and Circui\TikZ\ version \pgfcircversion{}.
 
 \begin{tikzpicture}
     \draw[color=red] (0,0) to[R] +(2,0) +(0,0) -- ++(0,-1);
@@ -1470,9 +1470,9 @@ Explanation of the parameters:\\
 \end{framed}
 
 \begin{framed}
-	\noindent\textbf{Also notice:} If using the \verb!\tikzexternalize! feature, as of Ti\emph{k}z 2.1 all pictures must end with \verb!\end{tikzpicture}!. Thus you \emph{cannot} use the \verb!circuitikz! environment.
+	\noindent\textbf{Also notice:} If using the \verb!\tikzexternalize! feature, as of \TikZ\ 2.1 all pictures must end with \verb!\end{tikzpicture}!. Thus you \emph{cannot} use the \verb!circuitikz! environment.
 
-	\noindent Which is ok: just use the environment \verb!tikzpicture!: everything will work there just fine.
+	\noindent Which is OK: just use the environment \verb!tikzpicture!: everything will work there just fine.
 \end{framed}
 
 \subsubsection{Mirroring and flipping}\label{sec:mirroring-and-flipping}
@@ -1702,7 +1702,7 @@ The style \texttt{legacy} is a style that set (most) of the style parameters to 
 
 The best option is to start from \texttt{ctikzstyle-legacy.tex} and edit your style file from it. Then you just put it in your input path and that's all. If you want, you can contribute your style file to the project.
 
-Basically, to write the style \texttt{example}, you edit a file named \texttt{ctikzstyle-romano.tex} with will define and enact Ti\emph{k}Z style with name \texttt{example circuit style}; basically it has to be something along this:
+Basically, to write the style \texttt{example}, you edit a file named \texttt{ctikzstyle-romano.tex} with will define and enact \TikZ\ style with name \texttt{example circuit style}; basically it has to be something along this:
 
 \lstinputlisting[frame=single, framesep=10pt]{ctikzstyle-example.tex}
 
@@ -1958,7 +1958,7 @@ They are similar to ground anchors, and the geographical anchors are correct onl
 
 You can change the scale of the power supplies by setting the key \texttt{power supplies/scale} (default \texttt{1.0}).
 
-Given that the power supply symbols are basically arrows, you can change them using all the options of the \texttt{arrows.meta} package (see the Ti\emph{k}Z manual for details) by changing the keys \texttt{monopoles/vcc/arrow} and \texttt{monopoles/vee/arrow} (the default for both is \texttt{legacy}, which will use the old code for drawing them).
+Given that the power supply symbols are basically arrows, you can change them using all the options of the \texttt{arrows.meta} package (see the \TikZ\ manual for details) by changing the keys \texttt{monopoles/vcc/arrow} and \texttt{monopoles/vee/arrow} (the default for both is \texttt{legacy}, which will use the old code for drawing them).
 Note that the anchors are at the start of the connecting lines, and that geographical anchors are just approximation if you change the arrow symbol!
 
 \begin{LTXexample}[varwidth=true]
@@ -8127,7 +8127,7 @@ Use option \texttt{americanvoltage} or set \verb![american voltages]! or use the
 
 Since version \texttt{1.2.1}, ``raised'' American voltages are available; to use them, set the style \verb![raised voltages]! or use the option \texttt{voltage=raised}.
 This is a version of the American-style voltage where the signs are raised to the level of the label.
-The label is centered between the two signs, and the position of the signs is calculated supposing that the label itself will be pretty simple; if you have very big labels you will need to adjust the position with \texttt{voltage shift} and/or the \texttt{voltage/distance from node} properties (see section~\ref{sec:common-vif-pos}).
+The label is centered between the two signs, and the position of the signs is calculated by supposing that the label itself will be pretty simple; if you have very big labels you will need to adjust the position with \texttt{voltage shift} and/or the \texttt{voltage/distance from node} properties (see section~\ref{sec:common-vif-pos}).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[raised voltages]
@@ -8168,7 +8168,7 @@ The label is centered between the two signs, and the position of the signs is ca
 
 \subsubsection{Voltage position}\label{sec:sub-voltage-position}
 
-It is possible to move the arrows and the plus or minus signs away form the component with the key \texttt{voltages shift} (default value is \texttt{0}, which gives the standard position):
+It is possible to move the arrows and the plus or minus signs away from the component with the key \texttt{voltages shift} (default value is \texttt{0}, which gives the standard position):
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[]
@@ -8196,7 +8196,7 @@ Negative values do work as expected:
 \end{circuitikz}
 \end{LTXexample}
 
-You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \texttt{voltage/shift} (default \texttt{0.0} for the former and \texttt{voltage/american label distance} (the distance of the label form the lines of the symbols, default \texttt{1.4}) for the latter.
+You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \texttt{voltage/shift} (default \texttt{0.0} for the former and \texttt{voltage/american label distance} (the distance of the label from the lines of the symbols, default \texttt{1.4}) for the latter.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american voltages]
@@ -8233,7 +8233,7 @@ Additionally, the \texttt{open} component is treated differently; the voltage is
 \end{circuitikz}
 \end{LTXexample}
 
-If you want or need to maintain the old behavior for \texttt{open} voltage, you can set the key \texttt{open voltage position} to \texttt{legacy} (the default is the new behavior, which correspond to the value \texttt{center}).
+If you want or need to maintain the old behavior for \texttt{open} voltage, you can set the key \texttt{open voltage position} to \texttt{legacy} (the default is the new behavior, which corresponds to the value \texttt{center}).
 
 \subsubsection{American voltages customization}
 
@@ -8249,7 +8249,7 @@ Since 0.9.0, you can change the font\footnote{There was a bug before, noticed by
 \end{circuitikz}
 \end{LTXexample}
 
-Also, if you want to change the symbols (sometime just the $+$ sign is drawn, for example, or for highlighting something),
+Also, if you want to change the symbols (sometimes just the $+$ sign is drawn, for example, or for highlighting something),
 using the keys \texttt{voltage/american plus} and \texttt{voltage/american minus} (default \verb|$+$| and \verb|$-$|).
 
 \begin{LTXexample}[varwidth=true]
@@ -8297,7 +8297,7 @@ This is arguably a bug, but fixing it (separating the voltage generator shapes f
 \subsection{Changing the style of labels, voltages, and other text ornaments}\label{sec:ornament-style}
 
 Since version \texttt{0.9.5}, it is possible to change the style of bipole text ornaments (labels, annotations, voltages etc) by using the appropriate styles or keys.
-The basic style applied to the text are defined in the \texttt{/tikz/circuitikz} key directory and applied to every node that contains the text; you can also change them locally by using the \texttt{tikz} direct keys in local scopes.
+The basic style applied to the text is defined in the \texttt{/tikz/circuitikz} key directory and applied to every node that contains the text; you can also change them locally by using the \texttt{tikz} direct keys in local scopes.
 
 For example, you can make all annotations small by using:
 
@@ -8337,7 +8337,7 @@ The available styles and commands are \texttt{bipole label style}, \texttt{bipol
 
 \subsection{Accessing labels text nodes}
 
-Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{label}s and \texttt{annotation}s was present before, but not documented.} using special node names. So, if you use \texttt{name} to give a name to the bipole node, you can access also the following nodes: \texttt{namelabel} (notice: no space nor any other symbol between \texttt{name} and \texttt{label}!), \texttt{nameannotation}, \texttt{namevoltage}, \texttt{namecurrent} and \texttt{nameflow}. Notice that the node names are available only if the bipole has an anchor or an annotation, of course.
+Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{label}s and \texttt{annotation}s was present before, but not documented.} using special node names. So, if you use \texttt{name} to give a name to the bipole node, you can also access the following nodes: \texttt{namelabel} (notice: no space nor any other symbol between \texttt{name} and \texttt{label}!), \texttt{nameannotation}, \texttt{namevoltage}, \texttt{namecurrent} and \texttt{nameflow}. Notice that the node names are available only if the bipole has an anchor or an annotation, of course.
 
 \begin{LTXexample}[varwidth=true,
             pos=t
@@ -8362,7 +8362,7 @@ Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{
 
 If you want to have more access to the label positioning algorithm, since \texttt{1.2.5} you can access the label  rotation using the command \texttt{\textbackslash ctikzgetdirection\{\emph{nodename}\}} (where node name is for example \texttt{L1label} or \texttt{L2annotation}), and the anchor used for positioning the node as \texttt{\textbackslash ctikzgetanchor\{\emph{component label}\}\{\emph{type}\}}, where \emph{component label} is, for example, \texttt{L1} and type is either \texttt{label} or \texttt{annotation} (notice that the syntax is slightly different, for implementation reasons).
 Those values are available only if the dipole declares a \texttt{l} or \texttt{a} keys; if you want them without any label you need to declare a blank one (like for example \texttt{l=\textasciitilde}).
-The following example gives an idea of the values of those macro for the three types of label positioning strategies.
+The following example gives an idea of the values of those macros for the three types of label positioning strategies.
 
 \begin{LTXexample}[varwidth=true, pos=t]
 \newcommand{\marklabann}[3][45]{% [angle] {node label} {type: label or annotation}
@@ -8389,7 +8389,7 @@ pin={[draw, blue, font=\tiny, align=left]#1:{#2 \\ dir: \ctikzgetdirection{#2#3}
 \subsection{Advanced voltages, currents and flows}\label{sec:vif-anchors}
 
 Since version \texttt{1.2.1}\footnote{some options have been added in \texttt{v1.4.1}}, it is possible to access the anchors of the ``ornaments'' --- voltage, current and flows, together with some additional information that makes it possible to personalize them.
-Normally, voltages and flow and currents are drawn into the path of the bipoles, so that it is not possible, for example, to change the line type or color of the arrows, or the type of arrows\footnote{in regular voltages, the arrows are not real \TikZ{} arrows, but the auxiliary arrow shapes of \Circuitikz{}}. Access to the anchors allows to do all this things, and more.
+Normally, voltages and flow and currents are drawn into the path of the bipoles, so that it is not possible, for example, to change the line type or color of the arrows, or the type of arrows\footnote{in regular voltages, the arrows are not real \TikZ{} arrows, but the auxiliary arrow shapes of \Circuitikz{}}. Access to the anchors allows you to do all these things, and more.
 
 For example, you can do something like this:
 
@@ -8485,7 +8485,7 @@ The meaning of the anchors is the following:
     \texttt{Ipos} and \texttt{Fpos} are the position for the arrowhead or the small flow arrow (which is a \texttt{currarrow} or \texttt{flowarrow} node normally) is positioned, respectively. The label is then added to the correct side of it using the anchor available via \verb|\ctikzgetanchor| (see below,~\ref{sec:advances-aux-info}). In this case, the exact position of the label is not available if you do not position the element, for this there is no \texttt{Flab} or \texttt{Ilab} coordinate; you have to use the \texttt{Fpos} and \texttt{Ipos} coordinate with the corresponding \texttt{Ilab} and \texttt{Flab} anchors.
 \end{itemize}
 
-Changing the options of the elements, will change the anchors acoordingly:
+Changing the options of the elements will change the anchors accordingly:
 
 \begin{lstlisting}
     \ctikzset{current/distance=0.2}
@@ -8536,7 +8536,7 @@ Obviously, the anchors follow the voltage style you choose:
     }
 \end{circuitikz}
 
-Notice the postion of the control points, as well as the fact that the anchor available with \verb|\ctikzgetanchor| is applied to \texttt{Vfrom} and \texttt{Vto} symbols, too.
+Notice the position of the control points, as well as the fact that the anchor available with \verb|\ctikzgetanchor| is applied to \texttt{Vfrom} and \texttt{Vto} symbols, too.
 
 Finally, as ever, generators are treated differently, but you have all your anchors too.
 
@@ -8585,7 +8585,7 @@ For example, you could like the voltage label oriented with the bipole:
 \end{circuitikz}
 \end{LTXexample}
 
-Or you could use the anchor to substitute the flow with a fancy one and still position automatically the label; suppose you have the following definition in your preamble (see \TikZ{} manual, ``Path decorations''):
+Or you could use the anchor to substitute the flow with a fancy one and still position the label automatically; suppose you have the following definition in your preamble (see \TikZ{} manual, ``Path decorations''):
 
 \begin{lstlisting}
 % requires \usetikzlibrary{decorations, decorations.pathmorphing}
@@ -8771,7 +8771,7 @@ You can add nodes to the bipoles, positioned at the coordinates surrounding the 
 \end{circuitikz}
 \end{LTXexample}
 
-These bipole nodes are added after the path is drawn, as every node in Ti\emph{k}Z --- this is the reason why they are always filled (with the main color the normal nodes, with white the open ones), in order to ``hide'' the wire below. You can override the fill color if you want; but notice that if you draw things in two different paths, you will have ``strange'' results; notice that in the second line of resistors the second wire is starting from the center of the white \texttt{ocirc} of the previous path.
+These bipole nodes are added after the path is drawn, as every node in \TikZ\ --- this is the reason why they are always filled (with the main color the normal nodes, with white the open ones), in order to ``hide'' the wire below. You can override the fill color if you want; but notice that if you draw things in two different paths, you will have ``strange'' results; notice that in the second line of resistors the second wire is starting from the center of the white \texttt{ocirc} of the previous path.
 
 \begin{LTXexample}[varwidth=true,
         pos=t
@@ -8918,7 +8918,7 @@ You also have the similar keys for the ``full'' poles (albeit they are probably 
 
 
 \subsection{Mirroring and Inverting}
-Bipole paths can also mirrored and inverted (or reverted) to change the drawing direction.
+Bipole paths can also be mirrored and inverted (or reverted) to change the drawing direction.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -8937,7 +8937,7 @@ Bipole paths can also mirrored and inverted (or reverted) to change the drawing 
 \end{circuitikz}
 \end{LTXexample}
 
-Placing labels, currents and voltages works also, please note, that mirroring and inverting does not influence the positioning of labels and voltages. Labels are by default above/right of the bipole and voltages below/left, respectively.
+Placing labels, currents and voltages also works, please note, that mirroring and inverting does not influence the positioning of labels and voltages. Labels are by default above/right of the bipole and voltages below/left, respectively.
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
    \draw (0,0) to[ospst=T, i=$i_1$, v=$v$] (2,0);
@@ -8999,9 +8999,9 @@ To correct the line ending, there are support shapes to fill the missing rectang
 
 \section{Colors}\label{sec:colors}
 
-Color support in \Circuitikz{} has been quite limited up to version 1.5.1; from that one onward there has been an effort to make component's behavior more intuitive.
+Color support in \Circuitikz{} has been quite limited up to version 1.5.1; from that one onward there has been an effort to make components' behavior more intuitive.
 
-Part of the problem is how colors in paths are treated by \TikZ{} itself; you can see part of the discussion \href{https://github.com/circuitikz/circuitikz/issues/605}{this issue} and in \href{https://tex.stackexchange.com/questions/634987/pgf-basic-layer-struggling-again-with-colors}{this question on TeX.SX} --- many thanks to \texttt{@muzimuzhi} for helping there. Basically, nodes are drawn \emph{after} the path is completed, and color is applied to the path at the end. Look at this code (pure \TikZ, no \Circuitikz{} here):
+Part of the problem is how colors in paths are treated by \TikZ{} itself; you can see part of the discussion on \href{https://github.com/circuitikz/circuitikz/issues/605}{this issue} and in \href{https://tex.stackexchange.com/questions/634987/pgf-basic-layer-struggling-again-with-colors}{this question on TeX.SX} --- many thanks to \texttt{@muzimuzhi} for helping there. Basically, nodes are drawn \emph{after} the path is completed, and color is applied to the path at the end. Look at this code (pure \TikZ, no \Circuitikz{} here):
 
 \begin{LTXexample}[varwidth=true]
 \tikz \draw[thick] (0,0) -- (1,0) {[color=red] -- (2,0) node[draw]{}} --(3,0); \par
@@ -9035,7 +9035,7 @@ Black text
 \tikz \draw[fill=yellow] (0,0) to[R] (2,0) to[R,color=cyan] (4,0) to [generic] (6,0) to [fullgeneric] (8,0);
 \end{LTXexample}
 
-\Circuitikz{} components that are fillable will inherit the \texttt{fill} property of the path (it is almost impossible to do otherwise) as if the \texttt{fill} flag was present. ``Full''-type elements (for example, full diodes or similar) are filled with the draw color; elements with intrinsic labels (i.e., labels that are part of the shape, like signs on amplifiers and pin numbers in chip) are drawn with the ``draw'' colors.
+\Circuitikz{} components that are fillable will inherit the \texttt{fill} property of the path (it is almost impossible to do otherwise) as if the \texttt{fill} flag was present. ``Full''-type elements (for example, full diodes or similar) are filled with the draw color; elements with intrinsic labels (i.e., labels that are part of the shape, like signs on amplifiers and pin numbers in chips) are drawn with the ``draw'' colors.
 
 Basically, you should have no problem if:
 \begin{enumerate}
@@ -9073,7 +9073,7 @@ If you see this problem, please do not use just the color name as a style, like 
 ;\end{circuitikz}
 \end{LTXexample}
 
-One can of course change the color directly in the component:
+One can, of course, change the color directly in the component:
 \begin{LTXexample}[pos=t, varwidth=true]
 \begin{circuitikz} \draw
   (0,0) node[pnp, color=blue](pnp2){q1}
@@ -9095,7 +9095,7 @@ The all-in-one stream of bipoles poses some challenges, as only the actual body 
 ;\end{circuitikz}
 \end{LTXexample}
 
-The postponed application of colors creates problem if you want to use arrows for voltages, because the ``arrows'' are partially part of the path, partially nodes:
+The postponed application of colors creates a problem if you want to use arrows for voltages, because the ``arrows'' are partially part of the path, partially nodes:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
@@ -9181,7 +9181,7 @@ You can combine shape colors with fill colors, too, but you should use the expli
 
 \subsubsection{Background colors different from white}
 
-Notice also that the connection point are always filled, and the color \emph{tries} to follow the color of the filling of the component (but look at section~\ref{sec:transparent-poles}). Moreover, if you want to pass fill transparency down to path-style components, you \emph{have} to put it into the options of the \verb|\draw| command.
+Notice also that the connection point is always filled, and the color \emph{tries} to follow the color of the filling of the component (but look at section~\ref{sec:transparent-poles}). Moreover, if you want to pass fill transparency down to path-style components, you \emph{have} to put it into the options of the \verb|\draw| command.
 
 \begin{LTXexample}[varwidth=true, pos=t]
 \begin{circuitikz}
@@ -9198,7 +9198,7 @@ Notice also that the connection point are always filled, and the color \emph{tri
 
 As you can see, the ``black'' components (as \texttt{D*}) follow the color of the line, not the fill.
 
-Note however that if you choose a colored background, for example with the \verb|\pagecolor{}| command or with other tricks, the nodes will be by default still filled with white.
+Note, however, that if you choose a colored background, for example with the \verb|\pagecolor{}| command or with other tricks, the nodes will be by default still filled with white.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[european]
@@ -9248,7 +9248,7 @@ in your preamble.
 
 But really, your circuit definition is buggy, so the best thing to do is fix that; if you want to name a point in your circuit, you should use a \texttt{coordinate}, not a \texttt{node}.\footnote{Yes, I understand from where the confusion arise --- in circuit theory they are called nodes.} Here is a small tutorial on \emph{why} you should change your circuit.
 
-Nodes, in \TikZ, have normally a non-zero size even when they are empty; moreover, connections are supposed to join the border of nodes. Please study the following (pure \TikZ, not \Circuitikz):
+Nodes, in \TikZ, normally have a non-zero size even when they are empty; moreover, connections are supposed to join the border of nodes. Please study the following (pure \TikZ, not \Circuitikz):
 
 \begin{LTXexample}[varwidth=true]
 \begin{tikzpicture}
@@ -9284,9 +9284,9 @@ Now, before version \texttt{1.2.1} (and since around \texttt{0.6}), \Circuitikz{
 \end{tikzpicture}
 \end{LTXexample}
 
-You can see more example and more reasoning on GitHub; start from the
+You can see more examples and more reasonings on GitHub; start from the
 \href{https://github.com/circuitikz/circuitikz/issues/417}{issue detecting the join problem}, then
-\href{https://github.com/circuitikz/circuitikz/pull/418}{look at the merged fix}; you can follow several issue and discussion from there, but for example there are circuits that can't be drawn with the ``hack'' in, \href{https://github.com/circuitikz/circuitikz/issues/76#issuecomment-652980687}{like this one}.
+\href{https://github.com/circuitikz/circuitikz/pull/418}{look at the merged fix}; you can follow several issues and discussions from there, but for example there are circuits that can't be drawn with the ``hack'' in, \href{https://github.com/circuitikz/circuitikz/issues/76#issuecomment-652980687}{like this one}.
 
 So finally it was decided\footnote{well, Romano decided, so you can blame him. \emph{I do not think that workarounds to correct malformed circuits are really maintainable; just see the bunch of code removed by the patch! --- Romano.}}  to remove the change, to simplify the code and to make the package more maintainable.
 
@@ -9322,7 +9322,7 @@ Nor this one, which is even stranger:
 \end{circuitikz}
 \end{LTXexample}
 
-The other one is to use \texttt{edge} operations\footnote{I took the idea form \href{https://tex.stackexchange.com/a/554905/38080}{this answer by \texttt{@LaTeXdraw-com} user on TeX.SE}, thanks!}; be sure to read about it on the \TikZ{} manual\footnote{in 3.1.5b, section~17.12, ``connecting nodes: use the \texttt{edge} operation''} --- but basically this is similar to the \texttt{to} operation but it builds another path (added at the end of the current path, like nodes are). This means that it can use different options, and that it \textbf{does not} moves the path coordinates.
+The other one is to use \texttt{edge} operations\footnote{I took the idea form \href{https://tex.stackexchange.com/a/554905/38080}{this answer by \texttt{@LaTeXdraw-com} user on TeX.SE}, thanks!}; be sure to read about it on the \TikZ{} manual\footnote{in 3.1.5b, section~17.12, ``connecting nodes: use the \texttt{edge} operation''} --- but basically this is similar to the \texttt{to} operation but it builds another path (added at the end of the current path, like nodes are). This means that it can use different options, and that it \textbf{does not} move the path coordinates.
 
 So, for example:
 
@@ -9416,7 +9416,7 @@ In versions up to \texttt{1.2.7}, use for example \verb|\mbox{}| or define \verb
 
 \subsection{Global scaling and rotating}\label{faqs:scale-and-rotate}
 
-\faqQ I tried to change the direction of the $y$ axis with \texttt{yscale=-1}, but the circuit is completely messed up.
+\faqQ I tried to change the direction of the $y$-axis with \texttt{yscale=-1}, but the circuit is completely messed up.
 
 \faqA Yes, it's a known bug (or misfeature, or limitation). See section~\ref{sec:bugs}. Don't do that.
 
@@ -9463,11 +9463,11 @@ Version 1.3.3 fixes the direction of the arrows in tunable elements; before this
 \end{quote}
 
 
-\textbf{Big fat warning}: this material is reserved to \TeX-hackers; do not delve into this if you have no familiarity with (at least) a bit of core \TeX{} programming and to the basic \TikZ{} layer. You have been warned.
+\textbf{Big fat warning}: this material is reserved for \TeX-hackers; do not delve into this if you have no familiarity with (at least) a bit of core \TeX{} programming and to the basic \TikZ{} layer. You have been warned.
 
 \subsection{Suggested setup}
 
-Notice: the source code has been re-organized after release 1.2.7; if you are bound to use an older version check the corresponding manual.
+Notice: the source code has been reorganized after release 1.2.7; if you are bound to use an older version check the corresponding manual.
 
 The suggested way to start working on a new component is to use the utilities of the \Circuitikz{} manual for checking and testing your device. Basically, find (or download) the source code of the last version of \Circuitikz{} and find the file \texttt{ctikzmanutils.sty}; copy it in your directory and prepare a file like this:
 
@@ -9504,7 +9504,7 @@ The suggested way to start working on a new component is to use the utilities of
 \end{document}
 \end{lstlisting}
 
-This will compile to something like this (in this case, we are using a couple of existing components to check everything is ok):
+This will compile to something like this (in this case, we are using a couple of existing components to check everything is OK):
 
 \circuitdescbip*{damper}{Mechanical damping}{}(left/135/0.2, right/45/0.2, center/-90/0.3)
 
@@ -9527,7 +9527,7 @@ Let's define for example a path style component, like the one suggested by the u
 
 The definitions of the components are in the files \texttt{pgfcirc\emph{something}.tex}; they are more or less distributed by the number of terminals, but there are exceptions (for example, switches are in \texttt{bipoles}, even if several of them are tripoles or more\dots \texttt{grep} is your friend here.
 
-To define the new component we will look into (in this case) \texttt{pgfcircbipoles.tex}; at the start of the block where the components are defined you can find the relevant definitions (sometime some of the definitions are in \texttt{pgfcirc.defines.tex}, for historical or dependencies reasons).
+To define the new component we will look into (in this case) \texttt{pgfcircbipoles.tex}; at the start of the block where the components are defined, you can find the relevant definitions (sometime some of the definitions are in \texttt{pgfcirc.defines.tex}, for historical or dependencies reasons).
 The first step is to check if we can use the definition already existing for similar elements (for coherence of size) or if we need to define new ones; for this you have to check into the  we find
 
 \begin{lstlisting}
@@ -9595,7 +9595,7 @@ This is not sufficient for using the element in a \texttt{to[]} path command; yo
 \pgfcirc@activate@bipole@simple{l}{viscoe}
 \end{lstlisting}
 
-In the definition above, the \texttt{\{l\}} parameter means that using the component like \texttt{to[viscoe=A]} will be equivalent to \texttt{to[viscoe, l=A]}; you can use also \texttt{v} or \texttt{i} or \texttt{f} if your component needs it.
+In the definition above, the \texttt{\{l\}} parameter means that using the component like \texttt{to[viscoe=A]} will be equivalent to \texttt{to[viscoe, l=A]}; you can also use \texttt{v} or \texttt{i} or \texttt{f} if your component needs it.
 Now you can show it with:
 
 \begin{lstlisting}
@@ -9611,10 +9611,10 @@ Now you can show it with:
 \end{LTXexample}
 \end{lstlisting}
 
-Obviously, at first you you just have a component that is the same as the one you copied with another name.
+Obviously, at first you just have a component that is the same as the one you copied with another name.
 It is now just a matter of modifying it so that it has the desired shape; in the example above you can already see the new symbol after the changes.
 
-When doing the drawing in the main argument of the \verb|\pgfcircdeclarebipole|, things will be setup so that the lengths \verb|\pgf@circ@res@right|
+When doing the drawing in the main argument of the \verb|\pgfcircdeclarebipole|, things will be set up so that the lengths \verb|\pgf@circ@res@right|
 and \verb|\pgf@circ@res@up| are the $x$-$y$ coordinates of the upper right corner, and
 \verb|\pgf@circ@res@left|  and \verb|\pgf@circ@res@down| are the $x$-$y$ coordinates of the lower left corner of your shape. The \texttt{center} coordinate is usually at $(0pt, 0pt)$.
 
@@ -9657,7 +9657,7 @@ Now you can check if the voltage labels are correct for your new component:
 \end{circuitikz}
 \end{LTXexample}
 
-If you think they are too tight or too loose you can use a (developer-only) key to adjust the distance:
+If you think they are too tight or too loose, you can use a (developer-only) key to adjust the distance:
 
 \begin{LTXexample}[varwidth]
 \begin{circuitikz}
@@ -9712,7 +9712,7 @@ Since version \texttt{v1.5.0}, before starting the drawing of any component, \Ci
     \item \texttt{\textbackslash ctikz@hook@start@draw@class@\emph{myclass}}
     \item \texttt{\textbackslash ctikz@hook@start@draw@default}
 \end{itemize}
-The first one that is defined in the current (or outer) scope is used, and the following ones are not used. This hooks can be used to set drawing parameters, or to reset them to a known state: \TikZ{} normally inherit most of the drawing option, but that can lead to surprises (like unexpected arrows, etc.).
+The first one that is defined in the current (or outer) scope is used, and the following ones are not used. These hooks can be used to set drawing parameters, or to reset them to a known state: \TikZ{} normally inherit most of the drawing option, but that can lead to surprises (like unexpected arrows, etc.).
 
 In the same way, before leaving  \verb|\pgf@circ@draw@component|, a set of similar hooks (with \texttt{end} instead of \texttt{start}) is tried, with the same logic.
 
@@ -9721,7 +9721,7 @@ The only predefined hook is \texttt{\textbackslash ctikz@hook@start@draw@default
     \pgfsetshortenstart{+0pt}\pgfsetshortenend{+0pt}\pgfsetarrows{-}%
     \def\pgf@circ@reset@rounded{\pgfsetcornersarced{\pgfpointorigin}}%
 \end{lstlisting}
-which mean that, by  default, arrows parameters are reset to the default (no shorten, no arrows) and that corners are not rounded. If you want to override them, just define the appropriate hook for you component/class and the generic one will not be called.
+which means that, by  default, arrows parameters are reset to the default (no shorten, no arrows) and that corners are not rounded. If you want to override them, just define the appropriate hook for your component/class and the generic one will not be called.
 
 No \texttt{...@end@draw@...} hook is defined by default.
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -503,7 +503,7 @@ Finally, we would like to add voltages indication for carrying out the current f
 \end{circuitikz}
 \end{LTXexample}
 
-\emph{Et voilá!}. Remember that this is still \LaTeX, which means that you have done a description of your circuit, which is, in a lot of way, independent of the visualization of it. If you ever have to adapt the circuit to, say, a journal that forces European style and flows instead of currents, you just change a couple of things and you have what seems a completely different diagram:
+\emph{Et voilà!}. Remember that this is still \LaTeX, which means that you have done a description of your circuit, which is, in a lot of way, independent of the visualization of it. If you ever have to adapt the circuit to, say, a journal that forces European style and flows instead of currents, you just change a couple of things and you have what seems a completely different diagram:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[european, voltage shift=0.5]

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -156,7 +156,7 @@ There is really no support for Plain TeX --- the maintainers are willing to cons
 
 The stable version of the package should come with your \LaTeX\ distribution. Downloading the files from CTAN and installing them locally is, unfortunately, a distribution-dependent task and sometimes not so trivial. If you search for \texttt{local texmf tree} and the name of your distribution on \url{https://tex.stackexchange.com/} you will find a lot of hints.
 
-Anyway, the easiest way of using whichever version of \Circuitikz\ is to point to the github page \url{https://circuitikz.github.io/circuitikz/} of the project, and download the version you want. You will download a simple (biggish) file, called \texttt{circuitikzgit.sty}.
+Anyway, the easiest way of using whichever version of \Circuitikz\ is to point to the GitHub page \url{https://circuitikz.github.io/circuitikz/} of the project, and download the version you want. You will download a simple (biggish) file, called \texttt{circuitikzgit.sty}.
 
 Now you can just put this file in your local \texttt{texmf} tree, if you have one, or simply adding it into the same directory where your main file resides, and then use
 
@@ -246,7 +246,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 
 
 \subsection{Incompabilities between versions}\label{sec:incompatible-changes}
-Here, we will provide a list of incompabilities between different version of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
+Here, we will provide a list of incompabilities between different versions of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
 If unsure, you can check the version in your local installation by using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
     \item Version \texttt{1.6.0} has a big rewrite of the block's code. In principle the changes are backward-compatible, but there were several bugs (wrong anchors, errors with rotations, and so on) that have been fixed in the process.
@@ -304,7 +304,7 @@ If you have older projects that show compatibility problems, you have two option
         \end{lstlisting}
         which is an inferior solution because it can fool any package you use that depend on \texttt{circuitikz}.
 
-        Either way, you have to take care of the options that may have changed between versions (and sometime syles, if you use them).
+        Either way, you have to take care of the options that may have changed between versions (and sometime styles, if you use them).
     \item   if you are using  \ConTeXt, only versions \texttt{0.8.3}, \texttt{0.9.3},  \texttt{0.9.6}, \texttt{1.0}, \texttt{1.1.2}, \texttt{1.2.7}, and \texttt{1.4.6} are packaged; you can use it with
         \begin{lstlisting}[numbers=none]
             \usemodule[circuitikz-0.8.3]
@@ -313,7 +313,7 @@ If you have older projects that show compatibility problems, you have two option
 
 
 \subsection{Feedback}
-The easiest way to contact the authors is via the official Github repository: \url{https://github.com/circuitikz/circuitikz/issues}. For general help question, a lot of nice people are  quite active on \url{https://tex.stackexchange.com/questions/tagged/circuitikz} --- be sure to read the help pages for the site and ask!
+The easiest way to contact the authors is via the official GitHub repository: \url{https://github.com/circuitikz/circuitikz/issues}. For general help question, a lot of nice people are  quite active on \url{https://tex.stackexchange.com/questions/tagged/circuitikz} --- be sure to read the help pages for the site and ask!
 
 \subsection{Package options}
 \label{sec:package-options}
@@ -422,7 +422,7 @@ Feel free to load the package with your own cultural options:
 
 \section{Tutorials}
 
-Before even starting with  \Circuitikz{} you should be sure to have understood the basics of \TikZ{}. It is \emph{higlhly recommended} that you read and go through \emph{at least}  the following parts of the \TikZ{} manual:
+Before even starting with  \Circuitikz{} you should be sure to have understood the basics of \TikZ{}. It is \emph{hightly recommended} that you read and go through \emph{at least}  the following parts of the \TikZ{} manual:
 \begin{itemize}
     \item ``Tutorial: A Picture for Karl's Students'' (around page 30);
     \item ``Specifying Coordinates'' (around page 131)
@@ -564,7 +564,7 @@ We have to start the drawing from a generic point. Given that the idea is to hav
 \end{circuitikz}
 \end{LTXexample}
 
-In this snippet, notice that the only absolute coordinate is the first one; that will enable us to ``copy and paste'' the circuit in several places, or create a macro for it. We position a text node above it, and then draw a wire with a pole to a relative \texttt{(1,0)} coordinate: in other word, we \emph{move} 1~unit to the right drawing a short-circuit, which is the same as a wire. The usage of \texttt{to[short...]} simplifies the position of the pole, but notice that we could have also written:
+In this snippet, notice that the only absolute coordinate is the first one; that will enable us to ``copy and paste'' the circuit in several places, or create a macro for it. We position a text node above it, and then draw a wire with a pole to a relative \texttt{(1,0)} coordinate: in other words, we \emph{move} 1~unit to the right drawing a short-circuit, which is the same as a wire. The usage of \texttt{to[short...]} simplifies the position of the pole, but notice that we could have also written:
 \begin{lstlisting}[numbers=none]
     \draw (0,0) node[above]{$v_i$} node[ocirc]{} -- ++(1,0) ...
 \end{lstlisting}
@@ -674,7 +674,7 @@ Defining a macro for our amplifier could be as easy as this:
 }
 \end{lstlisting}
 
-We remove the open poles (it's better to draw them at the end to avoid artefacts) and then we make the names of the coordinates and of the nodes unique, by prepending a parameter that we will provide at every invocation. Then we remove the labels (for simplicity here) and add a couple of coordinates that we will be able to use from the outside when building our circuit.
+We remove the open poles (it's better to draw them at the end to avoid artifacts) and then we make the names of the coordinates and of the nodes unique, by prepending a parameter that we will provide at every invocation. Then we remove the labels (for simplicity here) and add a couple of coordinates that we will be able to use from the outside when building our circuit.
 
 And we can use it like in the following:
 
@@ -787,7 +787,7 @@ We will start connecting the first transistor with the power supply with a coupl
 \end{circuitikz}
 \end{LTXexample}
 
-After that, let's add the input part. I will use a named node here, referring to it to add the input source. Notice how the ground node is positioned: the coordinate \texttt{(in |- GND)} is the point with the horizontal coordinate of \texttt{(in)}  and the vertical one of \texttt{(GND)}, lining it up with the ground of the capacitor $C_1$ (you can think it as ``the point aligned verticallly with \texttt{in} and horizontally with \texttt{GND}'').
+After that, let's add the input part. I will use a named node here, referring to it to add the input source. Notice how the ground node is positioned: the coordinate \texttt{(in |- GND)} is the point with the horizontal coordinate of \texttt{(in)}  and the vertical one of \texttt{(GND)}, lining it up with the ground of the capacitor $C_1$ (you can think it as ``the point aligned vertically with \texttt{in} and horizontally with \texttt{GND}'').
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american, scale=0.7, transform shape]
@@ -1076,7 +1076,7 @@ Now we can add the not port. Since version~\texttt{1.1.3} you can use a path-sty
 \end{circuitikz}
 \end{LTXexample}
 
-In earlier version, you should have found the center point between the two terminal, position the ``not'' shape and ten connect it, like for example (this code must stay into the \verb|\draw| command):
+In earlier versions, you should have found the center point between the two terminal, position the ``not'' shape and ten connect it, like for example (this code must stay into the \verb|\draw| command):
 
 \begin{lstlisting}
     % let's position the NOT in the center
@@ -1086,7 +1086,7 @@ In earlier version, you should have found the center point between the two termi
     (in) -- (NOT.in) (NOT.out) |- (AND2.in 2)
 \end{lstlisting}
 
-Now we have the basic block; we have to use it twice, so one of the possible way to do it is to prepare a command.
+Now we have the basic block; we have to use it twice, so one of the possible ways to do it is to prepare a command.
 We will change the names of the nodes and the coordinates to be different for any ``call'' of the block (another option is to use a \texttt{pic}; but this is more straightforward).
 
 \begin{lstlisting}
@@ -1293,11 +1293,11 @@ the \texttt{+(x,y)}-style coordinates (which are supposed to set a temporary rel
 
 These kind of coordinate have in practice little use for the building of circuits, so have been only (very) lightly tested; avoid them if you can --- the behavior will depend not only on the \Circuitikz{} version, but also on the \TikZ{} layer underneath.
 
-This behavior, although not optimal, was standard in \texttt{to} operation in plain \TikZ{} before version 3.1.8; it was changed by Henri Menke in later versions. Notice that the change revealed a problem in \Circuitikz{} that should hopefully fixed in \texttt{v1.4.1}; for more details see \href{https://github.com/circuitikz/circuitikz/issues/569}{this issue on GitHub}.
+This behavior, although not optimal, was standard in \texttt{to} operation in plain \TikZ{} before version 3.1.8; it was changed by Henri Menke in later versions. Notice that the change revealed a problem in \Circuitikz{} that should hopefully be fixed in \texttt{v1.4.1}; for more details see \href{https://github.com/circuitikz/circuitikz/issues/569}{this issue on GitHub}.
 
 You can see from the example below (notice the blue curve using a spline line). If all the vertical lines are at the left, the manual has been compiled with a new \Circuitikz{} and \TikZ. Otherwise, the red and/or blue curve will have the vertical line at the right (which in principle is wrong).
 
-In the last (green) example, you can see a workaround using local path and the key \texttt{current point is local} that will work for older (and do not create problem in newer) versions.
+In the last (green) example, you can see a workaround using local path and the key \texttt{current point is local} that will work for older (and do not create problems in newer) versions.
 
 \begin{LTXexample}[varwidth=true, pos=t]
 Plotted using Ti\emph{k}Z version \pgfversion{} and CircuiTi\emph{k}Z version \pgfcircversion{}.
@@ -1429,7 +1429,7 @@ The shape of the components are adjustable with a lot of parameters; in this man
     \tikz \draw (0,0) to[R=1<\ohm>] (2,0);
 \end{LTXexample}
 
-It is recommended to use the styling parameters to change the shapes; they are not so fine grained (for example, you can change the width of resistor, not the height at the moment), but they are more stable and coherent across your circuit.
+It is recommended to use the styling parameters to change the shapes; they are not so fine-grained (for example, you can change the width of resistor, not the height at the moment), but they are more stable and coherent across your circuit.
 
 \subsubsection{Descriptions}
 
@@ -1460,7 +1460,7 @@ Node-style components (monopoles, multipoles) can be drawn at a specified point 
 \noindent
 Explanation of the parameters:\\
 \texttt{\#1}: component name\footnote{For using bipoles as nodes, the name of the node is \texttt{\#1shape}.} (mandatory)\\
-\texttt{\#2}: list of comma separated options (optional)\\
+\texttt{\#2}: list of comma-separated options (optional)\\
 \texttt{\#3}: name of an anchor (optional)\\
 \texttt{\#4}: text written to the text anchor of the component (optional)\\
 
@@ -1477,7 +1477,7 @@ Explanation of the parameters:\\
 
 \subsubsection{Mirroring and flipping}\label{sec:mirroring-and-flipping}
 
-Mirroring and flipping of node components is obtained by using the \TikZ\ keys \texttt{xscale} and \texttt{yscale}. Notice that this parameters affect also text labels, so they need to be un-scaled by hand. Notice that you \textbf{do not} use \texttt{xscale} or~\texttt{yscale} in a path-style component, see section~\ref{sec:mirror-flip-path} for that case.
+Mirroring and flipping of node components is obtained by using the \TikZ\ keys \texttt{xscale} and \texttt{yscale}. Notice that these parameters also affect text labels, so they need to be un-scaled by hand. Notice that you \textbf{do not} use \texttt{xscale} or~\texttt{yscale} in a path-style component, see section~\ref{sec:mirror-flip-path} for that case.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[scale=0.7, transform shape]
@@ -1507,7 +1507,7 @@ the text of nodes drawn with, respectively,
 
 \subsubsection{Anchors}
 
-Node components anchors vary a lot across the various kind of components, so they will described better after each category is presented in the manual. In general all components have geographic anchors (\texttt{north}, \texttt{north west}, \dots), but most of the other anchors are very component-specific.
+Node components anchors vary a lot across the various kinds of components, so they will be described better after each category is presented in the manual. In general all components have geographic anchors (\texttt{north}, \texttt{north west}, \dots), but most of the other anchors are very component-specific.
 
 \subsubsection{Descriptions}
 
@@ -1691,7 +1691,7 @@ The \texttt{example} style file will simply make the amplifiers filled with ligh
 \ctikzloadstyle{legacy}
 \ctikzloadstyle{romano}
 
-The styles \texttt{legacy} is a style that set (most) of the style parameters to the default, and \texttt{romano} is a style used by one of the authors; you can use these styles as is or you can use them to learn to how to write new file style following the instructions in section~\ref{sec:writingstylefiles}. In the next diagrams, the left hand one is using the \texttt{romano circuit style} and the rigth hand one the legacy style.
+The style \texttt{legacy} is a style that set (most) of the style parameters to the default, and \texttt{romano} is a style used by one of the authors; you can use these styles as is or you can use them to learn to how to write new file style following the instructions in section~\ref{sec:writingstylefiles}. In the next diagrams, the left hand one is using the \texttt{romano circuit style} and the rigth hand one the legacy style.
 
 \fbox{\tmpcirc{scale=0.6, transform shape, romano circuit style}{}}
 \fbox{\tmpcirc{scale=0.6, transform shape, legacy circuit style}{}}
@@ -1706,7 +1706,7 @@ Basically, to write the style \texttt{example}, you edit a file named \texttt{ct
 
 \lstinputlisting[frame=single, framesep=10pt]{ctikzstyle-example.tex}
 
-This kind of style will \emph{add} to the existing style.  If you want to have a style that \emph{substitute} the current style, you should do like this:
+This kind of style will \emph{add} to the existing style.  If you want to have a style that \emph{substitutes} the current style, you should do like this:
 
 \begin{lstlisting}[frame=single, framesep=10pt]
 \ctikzloadstyle{legacy}% start from a known state
@@ -1719,7 +1719,7 @@ This kind of style will \emph{add} to the existing style.  If you want to have a
     }}
 \end{lstlisting}
 
-If you want to add a setting to your style file that has been recently added to the package (for example, the thyristor compact shapes added in \texttt{1.3.5}), but you want that your style file is still compatible with older versions of \Circuitikz, you can use the \texttt{.try} statement:
+If you want to add a setting to your style file that has been recently added to the package (for example, the thyristor compact shapes added in \texttt{1.3.5}), but you want your style file to be still compatible with older versions of \Circuitikz, you can use the \texttt{.try} statement:
 
 \begin{lstlisting}[frame=single, framesep=10pt]
     % Diodes
@@ -1742,7 +1742,7 @@ Or, in case of new values of existing ``choice'' keys, you can use the syntax:
 
 \subsection{Subcircuits}\label{sec:subcircuits}
 
-Starting from version \texttt{1.3.5}, there is support for generating sub-circuits, or circuits blocks. The creation and use of subcircuits is somewhat limited, to keep them simple and easy to define and maintain.
+Starting from version \texttt{1.3.5}, there is support for generating sub-circuits, or circuit blocks. The creation and use of subcircuits is somewhat limited, to keep them simple and easy to define and maintain.
 
 A subcircuit is basically a path (and just one path!) of generic \TikZ{} instructions, with a series of accessible coordinates that behave more or less like anchors in the ``real'' shapes. The basic limitation is that a subcircuit can be moved, replicated and placed around but it can't be easily personalized. Even if scaling and rotation is in principle possible, it is not easily done. Nevertheless, they can be quite useful to build complex components and reusable blocks.
 
@@ -1750,8 +1750,8 @@ A subcircuit is basically a path (and just one path!) of generic \TikZ{} instruc
 
 To define a block you use the \verb|\ctikzsubcircuitdef| macro; this macro has 3 arguments:
 \begin{itemize}
-    \item the first argument is the name of the subcircuit, and it must form a valid TeX command name when prepended with a backslash: so just letters (no spaces, nor numbers, nor symbols like underscores etc.);
-    \item the second one is a comma-separated list of anchors names; here you can use whatever you can use for naming a coordinate or a node (so it's much more relaxed that the first one);
+    \item the first argument is the name of the subcircuit, and it must form a valid TeX command name when prepended with a backslash: so just letters (no spaces, nor numbers, nor symbols like underscores, etc.);
+    \item the second one is a comma-separated list of anchor names; here you can use whatever you can use for naming a coordinate or a node (so it's much more relaxed than the first one);
 \item finally, the commands that will draw the circuit. You must suppose you are in a \verb|\draw| command, with the start coordinate already set-up. You can (and should) use \verb|#1| as the name of the current node, and you \emph{must} define the coordinates of all the anchors listed before as \texttt{coordinate(\#1-\emph{anchorname})}. You should \textbf{not} finish the path here and use \textbf{only relative coordinates} or \textbf{named ones}.
 \end{itemize}
 
@@ -1805,7 +1805,7 @@ Then we have a series of anchor names; here we can use letters, numbers, spaces 
 Additionally, the anchor named \texttt{subckt@reference} is reserved and shouldn't be used.
 If you use spaces, be on the safe side and \emph{never} use two or more consecutive spaces.
 
-After that, you have to draw your subcircuit as if you where into a \verb|\draw| command, starting from a generic point.
+After that, you have to draw your subcircuit as if you were into a \verb|\draw| command, starting from a generic point.
 In this case, we decide to draw the circuit around this generic point so that it will result to be the center of the block; so as a first thing, we ``mark'' the position of the center anchor, with \texttt{coordinate(\#1-center)}.
 The \texttt{\#1} will be substituted with the specific name of the subcircuit's instance later --- so if you then call one instance of the optocoupler \texttt{opto1}, that coordinate will be called \texttt{opto1-center}.
 
@@ -1853,7 +1853,7 @@ To scale and rotate a subcircuit you have to include it into a \texttt{scope} wi
 
 \subsubsection{Parameters in subcircuits}
 
-There are no additional parameters definable for subcircuit shapes; this is a bit of a pity, because sometime they could be useful, especially for labels of objects.
+There are no additional parameters definable for subcircuit shapes; this is a bit of a pity, because sometimes they could be useful, especially for labels of objects.
 Given the need to use \texttt{transform shape} to translate and rotate them, though, it is better not to add invariant-direction things (like text) into the subcircuit, unless you are sure you will just translate them.
 One possibility is to use additional macros and anchors for positioning, like in the following example.
 
@@ -1947,7 +1947,7 @@ The power supplies are normally drawn with the arrows shown in the list above.
 
 \paragraph{Power supply anchors}
 
-They are similar to grounds anchors, and the geographical anchors are correct only for the default arrow.
+They are similar to ground anchors, and the geographical anchors are correct only for the default arrow.
 
 \showanchors[baseline]{vcc, scale=1.5}{}(north/90/0.4, north east/45/0.4, east/0/0.4, south east/-45/0.4,
     south/-90/0.4, south west/-135/0.4, west/180/0.4, north west/135/0.4)
@@ -1978,7 +1978,7 @@ Note that the anchors are at the start of the connecting lines, and that geograp
 
 However, arrows in \TikZ{} are in the same class with the line thickness, so they do not scale with neither the class \texttt{power supplies} scale nor the global scale parameter (you should use \texttt{transform canvas=\{scale\dots\}} for this).
 
-If you want that the arrows behave like the legacy symbols (which are shapes), \emph{only in the arrow definitions}, you can use the special length parameter \verb|\scaledwidth|\footnote{Thanks to @Schrödinger's cat on \href{https://tex.stackexchange.com/a/506249/38080}{\TeX{} stackexchange site}} in the arrow definition, which correspond to the width of the legacy \texttt{vcc} or \texttt{vee}. Compare the effects on the following circuit.
+If you want the arrows to behave like the legacy symbols (which are shapes), \emph{only in the arrow definitions}, you can use the special length parameter \verb|\scaledwidth|\footnote{Thanks to @Schrödinger's cat on \href{https://tex.stackexchange.com/a/506249/38080}{\TeX{} stackexchange site}} in the arrow definition, which correspond to the width of the legacy \texttt{vcc} or \texttt{vee}. Compare the effects on the following circuit.
 
 \begin{LTXexample}[pos=t]
 \ctikzset{%
@@ -2066,7 +2066,7 @@ Since version \texttt{0.9.5}, you can control the position of the wiper in poten
 \end{circuitikz}
 \end{LTXexample}
 
-Since version \texttt{1.6.0}, potentiometers and variable resistors have extra anchors\footnote{Thanks to a suggestion by \href{https://github.com/circuitikz/circuitikz/issues/663}{Dr. Matthias Jung on GitHub}}, to allow this kind of circuits (that seems to be common in some region):
+Since version \texttt{1.6.0}, potentiometers and variable resistors have extra anchors\footnote{Thanks to a suggestion by \href{https://github.com/circuitikz/circuitikz/issues/663}{Dr. Matthias Jung on GitHub}}, to allow this kind of circuit (that seems to be common in some region):
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
 \begin{circuitikz}[european]
@@ -2121,7 +2121,7 @@ For the american style resistors, you can change the number of ``zig-zags'' by s
 
 \paragraph{Thickness.}\label{sec:resistor-thickness} The line thickness of the resistive components is governed by the class thickness; you can change it assigning a value to the key \texttt{resistors/thickness} (default \texttt{none}, that means \texttt{bipoles/thickness} is used, and that defaults to \texttt{2.0}; the value is relative to the base line thickness).
 
-We can call \emph{modifiers} the elements that are added to the basic shape to express some characteristics of the component; for example the arrows for the variable resistors or the bar for the sensors. Normally the thickness of this elements is the same as the one chosen for the component\footnote{Due to a bug in versions before 1.3.4, that didn't happen for thermistors}. You can change their thickness with the class key \texttt{modifier thickness} which is relative to the main component thickness.
+We can call \emph{modifiers} the elements that are added to the basic shape to express some characteristics of the component; for example the arrows for the variable resistors or the bar for the sensors. Normally the thickness of these elements are the same as the one chosen for the component\footnote{Due to a bug in versions before 1.3.4, that didn't happen for thermistors}. You can change their thickness with the class key \texttt{modifier thickness} which is relative to the main component thickness.
 
 \begin{LTXexample}[varwidth]
 \begin{circuitikz}[american]
@@ -2248,7 +2248,7 @@ Finally, if the \texttt{europeaninductors} option is active (or the style \textt
     \ctikzset{inductor=cute} % back to default
 \end{groupdesc}
 
-For historical reasons, \emph{chokes} comes only in the \texttt{cute}. You can use the \texttt{core west} and \texttt{core east} anchors (see~\ref{sec:inductors-core-anchors}) to build your own core lines for the other inductors.
+For historical reasons, \emph{chokes} come only in the \texttt{cute}. You can use the \texttt{core west} and \texttt{core east} anchors (see~\ref{sec:inductors-core-anchors}) to build your own core lines for the other inductors.
 
 \begin{groupdesc}
     \circuitdescbip[cutechoke]{cute choke}{Choke}{}
@@ -2313,7 +2313,7 @@ to[L, loops=6, name=D] ++(2,0);
 \end{LTXexample}
 
 \paragraph{Core anchors.}\label{sec:inductors-core-anchors}
-Inductors have additional anchors to add core lines (for historical reasons, there is a \texttt{cute choke} component also, but to use inductors in the chosen style you better use these anchors). The anchors are called \texttt{core west} and \texttt{core east} and they are positioned at a distance that you can tweak with the \texttt{\textbackslash ctikzset} key \texttt{bipoles/inductors/core distance} (default \texttt{2pt}).
+Inductors have additional anchors to add core lines (for historical reasons, there is a \texttt{cute choke} component also, but to use inductors in the chosen style you'd better use these anchors). The anchors are called \texttt{core west} and \texttt{core east} and they are positioned at a distance that you can tweak with the \texttt{\textbackslash ctikzset} key \texttt{bipoles/inductors/core distance} (default \texttt{2pt}).
 
 \begin{LTXexample}[varwidth]
     \begin{circuitikz}[]
@@ -2332,7 +2332,7 @@ Inductors have additional anchors to add core lines (for historical reasons, the
 Notice that the core lines will \textbf{not} change the position of labels. You have to move them by hand if needed (or position them on the other side); see~\ref{sec:adjust-label-position}.
 
 \paragraph{Dot anchors.}
-Inductances have also ``dot'' anchors\footnote{proposed by Romano in a discussion by \href{https://github.com/circuitikz/circuitikz/issues/618}{GitHub user AndreaDiPietro92}},
+Inductances also have ``dot'' anchors\footnote{proposed by Romano in a discussion by \href{https://github.com/circuitikz/circuitikz/issues/618}{GitHub user AndreaDiPietro92}},
 to help positioning dots when specifying mutual inductance signs. The anchors are name \texttt{lr dot} (for lower right dot), \texttt{ur dot} (upper right) and so on:
 \begin{quote}
     \showanchors{cuteinductorshape}{}(lr dot/-45/0.2, ur dot/45/0.2, ll dot/-135/0.2, ul dot/135/0.2)
@@ -2591,9 +2591,9 @@ Notice that source and generators are divided in three classes that can be style
 \end{groupdesc}
 
 \begin{framed}
-If (default behaviour) \texttt{europeancurrents} option is active (or the style \texttt{[european currents]} is used), the shorthands \texttt{current source}, \texttt{isource}, and \texttt{I} are equivalent to \texttt{european current source}. Otherwise, if \texttt{americancurrents} option is active (or the style \texttt{[american currents]} is used) they are equivalent to \texttt{american current source}.
+If (default behavior) \texttt{europeancurrents} option is active (or the style \texttt{[european currents]} is used), the shorthands \texttt{current source}, \texttt{isource}, and \texttt{I} are equivalent to \texttt{european current source}. Otherwise, if \texttt{americancurrents} option is active (or the style \texttt{[american currents]} is used) they are equivalent to \texttt{american current source}.
 
-Similarly, if (default behaviour) \texttt{europeanvoltages} option is active (or the style \texttt{[european voltages]} is used), the shorthands \texttt{voltage source}, \texttt{vsource}, and \texttt{V} are equivalent to \texttt{european voltage source}. Otherwise, if \texttt{americanvoltages} option is active (or the style \texttt{[american voltages]} is used) they are equivalent to \texttt{american voltage source}.
+Similarly, if (default behavior) \texttt{europeanvoltages} option is active (or the style \texttt{[european voltages]} is used), the shorthands \texttt{voltage source}, \texttt{vsource}, and \texttt{V} are equivalent to \texttt{european voltage source}. Otherwise, if \texttt{americanvoltages} option is active (or the style \texttt{[american voltages]} is used) they are equivalent to \texttt{american voltage source}.
 \end{framed}
 
 
@@ -2623,9 +2623,9 @@ Similarly, if (default behaviour) \texttt{europeanvoltages} option is active (or
 \end{groupdesc}
 
 \begin{framed}
-If (default behaviour) \texttt{europeancurrents} option is active (or the style \texttt{[european currents]} is used), the shorthands \texttt{controlled current source}, \texttt{cisource}, and \texttt{cI} are equivalent to \texttt{european controlled current source}. Otherwise, if \texttt{americancurrents} option is active (or the style \texttt{[american currents]} is used) they are equivalent to \texttt{american controlled current source}.
+If (default behaviur) \texttt{europeancurrents} option is active (or the style \texttt{[european currents]} is used), the shorthands \texttt{controlled current source}, \texttt{cisource}, and \texttt{cI} are equivalent to \texttt{european controlled current source}. Otherwise, if \texttt{americancurrents} option is active (or the style \texttt{[american currents]} is used) they are equivalent to \texttt{american controlled current source}.
 
-Similarly, if (default behaviour) \texttt{europeanvoltages} option is active (or the style \texttt{[european voltages]} is used), the shorthands \texttt{controlled voltage source}, \texttt{cvsource}, and \texttt{cV} are equivalent to \texttt{european controlled voltage source}. Otherwise, if \texttt{americanvoltages} option is active (or the style \texttt{[american voltages]} is used) they are equivalent to \texttt{american controlled voltage source}.
+Similarly, if (default behaviur) \texttt{europeanvoltages} option is active (or the style \texttt{[european voltages]} is used), the shorthands \texttt{controlled voltage source}, \texttt{cvsource}, and \texttt{cV} are equivalent to \texttt{european controlled voltage source}. Otherwise, if \texttt{americanvoltages} option is active (or the style \texttt{[american voltages]} is used) they are equivalent to \texttt{american controlled voltage source}.
 \end{framed}
 
 The following two behave like the corresponding independent sources, see section~\ref{sec:sinusoidal-vi}.
@@ -2694,7 +2694,7 @@ Notice that if you choose the dashed style, the noise sources are fillable:
     \circuitdescbip*[oosource]{ioosource}{Double Zero style current source}{}
     \circuitdescbip*[oosource]{voosource}{Double Zero style voltage source}{}
     \circuitdescbip*[oosourcetrans]{oosourcetrans}{transformer source\footnotemark}{}(centerprim/90/0.3, centersec/-90/0.3)
-        \footnotetext{The \texttt{oosourcetrans} and \texttt{ooosource} componentes have benn added by \href{https://github.com/circuitikz/circuitikz/pull/397}{user \texttt{@olfline} on GitHub}}.
+        \footnotetext{The \texttt{oosourcetrans} and \texttt{ooosource} components have been added by \href{https://github.com/circuitikz/circuitikz/pull/397}{user \texttt{@olfline} on GitHub}}.
     \begingroup
         \ctikzset{sources/scale=1.5}
         \circuitdescbip*[ooosource]{ooosource}{transformer with three windings\footnotemark}{}(left/175/0.2, right/5/0.7, prim1/130/.2, prim2/-130/.2, sec1/35/.2, sec2/60/.2, sec3/90/.2, tert1/0/.2, tert2/-45/.2, tert3/-90/.2, centerprim/92/0.8, centersec/35/0.9, centertert/-35/0.8)
@@ -2783,7 +2783,7 @@ Notice that the size of the double-circle sources (and of the triple-circle one)
 \paragraph{Waveform symbols.}
 Internal symbols of sinusoidal, triangular and square sources are drawn with the same line thickness as the component by default. You can modify this by setting the key \texttt{sources/symbols/thickness} for independent sources and the corresponding \texttt{csource/...} for dependent ones. The value used here is relative to the component (i.e. the circle) value.
 
-Normally the symbol is oriented in the same direction as the line, and rotate rigidly with the component; you can change this orientation using the key \texttt{sources/symbols/rotate} or \texttt{csource/...}. The default value is \texttt{90} which correspond to the ``line'' direction (remember, path component are defined as horizontal ones).
+Normally the symbol is oriented in the same direction as the line, and rotate rigidly with the component; you can change this orientation using the key \texttt{sources/symbols/rotate} or \texttt{csource/...}. The default value is \texttt{90} which correspond to the ``line'' direction (remember, path components are defined as horizontal ones).
 If instead of an angle value you use \texttt{auto}, the symbol will be rotated so that the waveform is always vertical, similar to what happens in instruments:
 
 \begin{LTXexample}[varwidth=true]
@@ -3028,7 +3028,7 @@ If you prefer it, you have the option to use square meters, in order to have mor
 \end{circuitikz}
 \end{LTXexample}
 
-Another possibility is to use QUCS\footnote{QUCS is an open source circuit simulator: \url{http://qucs.sourceforge.net/}}-style probes, which have the nice property of explictly showing the type of connection (in series or parallel) of the meter:
+Another possibility is to use QUCS\footnote{QUCS is an open source circuit simulator: \url{http://qucs.sourceforge.net/}}-style probes, which have the nice property of explicitly showing the type of connection (in series or parallel) of the meter:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american]
@@ -3155,7 +3155,7 @@ You can change the scale of all the miscellaneous elements by setting the key \t
 
 \subsection{Multiple wires (buses)}
 
-This are simple drawings to indicate multiple wires.
+These are simple drawings to indicate multiple wires.
 \begin{groupdesc}
 \circuitdescbip{multiwire}{Single line multiple wires}{multiwire}
 \circuitdescbip{bmultiwire}{Double line multiple wires}{bmultiwire}
@@ -3209,7 +3209,7 @@ However, sometimes it is advisable to mark the non-contact situation more explic
 \end{circuitikz}
 \end{LTXexample}
 
-That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometime a bit of trial and error is needed to position it.
+That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometimes a bit of trial and error is needed to position it.
 
 For a more powerful (and elegant) way you can use the crossing nodes:
 
@@ -3348,7 +3348,7 @@ It also has a \texttt{zero} anchor if you need to rotate it about its real cente
 
 \subsubsection{IEC 60617 socket-plug connectors}
 
-Plug and socket connectors (modeled on the IEC60617 standard) are available\footnote{Since \texttt{v1.5.0}; thanks to Alexander Sauter for suggesting them and \href{https://github.com/circuitikz/circuitikz/issues/611}{helping in the design}.} both in path-style form and, with separated but matching shapes for plug and socket, in node-style. There are two differently oriented shapes for each type to ease the construction of ``split'' connections (see the examples below). \textbf{Notice} that the elements in the following table are scaled by a factor 1.5, to better show the position of the anchors.
+Plug and socket connectors (modeled on the IEC60617 standard) are available\footnote{Since \texttt{v1.5.0}; thanks to Alexander Sauter for suggesting them and \href{https://github.com/circuitikz/circuitikz/issues/611}{helping in the design}.} both in path-style form and, with separated but matching shapes for plug and socket, in node-style. There are two differently oriented shapes for each type to ease the construction of ``split'' connections (see the examples below). \textbf{Notice} that the elements in the following table are scaled by a factor of 1.5, to better show the position of the anchors.
 
 \begin{groupdesc}
     \ctikzset{connectors/scale=1.5}
@@ -3496,7 +3496,7 @@ The ports of the \texttt{mixer}, \texttt{adder}, \texttt{oscillator} and \texttt
 ;\end{circuitikz}
 \end{LTXexample}
 
-In addition, since \texttt{v1.6.0},  most blocks have also the \texttt{left up}, \texttt{left down}, \texttt{right up} and \texttt{right down} anchors:
+In addition, since \texttt{v1.6.0},  most blocks also have the \texttt{left up}, \texttt{left down}, \texttt{right up} and \texttt{right down} anchors:
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
     (0,0) to[bandpass, name=bp] ++(2,0)
@@ -3517,8 +3517,8 @@ You can use those anchors to build ``mixed-type'' circuits, positioning the node
     \draw (A.right up) -- (B.left up) (A.right down) to[cute choke] (B.left down);
 \end{tikzpicture}
 \end{LTXexample}
-Notice also form the previous example that the generic blocks (\texttt{twoport} and \texttt{twoportsplit}) can be made ``longer'' by setting different \texttt{width} and \texttt{height} (the other blocks are square, and just use the \texttt{width} key for bth dimensions).
-O
+Notice also from the previous example that the generic blocks (\texttt{twoport} and \texttt{twoportsplit}) can be made ``longer'' by setting different \texttt{width} and \texttt{height} (the other blocks are square, and just use the \texttt{width} key for both dimensions).
+
 Also, for \texttt{amp} and \texttt{vamp}, the \texttt{up} and \texttt{down} anchors follow the shape when they are not boxed.
 \begin{LTXexample}[varwidth=true]
 \begin{tikzpicture}
@@ -3529,7 +3529,7 @@ Also, for \texttt{amp} and \texttt{vamp}, the \texttt{up} and \texttt{down} anch
 \end{tikzpicture}
 \end{LTXexample}
 
-The \texttt{oscillator} has a displaced \texttt{center} anchor, to simplify the task of putting it at the left side of a circuit; it also as a special position for the node text. The four round elements (mixer, circulator, adder, and the oscillator) have a \texttt{geocenter} anchor which corresponds always to the center of the circle.
+The \texttt{oscillator} has a displaced \texttt{center} anchor, to simplify the task of putting it at the left side of a circuit; it also as a special position for the node text. The four round elements (mixer, circulator, adder, and the oscillator) have a \texttt{geocenter} anchor which always corresponds to the center of the circle.
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
 \begin{tikzpicture}[>=Stealth]
     \draw (0,0)node[oscillator](O){$f_0$} -- ++(1,0);
@@ -3594,7 +3594,7 @@ The couplers have:
 \end{circuitikz}
 \end{LTXexample}
 
-Or you can use also \texttt{port1} to \texttt{port4} if you prefer:
+Or you can also use \texttt{port1} to \texttt{port4} if you prefer:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw (0,1.5) %bounding box
@@ -3681,7 +3681,7 @@ Some two-ports have the option to place a normal label (\texttt{l=}) and a inner
 
 
 \paragraph{Box option}
-Several devices have the possibility to add a box around them with the \texttt{box} or \texttt{boxed} option. The inner symbol scales down to fit inside the box. For the ``circled'' devices (mixer, adder, oscillator and circulator) the inner circle is normally drawn, unless you use the \texttt{box only} or \texttt{boxed only} option.\footnote{Since 1.5.0, suggested by \href{https://github.com/circuitikz/circuitikz/issues/621}{GitHUb user myzinsky}}
+Several devices have the possibility to add a box around them with the \texttt{box} or \texttt{boxed} option. The inner symbol scales down to fit inside the box. For the ``circled'' devices (mixer, adder, oscillator and circulator) the inner circle is normally drawn, unless you use the \texttt{box only} or \texttt{boxed only} option.\footnote{Since 1.5.0, suggested by \href{https://github.com/circuitikz/circuitikz/issues/621}{GitHub user myzinsky}}
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz} \draw
   (0,0) node[mixer, box only, anchor=east](m){}
@@ -3714,7 +3714,7 @@ Moreover, the key \texttt{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|), 
 
 \paragraph{Dashing the DC symbol in blocks.}
 The symbol for the DC side can be different across countries,\footnote{Head-up from \href{https://github.com/circuitikz/circuitikz/issues/680}{user \texttt{@dbstf} on GitHub}} with different kind of dashing on the bottom line.
-Moreover, sometimes the dashing is used to convey different meaning (like rectified sinusoidal or stabilized DC).
+Moreover, sometimes the dashing is used to convey different meanings (like rectified sinusoidal or stabilized DC).
 You can change the general style for the DC symbol using the key \texttt{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \texttt{blocks dc in segments} and \texttt{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} option overrides these ones.
 
 \begin{LTXexample}[varwidth=true]
@@ -3826,7 +3826,7 @@ You can use the double-gated transistor for example like this:%
     \circuitdesc{pjfet}{p-type JFET}{}(G/-135/0.2,D/0/0.2,S/0/0.2)
 \end{groupdesc}
 
-\textsc{UJT} transistors\footnote{sugged by \href{https://github.com/circuitikz/circuitikz/issues/522}{user JetherReis on GitHub}.} have a different anchor names although \textbf{most} of the others, like \texttt{D} and \texttt{G}, work also (the exception is \texttt{E} and \texttt{emitter}!). Notice that if used with \texttt{nobase}, the anchor \texttt{E} follows the wire, while \texttt{G} is fixed (as is \texttt{kink}).
+\textsc{UJT} transistors\footnote{sugged by \href{https://github.com/circuitikz/circuitikz/issues/522}{user JetherReis on GitHub}.} have a different anchor names although \textbf{most} of the others, like \texttt{D} and \texttt{G}, also work (the exception is \texttt{E} and \texttt{emitter}!). Notice that if used with \texttt{nobase}, the anchor \texttt{E} follows the wire, while \texttt{G} is fixed (as is \texttt{kink}).
 
 \begin{groupdesc}
     \circuitdesc{nujt}{n-type UJT}{Q}(G/-135/0.2,B1/0/0.2,B2/0/0.2 , kink/90/0.4, E/135/0.2)
@@ -3849,7 +3849,7 @@ You can use the double-gated transistor for example like this:%
 
 \subsubsection{Transistor texts (labels)}\label{sec:transistors-labels}
 
-In versions before \texttt{0.9.7}, transistors text (the node text) was positioned near the collector terminal; since version \texttt{0.9.7} the default has been changed to a more natural position near the center of the device, similar to the multi-teminal transistors. You can revert to the old behavior locally with the key \texttt{legacy transistors text}, or globally by setting the package option \texttt{legacytransistorstext}.
+In versions before \texttt{0.9.7}, transistors text (the node text) was positioned near the collector terminal; since version \texttt{0.9.7} the default has been changed to a more natural position near the center of the device, similar to the multi-terminal transistors. You can revert to the old behavior locally with the key \texttt{legacy transistors text}, or globally by setting the package option \texttt{legacytransistorstext}.
 
 Notice the use of the utility functions \verb|\ctikzflip{|\texttt{\textsl{x,y,xy}}\verb|}| as explained in section~\ref{sec:mirroring-and-flipping}.
 
@@ -3925,7 +3925,7 @@ To add the circle to a single transistor, you use the \texttt{tr circle} keys in
 
 You can tweak the appearance of transistor's circles and even draw it partially; see ~\ref{sec:trans-circle-custom} for details.
 
-\paragraph{Body diodes and similar things.}\label{sec:bodydiodes-anchor} For all transistors (minus \texttt{bjtnpn} and \texttt{bjtpnp})  a body diode (or freewheeling or flyback diode) can automatically be drawn. Just use the global option \texttt{bodydiode}, or for single transistors, the tikz-option \texttt{bodydiode}.
+\paragraph{Body diodes and similar things.}\label{sec:bodydiodes-anchor} For all transistors (minus \texttt{bjtnpn} and \texttt{bjtpnp})  a body diode (or freewheeling or flyback diode) can automatically be drawn. Just use the global option \texttt{bodydiode}, or for single transistors, the \TikZ-option \texttt{bodydiode}.
 As you can see in the next example, the text for the diode is moved if a bodydiode is present (but beware, if you change a lot the relative dimension of components, it may become misplaced):
 
 \begin{LTXexample}[varwidth=true]


### PR DESCRIPTION
It's the word "voilà" in English (see https://en.wiktionary.org/wiki/voilà#English), from the French "voilà". The word "voilá" seems to be Spanish (https://en.wiktionary.org/wiki/voilá).