### PR TITLE
Enhance `hemt` to allow, for example, GaN transistors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.6.1 (unreleased)
 
-    New components: solder jumpers; a couple of small but very useful inversion markers for logical circuits, especially targeted at the mux-demux family; a new inline microphone. More tweaks to converters blocks, and a lot of typo/grammar fixes in the manual.
+    New components: solder jumpers; a couple of small but very useful inversion markers for logical circuits, especially targeted at the mux-demux family; a new inline microphone; a much more versatile hemt. More tweaks to converters blocks, and a lot of typo/grammar fixes in the manual.
 
     - Add configurable dashes to the dc symbols in converter blocks (suggested by [user `@dbstf` on GitHub](https://github.com/circuitikz/circuitikz/issues/680))
     - Add solder jumpers (by Romano)
     - Add a shape to mark european-style inversion (suggested by [user `yashpalgoyal1304` on GitHub](https://github.com/circuitikz/circuitikz/issues/679)), adjust European-style logic port triangle inversion symbols to match
     - Add a tail-less mic (suggested by [Dr. Mathhias Jung](https://github.com/circuitikz/circuitikz/issues/689) and an option to change the thickness of the microphone's bar
+    - Enhance the `hemt` shape with a GaN-hemt as example (suggested by [user `@epsilon-phi` on GitHub](https://github.com/circuitikz/circuitikz/issues/691).}
     - subcircuits are no more experimental
     - Correction of several typo/grammar errors in the documentation by [quark67](https://github.com/circuitikz/circuitikz/pull/686)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3781,6 +3781,7 @@ Basically they are the same as the normal \texttt{npn} and \texttt{pnp}, and the
     \circuitdesc{pmosd}{pmos depletion}{}
     \circuitdesc{hemt}{hemt}{}
     \circuitdesc{hemt, nobase}{hemt without base terminal}{Q}( G/180/0.2,D/0/0.2,S/0/0.2, nogate/-120/0.2)
+    \circuitdesc{GaN hemt}{Gallium Nitride hemt (a ``styled'' \texttt{hemt}, see~\ref{sec:hemt})}{Q}( G/180/0.2,D/0/0.2,S/0/0.2, nogate/-120/0.2)
 \end{groupdesc}
 
 \textsc{nfet}s and \textsc{pfet}s have been incorporated based on code provided by Clemens Helfmeier and Theodor Borsche. Use the package options \texttt{fetsolderdot}/\texttt{nofetsolderdot} to enable/disable solderdot at some fet-transistors. Additionally, the solderdot option can be enabled/disabled for single transistors with the option \texttt{solderdot} and \texttt{nosolderdot}, respectively.
@@ -3972,6 +3973,39 @@ For more complex snubs or protections, you can use the \texttt{body ...} anchors
     \node[npn, bodydiode](Q4) at(2,-3) {};
     \snubb{Q1}{in} \snubb{Q2}{in}
     \snubb{Q3}{out} \snubb{Q4}{out}
+\end{circuitikz}
+\end{LTXexample}
+
+\paragraph{HEMT customization.\label{sec:hemt}} Since \texttt{v1.6.1} the shape of the \texttt{hemt} transistor can be customized.\footnote{After a suggestion from \href{https://github.com/circuitikz/circuitikz/issues/691}{user \texttt{@epsilon-phi} on GitHub}.}
+There are several keys under the hierarchy \texttt{tripoles/hemt} that can be use to change the appearance; some of them are common to other transistors and some are specific.
+
+The main ones are \texttt{\dots/split gate} (boolean, default \texttt{false}) that will create a ``split'' gate, which sometimes is used to convey that the device is enhancement-type;
+\texttt{source arrow} (default \texttt{0}), to add an arrow on the source terminal (\texttt{1} for a right-facing one, \texttt{-1} the other way around; the arrow will obey \texttt{arrow pos=end} if issued, but otherwise the position is fixed);
+\texttt{gate asym} (default \texttt{0.0}) which displaces the gate asymmetrically. For example, the \texttt{GaN hemt} component is really a styled \texttt{hemt} (predefined), with the definition:
+
+\begin{lstlisting}
+\tikzset{GaN hemt/.style={hemt,
+        circuitikz/tripoles/hemt/base height=0.6,% length of the "base" vertical bar
+        circuitikz/tripoles/hemt/gate height=0.5,% distance of the S/D terminals
+        circuitikz/tripoles/hemt/bodydiode conn=0.85,% attachment point of body diode
+        circuitikz/tripoles/hemt/gate asym=-0.1,% slightly down
+        circuitikz/tripoles/hemt/split gate=true,% split gate
+        circuitikz/tripoles/hemt/source arrow=1,% right-facing arrow
+    },
+}
+\end{lstlisting}
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[]
+    \path (-1,-1) rectangle (3,3);% bounding box
+    \node  [hemt] at (0,2) {A};
+    \node  [hemt,
+        circuitikz/tripoles/hemt/split gate=true
+        ] at (2,2) {B};
+    \node  [GaN hemt]  at (0,0) {C};
+    \node  [GaN hemt,
+        circuitikz/tripoles/hemt/split gate=false
+        ]  at (2,0) {D};
 \end{circuitikz}
 \end{LTXexample}
 

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -2999,6 +2999,12 @@
 \ctikzset{tripoles/hemt/bodydiode distance/.initial=.3}
 \ctikzset{tripoles/hemt/bodydiode conn/.initial=.6}
 \ctikzset{tripoles/hemt/curr direction/.initial=1}
+%% New parameters
+\ctikzset{tripoles/hemt/curr direction/.initial=1}
+\ctikzset{tripoles/hemt/gate asym/.initial=0}
+\newif\ifpgf@circ@hemt@split
+\ctikzset{tripoles/hemt/split gate/.is if=pgf@circ@hemt@split}
+\ctikzset{tripoles/hemt/source arrow/.initial=0}
 
 \ctikzset{tripoles/nfet/width/.initial=.7}
 \ctikzset{tripoles/nfet/gate height/.initial=.35}
@@ -5270,7 +5276,16 @@
     \pgfcirc@ferroelectric{pmosd}{\ctikzvalof{tripoles/pmosd/depletion width}}
 }
 %% HEMT FET Transistor
+\def\pgf@circ@hemt@gate@anchor@helper{%
+    \northeast
+    \pgf@circ@res@up = \pgf@y
+    \pgf@circ@res@down = -\pgf@y
+    \pgfmathsetlength{\pgf@circ@res@step}{{(1+\gateasym)*\pgf@circ@res@up+(1-\gateasym)*\pgf@circ@res@down}}
+    \left
+    \pgf@y=\pgf@circ@res@step
+}
 \pgfcircdeclaretransistor{hemt}{
+        \savedmacro{\gateasym}{\edef\gateasym{\ctikzvalof{tripoles/hemt/gate asym}}}
         \anchor{inner up}{
             \northeast
             \pgf@y=\ctikzvalof{tripoles/hemt/gate height}\pgf@y
@@ -5279,42 +5294,107 @@
             \northeast
             \pgf@y=-\ctikzvalof{tripoles/hemt/gate height}\pgf@y
         }
+        % override gate/base anchors
+        \anchor{G}{\pgf@circ@hemt@gate@anchor@helper}
+        \anchor{gate}{\pgf@circ@hemt@gate@anchor@helper}
+        \anchor{nogate}{\pgf@circ@hemt@gate@anchor@helper\pgf@x=\ctikzvalof{tripoles/hemt/base width}\pgf@x}
+        \anchor{B}{\pgf@circ@hemt@gate@anchor@helper}
+        \anchor{base}{\pgf@circ@hemt@gate@anchor@helper}
+        \anchor{nobase}{\pgf@circ@hemt@gate@anchor@helper\pgf@x=\ctikzvalof{tripoles/hemt/base width}\pgf@x}
     }{%
     % add the circle if requested (before everything else, so we can fill it)
     \pgfcirc@transistorcircle
+    % upper connection
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
     {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@up}}
     \pgfpathlineto{\pgfpoint
         {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
     {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@up}}
-
+    % lower connection
     \pgfpathmoveto{\pgfpoint
         {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
-    {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
+        {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
-    {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
+        {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint
+        {\pgf@circ@res@right}{\pgf@circ@res@down-\pgfverticaltransformationadjustment*.5*\pgflinewidth}}
     \pgfusepath{draw}
-
     \pgfscope
-        \pgfpathmoveto{\pgfpoint
-            {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
-        {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint
-            {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
-        {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@down}}
+        \edef\@@tmp{\ctikzvalof{tripoles/hemt/source arrow}}
+        \ifnum\@@tmp=0 \else
+            \ifpgf@circuit@trans@arrowatend
+                \ifnum\@@tmp > 0 %
+                    \pgftransformshift{\pgfpoint
+                        {\pgf@circ@res@right}
+                        {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
+                \else
+                    \pgftransformshift{\pgfpoint
+                        {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                        {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
+                        \ifnum\@@tmp < 0 \pgftransformrotate{180}\fi
+                \fi
+                    \pgfnode{trarrow}{tip}{}{}{\pgfusepath{stroke}}
+            \else
+                % the position here is a bit strange...
+                \pgftransformshift{\pgfpoint
+                    {0.5*\pgf@circ@res@right+0.5*\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                    {\ctikzvalof{tripoles/hemt/gate height}\pgf@circ@res@down}}
+                    \ifnum\@@tmp < 0 \pgftransformrotate{180}\fi
+                    \pgfnode{trarrow}{center}{}{}{\pgfusepath{stroke}}
+            \fi
+        \fi
+    \endpgfscope
+    \pgfscope
+        % draw gate (base) bar
+        \ifpgf@circ@hemt@split
+            \pgfpathmoveto{\pgfpoint
+                {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint{\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                {(1.1+\gateasym)*\pgf@circ@res@up +
+                 (0.9-\gateasym)*\pgf@circ@res@down}}
+            \pgfpathmoveto{\pgfpoint{\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                {(1.05+\gateasym)*\pgf@circ@res@up +
+                 (0.95-\gateasym)*\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                {(0.95+\gateasym)*\pgf@circ@res@up +
+                 (1.05-\gateasym)*\pgf@circ@res@down}}
+            \pgfpathmoveto{\pgfpoint{\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+                {(0.9+\gateasym)*\pgf@circ@res@up +
+                 (1.1-\gateasym)*\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint
+                {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+            {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@down}}
+        \else
+            \pgfpathmoveto{\pgfpoint
+                {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+            {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpoint
+                {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
+            {\ctikzvalof{tripoles/hemt/base height}\pgf@circ@res@down}}
+        \fi
         \pgf@circ@setlinewidth{tripoles}{\pgflinewidth}
         \pgfusepath{draw}
     \endpgfscope
-
+    % draw the gate horizontal segment
     \ifpgf@circuit@bpt@drawgate
         \pgfpathmoveto{\pgfpoint
             {\ctikzvalof{tripoles/hemt/base width}\pgf@circ@res@left}
-        {\pgf@circ@res@up+\pgf@circ@res@down}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*.5*\pgflinewidth}{\pgf@circ@res@up+\pgf@circ@res@down}}
+        {(1+\gateasym)*\pgf@circ@res@up+(1-\gateasym)*\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left-\pgfhorizontaltransformationadjustment*.5*\pgflinewidth}
+            {(1+\gateasym)*\pgf@circ@res@up+(1-\gateasym)*\pgf@circ@res@down}}
         \pgfusepath{draw}
     \fi
+}
+\tikzset{GaN hemt/.style={hemt,
+        circuitikz/tripoles/hemt/base height=0.6,%length of the "base" vertical bar
+        circuitikz/tripoles/hemt/gate height=0.5,%distance of the S/D terminals
+        circuitikz/tripoles/hemt/bodydiode conn=0.85,% attachment point of body diode
+        circuitikz/tripoles/hemt/gate asym=-0.1,% slightly down
+        circuitikz/tripoles/hemt/split gate=true,% split gate
+        circuitikz/tripoles/hemt/source arrow=1,% right-facing arrow
+    },
 }
 
 \long\def\drawfetcore#1{


### PR DESCRIPTION
Fixes #691

![image](https://user-images.githubusercontent.com/6414907/217170934-1fd3c588-3924-4af1-8818-d49ff7cd338c.png)
