### PR TITLE
Prepare for CTAN release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.1 (unreleased)
+* Version 1.6.1 (2023-02-11)
 
     New components: solder jumpers; a couple of small but very useful inversion markers for logical circuits, especially targeted at the mux-demux family; a new inline microphone; a much more versatile hemt; a better legacy `tline`. More tweaks to converters blocks, and a lot of typo/grammar fixes in the manual.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -17,7 +17,7 @@
 \providecommand\DeclareCurrentRelease[2]{}
 
 \def\pgfcircversion{1.6.1}
-\def\pgfcircversiondate{2022/12/18}
+\def\pgfcircversiondate{2023/02/11}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -11,7 +11,7 @@
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
 \def\pgfcircversion{1.6.1}
-\def\pgfcircversiondate{2022/12/18}
+\def\pgfcircversiondate{2023/02/11}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 \usemodule[tikz]


### PR DESCRIPTION
New components: solder jumpers; a couple of small but very useful inversion markers for logical circuits, especially targeted at the mux-demux family; a new inline microphone; a much more versatile `hemt`; a better legacy `tline`. More tweaks to converters blocks, and a lot of typo/grammar fixes in the manual.

- Add configurable dashes to the dc symbols in converter blocks
- Add solder jumpers
- Add a shape to mark european-style inversion , adjust European-style logic port triangle inversion symbols to match
- Add a tail-less mic  and an option to change the thickness of the microphone's bar
- Enhance the `hemt` shape with a GaN-hemt as example
- Add anchors and a "bare" option to `tline`
- subcircuits are no more experimental
- Correction of several typo/grammar errors in the documentation