### PR TITLE
Grouped common "styling" action in a generic macro, add styling to crossing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - `context` compatibility is not guaranteed anymore: please see [this issue](https://github.com/circuitikz/circuitikz/issues/706)
     - Add styling of `transform core` lines (suggested by [user `@myzinsky` on GitHub](https://github.com/circuitikz/circuitikz/issues/702))
     - Add `scale` to the bodydiode options (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/703))
+    - Add styling of crossing vertical line (suggested by [user `@lkjell` on GitHub](https://github.com/circuitikz/circuitikz/issues/704))
     - Add `clockwedge` shape (suggested by [user `@Mario1159` on GitHub](https://github.com/circuitikz/circuitikz/issues/705))
 
 * Version 1.6.1 (2023-02-11)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3241,7 +3241,36 @@ For a more powerful (and elegant) way you can use the crossing nodes:
 
 Notice that the \texttt{plain crossing} and the \texttt{jump crossing} have a small gap in the straight wire, to enhance the effect of crossing (as a kind of shadow).
 
+\subsubsection{Crossing customization}
+
 The size of the crossing elements can be changed with the key \texttt{bipoles/crossing/size} (default 0.2).
+
+While the horizontal line will be drawn with the current path values, you can change the style of the vertical line\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/704}{user lkjell on GitHub}, implemented in \texttt{v1.6.2}.} in a similar way to the one used for transistor's bodydiodes, by setting keys with the \verb!\ctikzset! command under the \texttt{crossing vertical} hierarchy. The available keys are:
+
+\begin{center}
+    \begin{tabular}{>{\ttfamily}l>{\ttfamily}lp{0.5\linewidth}}
+        \toprule
+     parameter &  default & description  \\
+     \midrule
+     relative thickness & 1.0 & multiply the default thickness (which is the same of the \texttt{choke} component).\\
+     color & default & stroke color: \texttt{default} is the same as the component. \\
+     dash & default & dash pattern: \texttt{default} means not to change the setting for the component; \texttt{none} means unbroken line; every other input is a dash pattern.\footnotemark \\
+        \bottomrule
+    \end{tabular}
+    \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
+\end{center}
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+    \begin{circuitikz}[every node/.append style={scale=2}]
+        \draw (0,2) node[jump crossing](A){};
+        \begin{scope}
+            \ctikzset{crossing vertical/.cd, color=red, dash={{2pt}{1pt}}}
+            \draw (0,1) node[jump crossing](B){};
+        \end{scope}
+        \ctikzset{crossing vertical/dash=none}
+        \draw[densely dotted, blue] (0,0) node[plain crossing](B){};
+    \end{circuitikz}
+\end{LTXexample}
 
 \subsection{Arrows}\label{sec:arrows}
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4227,7 +4227,7 @@ The position of the circle on collector and emitter by default is the one shown 
      \midrule
      relative thickness & 1.0 & multiply the class thickness \\
      color & default & stroke color: \texttt{default} is the same as the component \\
-     dash & none & dash pattern: none means unbroken line\footnotemark \\
+     dash & default & dash pattern: none means solid line, default means keep the global pattern\footnotemark \\
      partial borders & none & draw only part of the circle border: none means draw all \\
      partial border dash & \{\{2pt\}\{2pt\}\} & dash pattern used in partial borders \\
         \bottomrule

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -448,6 +448,24 @@
     \fi
 }
 
+% set the color and dash pattern for a subset of the shape, following keys #1/color
+% and #1/dash. The keys must exist, and check for none or default for both
+\def\pgf@circ@subset@color@dash#1{%
+    % You *must* be sure that this is called inside a \pgfscope!
+    \edef\@@none{none}\edef\@@default{default}
+    \edef\@@tmp{\ctikzvalof{#1/color}}
+    \ifx\@@tmp\@@default\else
+        \pgfsetcolor{\@@tmp}
+    \fi
+    \edef\@@tmp{\ctikzvalof{#1/dash}}
+    \ifx\@@tmp\@@default\else
+        \ifx\@@tmp\@@none
+            \pgfsetdash{}{0pt}% solid line, override dash
+        \else
+            \expandafter\pgfsetdash\expandafter{\@@tmp}{0cm}
+        \fi
+    \fi
+}
 
 %%>>>
 
@@ -944,19 +962,7 @@
 \def\pgf@circ@set@optoarrow@style{%
     % You *must* be sure that this is called inside a \pgfscope!
     \pgfsetlinewidth{\ctikzvalof{opto arrows/relative thickness}\pgflinewidth}
-    \edef\@@none{none}\edef\@@default{default}
-    \edef\@@tmp{\ctikzvalof{opto arrows/color}}
-    \ifx\@@tmp\@@default\else
-        \pgfsetcolor{\@@tmp}
-    \fi
-    \edef\@@tmp{\ctikzvalof{opto arrows/dash}}
-    \ifx\@@tmp\@@default\else
-        \ifx\@@tmp\@@none
-            \pgfsetdash{}{0pt}% solid line, override dash
-        \else
-            \expandafter\pgfsetdash\expandafter{\@@tmp}{0cm}
-        \fi
-        \fi
+        \pgf@circ@subset@color@dash{opto arrows}
         \pgfcirc@set@arrows{opto}{}{latexslim}
     }
 

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -295,19 +295,7 @@
 
     % use the chocke line thickness
     \pgfsetlinewidth{\ctikzvalof{bipoles/cutechoke/cthick}*\ctikzvalof{transformer core/relative thickness}*\pgflinewidth}
-    \edef\@@none{none}\edef\@@default{default}
-    \edef\@@tmp{\ctikzvalof{transformer core/color}}
-    \ifx\@@tmp\@@default\else
-        \pgfsetcolor{\@@tmp}
-    \fi
-    \edef\@@tmp{\ctikzvalof{transformer core/dash}}
-    \ifx\@@tmp\@@default\else
-        \ifx\@@tmp\@@none
-            \pgfsetdash{}{0pt}% solid line, override dash
-        \else
-            \expandafter\pgfsetdash\expandafter{\@@tmp}{0cm}
-        \fi
-    \fi
+    \pgf@circ@subset@color@dash{transformer core}
 
     % Find the distance from center for the lines representing the core
     % the 2.5 is for backward compatibility --- the distance was calculated as a fraction

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -582,6 +582,10 @@
 
 %% crossings%<<<
 % full nodes for wire crossing
+% styling for the vertical wire (default: do none)
+\ctikzset{crossing vertical/relative thickness/.initial=1}
+\ctikzset{crossing vertical/color/.initial=default}
+\ctikzset{crossing vertical/dash/.initial=default}
 
 \pgfdeclareshape{jump crossing}
 {
@@ -591,18 +595,7 @@
         \pgf@x=-\pgf@y
     }
     \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
-    \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
-    \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
-    \anchor{west}{ \northwest \pgf@y=0pt }
-    \anchor{w}{ \northwest \pgf@y=0pt }
-    \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
-    \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
-    \anchor{north}{ \northwest \pgf@x=0pt }
-    \anchor{n}{ \northwest \pgf@x=0pt }
-    \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
-    \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
-    \anchor{north west}{ \northwest }
-    \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
+    \pgfcirc@northwest@symmetric@geoanchors
     \pgf@circ@draw@component{
         \northwest
         \pgf@circ@res@up = \pgf@y
@@ -615,13 +608,17 @@
         \pgfpatharc{0}{-180}{0.4*\pgf@circ@res@left}
         \pgfsetbeveljoin
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+        \pgfusepath{draw}
         % vertical, broken path
+        % styling of vertical line
+        \pgfsetlinewidth{\ctikzvalof{crossing vertical/relative thickness}\pgflinewidth}
+        \pgf@circ@subset@color@dash{crossing vertical}
+        %
         \pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{0pt}{0.5\pgf@circ@res@up}}
         \pgfpathmoveto{\pgfpoint{0pt}{0.3\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down}}
         \pgfusepath{draw}
-
     }
 }
 \pgfdeclareshape{plain crossing}
@@ -632,18 +629,7 @@
         \pgf@x=-\pgf@y
     }
     \anchor{center}{ \pgf@y=0pt \pgf@x=0pt }
-    \anchor{east}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
-    \anchor{e}{ \northwest \pgf@y=0pt \pgf@x=-\pgf@x  }
-    \anchor{west}{ \northwest \pgf@y=0pt }
-    \anchor{w}{ \northwest \pgf@y=0pt }
-    \anchor{south}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
-    \anchor{s}{ \northwest \pgf@x=0pt \pgf@y=-\pgf@y }
-    \anchor{north}{ \northwest \pgf@x=0pt }
-    \anchor{n}{ \northwest \pgf@x=0pt }
-    \anchor{south west}{ \northwest \pgf@y=-\pgf@y }
-    \anchor{north east}{ \northwest \pgf@x=-\pgf@x }
-    \anchor{north west}{ \northwest }
-    \anchor{south east}{ \northwest \pgf@x=-\pgf@x \pgf@y=-\pgf@y }
+    \pgfcirc@northwest@symmetric@geoanchors
     \pgf@circ@draw@component{
         \northwest
         \pgf@circ@res@up = \pgf@y
@@ -653,13 +639,17 @@
         % horizontal jumper
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+        \pgfusepath{draw}
         % vertical, broken path
+        % styling of vertical line
+        \pgfsetlinewidth{\ctikzvalof{crossing vertical/relative thickness}\pgflinewidth}
+        \pgf@circ@subset@color@dash{crossing vertical}
+        %
         \pgfpathmoveto{\pgfpoint{0pt}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{0pt}{0.1\pgf@circ@res@up}}
         \pgfpathmoveto{\pgfpoint{0pt}{0.1\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down}}
         \pgfusepath{draw}
-
     }
 }
 % %>>>

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -3359,7 +3359,7 @@
 \ctikzset{transistor circle/.is family}
 \ctikzset{transistor circle/relative thickness/.initial=1}
 \ctikzset{transistor circle/color/.initial=default}
-\ctikzset{transistor circle/dash/.initial=none}
+\ctikzset{transistor circle/dash/.initial=default}
 \ctikzset{transistor circle/scale circle radius/.initial=1}
 \ctikzset{transistor circle/default base in/.initial=0.9}
 \ctikzset{transistor circle/njfet base in/.initial=1.05}
@@ -3471,15 +3471,7 @@
     \pgfscope
         \pgf@circ@setlinewidth{tripoles}{\pgflinewidth}
         \pgfsetlinewidth{\ctikzvalof{transistor circle/relative thickness}\pgflinewidth}
-        \edef\@@none{none}\edef\@@default{default}
-        \edef\@@tmp{\ctikzvalof{transistor circle/color}}
-        \ifx\@@tmp\@@default\else
-            \pgfsetcolor{\@@tmp}
-        \fi
-        \edef\@@tmp{\ctikzvalof{transistor circle/dash}}
-        \ifx\@@tmp\@@none\else
-            \expandafter\pgfsetdash\expandafter{\@@tmp}{0cm}
-        \fi
+        \pgf@circ@subset@color@dash{transistor circle}
         % radius of the circle
         % \pgfmathsetlength{\pgf@circ@res@temp}{((#2+\extrabodydiodelen)-(#1)+(#3)*(#3)/((#2+\extrabodydiodelen)-(#1)))/2}
         % \pgfpathcircle{\pgfpoint{#1+\pgf@circ@res@temp}{0pt}}{\pgf@circ@res@temp}
@@ -3970,19 +3962,7 @@
         \ifpgf@circuit@fet@bodydiode
             \pgfscope
                 \pgfsetlinewidth{\ctikzvalof{transistor bodydiode/relative thickness}\pgflinewidth}
-                \edef\@@none{none}\edef\@@default{default}
-                \edef\@@tmp{\ctikzvalof{transistor bodydiode/color}}
-                \ifx\@@tmp\@@default\else
-                    \pgfsetcolor{\@@tmp}
-                \fi
-                \edef\@@tmp{\ctikzvalof{transistor bodydiode/dash}}
-                \ifx\@@tmp\@@default\else
-                    \ifx\@@tmp\@@none
-                        \pgfsetdash{}{0pt}% solid line, override dash
-                    \else
-                        \expandafter\pgfsetdash\expandafter{\@@tmp}{0cm}
-                    \fi
-                \fi
+                \pgf@circ@subset@color@dash{transistor bodydiode}
                 \drawbodydiode{#1}
             \endpgfscope
         \fi


### PR DESCRIPTION
Also, fixed a bug in the styling of the transistor circles; the option `none` was not resetting the line to solid. The old default action is better described as `default`; changed to it.