### PR TITLE
Document the consequences of the ConTeXt switch to LMTX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.6.2 (unreleased)
 
-    - `context` compatibility is not guaranteed anymore: please see [this issue](https://github.com/circuitikz/circuitikz/issues/706)
+    - there is no `siunitx` support for ConTeXt, point to the `units` package
+    - `context` compatibility can have glitches: please see [this issue](https://github.com/circuitikz/circuitikz/issues/706)
     - Add styling of `transform core` lines (suggested by [user `@myzinsky` on GitHub](https://github.com/circuitikz/circuitikz/issues/702))
     - Add `scale` to the bodydiode options (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/703))
     - Add styling of crossing vertical line (suggested by [user `@lkjell` on GitHub](https://github.com/circuitikz/circuitikz/issues/704))

--- a/doc/circuitikz-context.tex
+++ b/doc/circuitikz-context.tex
@@ -10,7 +10,9 @@
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
 
-% I have to use this to enable compilation on new context
+% This first line *shouldn't* be needed; it's here to work around a problem
+% in ConTeXt TikZ support when it switch to LMTX. Kept here to make CI happy.
+% See also https://github.com/circuitikz/circuitikz/issues/706
 % See https://github.com/pgf-tikz/pgf/issues/1248#issuecomment-1486235591
 % I have no clue on how to fix this; moving the following line *inside*
 % t-circuitikz.tex does not work
@@ -21,10 +23,10 @@
 
 A simple example to test the installation.
 
-% removed all the "pseudo-SI commands". They should work, but they
-% stopped working when context passed from mkiv to ltmx (March 2023)
-% I have no clue on what's going on.
-\startcircuitikz[scale=1.2]
+% removed all the "pseudo-SI commands". They were removed by ConTeXt,
+% when it moved to LMTX (March 2023).
+% For units you should use http://www.pragma-ade.nl/general/manuals/units-mkiv.pdf
+\startcircuitikz[scale=1.5]
 	\draw
   (0,2) to[I=1~mA] (2,2)
         to[R, l_=2~kΩ, *-*] (0,0)
@@ -38,20 +40,5 @@ A simple example to test the installation.
   (5,-2) node[flipflop JK, anchor=pin 1]{};
 
 \stopcircuitikz
-
-% \startcircuitikz[scale=1.2]
-% 	\draw
-%   (0,2) to[I=1\milli\ampere] (2,2)
-%         to[R, l_=2\kilo\ohm, *-*] (0,0)
-%         to[R, l_=2\kilo\ohm] (2,0)
-%         to[V, v_=2\volt] (2,2)
-%         to[cspst, l=$t_0$] (4,2) -- (4,1.5)
-%         to [generic, i=$i_1$, v=$v_1$] (4,-.5) -- (4,-1.5)
-%   (0,2) -- (0,-1.5) to[V, v_=4\volt] (2,-1.5)
-%         to [R, l=1\kilo\ohm] (4,-1.5)
-%   (5,2) node[dipchip, anchor=pin 1]{}
-%   (5,-2) node[flipflop JK, anchor=pin 1]{};
-
-% \stopcircuitikz
 
 \stoptext

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -140,7 +140,7 @@ This package is author-maintained. Permission is granted to copy, distribute and
 	\bottomrule
 \end{tabular}
 \end{table}
-\footnotetext{\ConTeXt\ support was added mostly thanks to Mojca Miklavec and Aditya Mahajan.\textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine, there are several problems and the compatibility is not guaranteed anymore. Please check and contribute to \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} if you feel you can help!}
+\footnotetext{\ConTeXt\ support was added mostly thanks to Mojca Miklavec and Aditya Mahajan.\textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine (March 2023), there can be problems to compile \TikZ{} which some version; it will be fixed soon. Please check \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} for details.}
 
 
 \noindent \TikZ\ will be automatically loaded; additionally, the \TikZ{} libraries \texttt{calc}, \texttt{arrows.meta}, \texttt{bending}, and \texttt{fpu} are loaded (the last one is used only on demand).
@@ -174,14 +174,13 @@ instead of \texttt{circuitikz}. This is also advantageous for ``future resilienc
     \item \texttt{siunitx}, if using \texttt{siunitx} option (better \texttt{v2} or newer).
 \end{itemize}
 
-A similar approach for \ConTeXt\ is available, with the file \texttt{t-circuitikzgit.tex}.
+A similar approach for \ConTeXt\ is available, with the file \texttt{t-circuitikzgit.tex}; the compatibility in this case is not guaranteed, but provided on a \emph{best effort} base.
 
 This manual has been typeset with \Circuitikz{} \pgfcircversion{} (\pgfcircversiondate) on \TikZ{} \pgfversion{} (\pgfversiondate).
 
-
 \subsection{Incompatible packages}\label{sec:incompatible-packages}
 
-\textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine, around March 2023, there are several problems and the compatibility is not guaranteed anymore. Please check and contribute to \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} if you feel you can help!
+\textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine, around March 2023, there can be problems with loading \TikZ. The glitches will be fixed by newer releases of \ConTeXt. Please check \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} for details.
 
 \TikZ's own \texttt{circuit} library, which was based on \Circuitikz, (re?)defines several styles used by this library. In order to have them work together you can use the \texttt{compatibility} package option, which basically prefixes the names of all \Circuitikz\ \texttt{to[]} styles with an asterisk.
 
@@ -249,10 +248,11 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 
 
 \subsection{Incompabilities between versions}\label{sec:incompatible-changes}
-Here, we will provide a list of incompabilities between different versions of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
+Here, we will provide a list of incompatibilities between different versions of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
 If unsure, you can check the version in your local installation by using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
-    \item Since version \texttt{1.6.2} there is a workaround to help compatibility with the new version of \ConTeXt{} (which switched to the new \texttt{lmtx} engine), but there are still several problems and the compatibility is not guaranteed anymore. Please check and contribute to \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} if you feel you can help!
+    \item Since version \texttt{1.6.2} \texttt{siunitx}  will \textbf{not}  work anymore with \ConTeXt{} (it was a very poor simulation layer, anyway); it has been disabled in upstream \ConTeXt, in favor of \href{https://www.pragma-ade.nl/general/manuals/units-mkiv.pdf}{its own \texttt{units} module}.
+    \item Since version \texttt{1.6.2} there is a workaround to help compatibility with the new version of \ConTeXt{} (which switched to the new \texttt{lmtx} engine around March 2023). The compilation problems will be temporary. Please check \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} for details.
     \item Version \texttt{1.6.0} has a big rewrite of the block's code. In principle the changes are backward-compatible, but there were several bugs (wrong anchors, errors with rotations, and so on) that have been fixed in the process.
     \item Since \texttt{v1.5.1}\footnote{Do not use \texttt{v1.5.0}, it's buggy.} color management (see section~\ref{sec:colors}) and the details of how the shapes are drawn and protected by the external drawing options has changed. There should be no substantial changes to the circuits, though.
     \item The \TikZ{} fix for \texttt{to[...] +(x,y)} behavior (see~\ref{sec:path-relative-coordinates}) uncovered a bug in the positioning of the labels in \Circuitikz{} that had been present since \texttt{v0.8}. So you \textbf{must} upgrade to \texttt{v1.4.1} or better if you have \TikZ{} newer than \texttt{3.1.8} (and you want/need to use the \texttt{+(x,y)} syntax).
@@ -324,7 +324,7 @@ The easiest way to contact the authors is via the official GitHub repository: \u
 
 Circuit people are very opinionated about their symbols. In order to satisfy the individual taste you can set a bunch of package options.
 
-There are arguably way too many options in \Circuitikz, as you can see in the following list. Since version \texttt{1.0}, it is recommended to just use the basic ones --- voltage directions (you \textbf{should} specify one of them), \texttt{siunitx}, the global style (\texttt{american} or \texttt{european}) and use styles (see~\ref{sec:styling}) for the remaining options.
+There are arguably way too many options in \Circuitikz, as you can see in the following list. Since version \texttt{1.0}, it is recommended to just use the basic ones --- voltage directions (you \textbf{should} specify one of them), \texttt{siunitx} (only for \LaTeX{}), the global style (\texttt{american} or \texttt{european}) and use styles (see~\ref{sec:styling}) for the remaining options.
 
 The standard options are set by historical reason, and reflect the preferences of the author that introduced them. For example you get this:
 
@@ -378,7 +378,7 @@ Feel free to load the package with your own cultural options:
         \item \texttt{europeangfsurgearrester}: uses rectangular gas filled surge arresters, as per european standards;
         \item \texttt{european}: equivalent to \texttt{europeancurrents}, \texttt{europeanvoltages}, \texttt{europeanresistors}, \texttt{europeaninductors}, \texttt{europeanports}, \texttt{europeangfsurgearrester};
         \item \texttt{american}: equivalent to \texttt{americancurrents}, \texttt{americanvoltages}, \texttt{americanresistors}, \texttt{americaninductors}, \texttt{americanports}, \texttt{americangfsurgearrester};
-        \item \texttt{siunitx}: integrates with \texttt{SIunitx} package. If labels, currents or voltages are of the form \verb!#1<#2>! then what is shown is actually \verb!\SI{#1}{#2}!;
+        \item \texttt{siunitx}: integrates with \texttt{SIunitx} package. If labels, currents or voltages are of the form \verb!#1<#2>! then what is shown is actually \verb!\SI{#1}{#2}! (not supported in \ConTeXt);
         \item \texttt{nosiunitx}: labels are not interpreted as above;
         \item \texttt{fulldiode}: the various diodes are drawn \emph{and} filled by default, i.e. when using styles such as \texttt{diode}, \texttt{D}, \texttt{sD}, \ldots Other diode styles can always be forced with e.g. \texttt{Do}, \texttt{D-},  \ldots
         \item \texttt{strokediode}: the various diodes are drawn \emph{and} stroke by default, i.e. when using styles such as \texttt{diode}, \texttt{D}, \texttt{sD}, \ldots Other diode styles can always be forced with e.g. \texttt{Do}, \texttt{D*},  \ldots
@@ -419,7 +419,7 @@ Feel free to load the package with your own cultural options:
 
     \medskip
 
-    In \ConTeXt\ the options are similarly specified: \texttt{current= european|american}, \texttt{voltage= european|american},  \texttt{resistor= american|european},  \texttt{inductor= cute|american|european}, \texttt{logic= american|european}, \texttt{siunitx= true|false}, \texttt{arrowmos= false|true}.
+    In \ConTeXt\ the options are similarly specified: \texttt{current= european|american}, \texttt{voltage= european|american},  \texttt{resistor= american|european},  \texttt{inductor= cute|american|european}, \texttt{logic= american|european}, \texttt{arrowmos= false|true}.
 
 } %\stop the \sloppy processing
 
@@ -7534,7 +7534,7 @@ You can add ``decorations'' to the path-style components; there are basically fi
 \end{LTXexample}
 
 
-Long names/styles for the bipoles can be used, of course, and there is a special syntax (that works only in simple cases --- use it with caution!) if you load the package with the `siunitx` options:
+Long names/styles for the bipoles can be used, of course, and there is a special syntax (that works only in simple cases, and olny with \LaTeX{} --- use it with caution!) if you load the package with the `siunitx` options:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}\draw
@@ -8860,7 +8860,7 @@ Another possibility is to have the arrow length based on the length of the compo
 
 \subsection{Integration with {\ttfamily siunitx}}
 
-If the option {\ttfamily siunitx} is active\footnote{This option is still experimental --- personally (Romano) I would advise using the normal \texttt{\textbackslash SI\{\}\{\}} syntax.}  (and \emph{not} in \ConTeXt), then the following are equivalent:
+If the option {\ttfamily siunitx} is active\footnote{This option is still experimental --- personally (Romano) I would advise using the normal \texttt{\textbackslash SI\{\}\{\}} syntax, or the \texttt{\textbackslash qty\{\}\{\}} one for \texttt{siunitx} \texttt{v3} and newer.}, then the following are equivalent (this will \textbf{not} work in \ConTeXt{}):
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}


### PR DESCRIPTION
Mention that the `siunitx` simulation layer is disabled for ConTeXt