### PR TITLE
Prepare for CTAN release 1.6.2 (2023-05-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.2 (unreleased)
+* Version 1.6.2 (2023-05-13)
+
+    Several more styling options for elements (body diodes, transformers, crossing), a clock wedge shape for logical circuits, and documentation updates for ConTeXt, mainly noticing the (upstream) elimination of the thin `siunitx` layer compatibility macros.
 
     - there is no `siunitx` support for ConTeXt, point to the `units` package
     - `context` compatibility can have glitches: please see [this issue](https://github.com/circuitikz/circuitikz/issues/706)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.2-unreleased}
-\def\pgfcircversiondate{2023/02/12}
+\def\pgfcircversion{1.6.2}
+\def\pgfcircversiondate{2023/05/13}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -9,12 +9,15 @@
 % 2. under the GNU Public License.
 %
 % See the files gpl-3.0_license.txt and lppl-1-3c_license.txt for more details.
+%
+% This module file is normally overriden by the provided m-circuitikz.tex
+% in the newer ConTeXt distributions.
+%
 \startmodule[circuitikz]
-\usemodule[pgfrcs,pgfmat]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.2-unreleased}
-\def\pgfcircversiondate{2023/02/12}
+\def\pgfcircversion{1.6.2}
+\def\pgfcircversiondate{2023/05/13}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 
@@ -94,6 +97,10 @@
    [\currentmoduleparameter{logic}]
    [european=>\ctikzset{ logic ports=european},
     american=>\ctikzset{ logic ports=american}]
+
+% This tiny siunitx emulation layer (REALLY tiny) is practically never
+% enabled because recent ConTeXt releases override this file with
+% m-circuitikz.tex and in that file it has been removed.
 
 \processaction
    [\currentmoduleparameter{siunitx}]


### PR DESCRIPTION
Several more styling options for elements (body diodes, transformers, crossing), a clock wedge shape for logical circuits, and documentation updates for ConTeXt, mainly noticing the (upstream) elimination of the thin `siunitx` layer compatibility macros.

- there is no `siunitx` support for ConTeXt, point to their `units` package
- Add styling of `transform core` lines
- Add `scale` to the bodydiode options
- Add styling of crossing vertical line
- Add `clockwedge` shape