### PR TITLE
Change default size for solder and bodydiode poles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,19 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.6.3 (unreleased)
 
-    The definition of the "plus" and "minus" symbols used in several parts of the library has changed, in
-    order to achieve better alignement of voltages and amplifier symbols when using fonts different from Computer Modern.
+    The main change is that the definition of the "plus" and "minus" symbols used in several parts of the library has changed in order to achieve better alignment of voltages and amplifier symbols when using fonts different from Computer Modern.
+    Additionally, internal connection dots in transistors are configurable and have a new default, and documentation has got several fixes and enhancements.
 
-    - changed the definition of "minus" symbol (see [this issue](https://github.com/circuitikz/circuitikz/issues/721)) for details.
-    - added documentation on how to contact the border of the source symbols (suggested by [user `@Tipounk` on GitHub](https://github.com/circuitikz/circuitikz/issues/722))
+    - Change the definition of "minus" symbol (see [this issue](https://github.com/circuitikz/circuitikz/issues/721)) for details
+    - Add documentation on how to contact the border of the source symbols (suggested by [user `@Tipounk` on GitHub](https://github.com/circuitikz/circuitikz/issues/722))
+    - in transistors, solder dots and connection dots for body diodes [are now configurable](https://github.com/circuitikz/circuitikz/issues/720)
+    - several documentation fixes
 
 * Version 1.6.2 (2023-05-13)
 
     Several more styling options for elements (body diodes, transformers, crossing), a clock wedge shape for logical circuits, and documentation updates for ConTeXt, mainly noticing the (upstream) elimination of the thin `siunitx` layer compatibility macros.
 
-    - there is no `siunitx` support for ConTeXt, point to the `units` package
+    - There is no `siunitx` support for ConTeXt, point to the `units` package
     - `context` compatibility can have glitches: please see [this issue](https://github.com/circuitikz/circuitikz/issues/706)
     - Add styling of `transform core` lines (suggested by [user `@myzinsky` on GitHub](https://github.com/circuitikz/circuitikz/issues/702))
     - Add `scale` to the bodydiode options (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/703))

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -256,6 +256,11 @@ If unsure, you can check the version in your local installation by using the mac
             \ctikzset{bipoles/vsourceam/inner minus=$-$}
             \ctikzset{voltage/american minus=$-$}
         \end{lstlisting}
+    \item Since version \texttt{1.6.3} the size of the solder dot and the connection dot of the body diodes for transistors has changed (now they are the same and are configurable). The new default scale of~\texttt{0.7} makes the dots \emph{area} more or less one half the one of the external connections. You can go back to the previous values with
+        \begin{lstlisting}
+            \ctikzset{transistor bodydiode/dot scale=0.5,
+                transistor solderdot scale=1.0}
+        \end{lstlisting}
     \item Since version \texttt{1.6.2} \texttt{siunitx}  will \textbf{not}  work anymore with \ConTeXt{} (it was a very poor simulation layer, anyway); it has been disabled in upstream \ConTeXt, in favor of \href{https://www.pragma-ade.nl/general/manuals/units-mkiv.pdf}{its own \texttt{units} module}.
     \item Version \texttt{1.6.0} has a big rewrite of the block's code. In principle the changes are backward-compatible, but there were several bugs (wrong anchors, errors with rotations, and so on) that have been fixed in the process.
     \item Since \texttt{v1.5.1}\footnote{Do not use \texttt{v1.5.0}, it's buggy.} color management (see section~\ref{sec:colors}) and the details of how the shapes are drawn and protected by the external drawing options has changed. There should be no substantial changes to the circuits, though.
@@ -3850,7 +3855,7 @@ Basically they are the same as the normal \texttt{npn} and \texttt{pnp}, and the
     \circuitdesc{GaN hemt}{Gallium Nitride hemt (a ``styled'' \texttt{hemt}, see~\ref{sec:hemt})}{Q}( G/180/0.2,D/0/0.2,S/0/0.2, nogate/-120/0.2)
 \end{groupdesc}
 
-\textsc{nfet}s and \textsc{pfet}s have been incorporated based on code provided by Clemens Helfmeier and Theodor Borsche. Use the package options \texttt{fetsolderdot}/\texttt{nofetsolderdot} to enable/disable solderdot at some fet-transistors. Additionally, the solderdot option can be enabled/disabled for single transistors with the option \texttt{solderdot} and \texttt{nosolderdot}, respectively.
+\textsc{nfet}s and \textsc{pfet}s have been incorporated based on code provided by Clemens Helfmeier and Theodor Borsche. Use the package options \texttt{fetsolderdot}/\texttt{nofetsolderdot} to enable/disable solderdot at some fet-transistors. Additionally, the solderdot option can be enabled/disabled for single transistors with the option \texttt{solderdot} and \texttt{nosolderdot}, respectively (You can adjust the size of the solder dot, see section~\ref{sec:solderdot-scale}).
 
 \begin{groupdesc}
     \circuitdesc{nfet}{nfet}{Q}(G/180/0.1, D/0/0.1, S/0/0.1)
@@ -3976,6 +3981,33 @@ If the option \texttt{arrowmos} is used (or after the command \verb!\ctikzset{tr
 
 You can go back to the no-arrows mos with \texttt{noarrowmos} locally or with
 \texttt{\textbackslash ctikzset\{tripoles/mos style/no arrows\}}.
+
+To draw the PMOS circle non-solid, use the option \texttt{emptycircle} or the command
+\\\verb!\ctikzset{tripoles/pmos style/emptycircle}!. To remove the dot completely (only useful if you have \texttt{arrowmos} enabled, otherwise there will be no difference between P-MOS and N-MOS), you can use the option \texttt{nocircle} or \verb|\ctikzset{tripoles/pmos style/nocircle}|.
+
+\begin{groupdesc}
+    \circuitdesc{pmos,emptycircle}{pmos}{}
+    \circuitdesc{pmos,nocircle,arrowmos}{pmos}{}
+\end{groupdesc}
+
+This example show the combined effects of the arrows and gate-circle options:
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}[
+    info/.style={left=1cm, blue, text width=5em, align=right},]
+    \draw (0,1) node{pmos} (2,1) node{nmos};
+    \draw (0,0) node[info]{default} node[pmos]{} (2,0) node[nmos]{};
+    \ctikzset{tripoles/mos style/arrows}
+    \draw (0,-2) node[info]{arrows} node[pmos]{} (2,-2) node[nmos]{};
+    \ctikzset{tripoles/pmos style/emptycircle}
+    \draw (0,-4) node[info]{emptycircle} node[pmos]{} (2,-4) node[nmos]{};
+    \ctikzset{tripoles/pmos style/nocircle}
+    \draw (0,-6) node[info]{nocircle} node[pmos]{} (2,-6) node[nmos]{};
+    \ctikzset{tripoles/mos style/no arrows}
+    \draw (0,-8) node[info, red]{no circle, no arrows, DON'T do it}
+          node[pmos]{} (2,-8) node[nmos]{};
+\end{circuitikz}
+\end{LTXexample}
 
 You can also change\footnote{Thanks to the idea by \href{https://github.com/circuitikz/circuitikz/issues/655}{Dr. Matthias Jung on GitHub}.} the type of the arrow for the ``light rays'' of the phototransistors with the generic arrows options shown in~\ref{sec:tunablearrows}, using the name \texttt{opto}, like in the following (overdone) example. Also the \texttt{opto arrows} styling options (see section~\ref{sec:opto-arrows}).
 
@@ -4162,14 +4194,6 @@ Normally, in bipolar IGBTs the outer base is the same size (height) of the inner
 \end{circuitikz}
 \end{LTXexample}
 
-To draw the PMOS circle non-solid, use the option \texttt{emptycircle} or the command
-\\\verb!\ctikzset{tripoles/pmos style/emptycircle}!. To remove the dot completely (only useful if you have \texttt{arrowmos} enabled, otherwise there will be no difference between P-MOS and N-MOS), you can use the option \texttt{nocircle} or \verb|\ctikzset{tripoles/pmos style/nocircle}|.
-
-\begin{groupdesc}
-    \circuitdesc{pmos,emptycircle}{pmos}{}
-    \circuitdesc{pmos,nocircle,arrowmos}{pmos}{}
-\end{groupdesc}
-
 \paragraph{Bulk terminals.} You can add a bulk terminal\footnote{Thanks to Burak Kelleci <kellecib@hotmail.com>.} to \texttt{nmos} and \texttt{pmos} using the key \texttt{bulk} in the node (and \texttt{nobulk} if you set the bulk terminal by default); additional anchors \texttt{bulk} and \texttt{nobulk} are added (in the next example, \texttt{tripoles/mos style/arrows} is enacted, too):
 
 \begin{groupdesc}
@@ -4183,21 +4207,19 @@ To draw the PMOS circle non-solid, use the option \texttt{emptycircle} or the co
     \footnotetext{Since \texttt{v1.4.4}, noticed by \href{https://tex.stackexchange.com/q/619334/38080}{user \texttt{hinata exc} on Stack Exchange}.}
 \end{groupdesc}
 
+
+\paragraph{Solder dots.}\label{sec:solderdot-scale}
+Solder dots are scaled-down\footnote{Since \texttt{v1.6.3}, suggested by \href{https://tex.stackexchange.com/q/687225/38080}{user Hartomes on TeX StackExchange}; previously, the default scale was \texttt{1.0}, which created a clash with body diodes.} version of the normal \texttt{circ} connection dot (\emph{pole}).
+This is to convey the information that the connection is \emph{internal} to the device, and not controllable from the outside. By default, they are scaled as the bodydiode connection dots (see section~\ref{sec:trans-bodydiode-custom}), but you can change them with the command \texttt{\textbackslash ctikzset\{transistor solderdot scale=\emph{x}\}}, where $x$ is the scale with respect to the normal \texttt{circ} node (default: \texttt{0.7}).
+
 \begin{LTXexample}[varwidth=true]
-\begin{circuitikz}[
-    info/.style={left=1cm, blue, text width=5em, align=right},]
-    \draw (0,1) node{pmos} (2,1) node{nmos};
-    \draw (0,0) node[info]{default} node[pmos]{} (2,0) node[nmos]{};
-    \ctikzset{tripoles/mos style/arrows}
-    \draw (0,-2) node[info]{arrows} node[pmos]{} (2,-2) node[nmos]{};
-    \ctikzset{tripoles/pmos style/emptycircle}
-    \draw (0,-4) node[info]{emptycircle} node[pmos]{} (2,-4) node[nmos]{};
-    \ctikzset{tripoles/pmos style/nocircle}
-    \draw (0,-6) node[info]{nocircle} node[pmos]{} (2,-6) node[nmos]{};
-    \ctikzset{tripoles/mos style/no arrows}
-    \draw (0,-8) node[info, red]{no circle, no arrows, DON'T do it}
-          node[pmos]{} (2,-8) node[nmos]{};
-\end{circuitikz}
+\begin{tikzpicture}[]
+    \draw (0,0) to[short,*-] ++(.1,0)
+        node[nigfete, solderdot, anchor=G]{};
+    \ctikzset{transistor solderdot scale=1}
+    \draw (2,0) to[short,*-] ++(.1,0)
+        node[nigfete, solderdot, anchor=G]{};
+\end{tikzpicture}
 \end{LTXexample}
 
 \paragraph{Simplified symbols for depletion-mode MOSFETs}.
@@ -4379,6 +4401,7 @@ You can change the style of the bodydiode\footnote{Suggested by \href{https://te
      color & default & stroke color: \texttt{default} is the same as the component \\
      dash & default & dash pattern: \texttt{default} means not to change the setting for the component; \texttt{none} means unbroken line; every other input is a dash pattern\footnotemark \\
      scale & 0.3 & scale of the diode, with respect to the basic (not scaled) diode dimension.\\
+     dot scale & 0.7 & scale of bodydiode connections dots, with respect to the \texttt{circ} pole. Use zero to remove them (useful if you have circles around the transistor).\\
         \bottomrule
     \end{tabular}
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
@@ -4393,9 +4416,10 @@ The following is a quite extensive example. Obviously, a good strategy in this c
         circuitikz/transistor bodydiode/relative thickness=0.3}]
     \draw (0,0) node (mosfet1) [nigfete,anchor=D,bodydiode] {$Q_1$};
     \draw[densely dashed]  (3,0) node (mosfet1) [nigfete,anchor=D,bodydiode] {$Q_2$};
-    \draw (6,0) node (mosfet1) [nigfete,anchor=D,bodydiode,
+    \draw (6,0) node (mosfet1) [nigfete,anchor=D,bodydiode, tr circle,
         circuitikz/transistor bodydiode/color=gray,
-        circuitikz/transistor bodydiode/scale=0.2] {$Q_3$};
+        circuitikz/transistor bodydiode/scale=0.2,
+        circuitikz/transistor bodydiode/dot scale=0] {$Q_3$};
     \draw (0,-2) node (mosfet1) [nigfete,anchor=D,bodydiode,
         circuitikz/transistor bodydiode/dash={{2pt}{1pt}}]  {$Q_4$};
     \draw[densely dashed]  (3,-2) node (mosfet1) [nigfete,anchor=D,
@@ -4403,12 +4427,11 @@ The following is a quite extensive example. Obviously, a good strategy in this c
     \ctikzset{transistor bodydiode/relative thickness=.5,
         transistor bodydiode/scale=0.6}% from now on, in scope
     \draw[densely dotted] (6,-2) node (mosfet1) [nigfete,anchor=D,bodydiode,
-          circuitikz/transistor bodydiode/dash=none] {$Q_6$};
+          circuitikz/transistor bodydiode/dash=none,
+          circuitikz/transistor bodydiode/dot scale=1] {$Q_6$};
     \path (7,0); %% adjust bounding box (node text is outside it!)
 \end{tikzpicture}
 \end{LTXexample}
-
-
 
 \subsubsection{Transistors anchors}
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -467,6 +467,18 @@
     \fi
 }
 
+% set the text color (via \color) if the color is not default or none
+% needed in some strange case (like bodydiode' dots)
+\def\pgf@circ@maybe@color#1{%
+    \edef\@@none{none}\edef\@@default{default}%
+     \edef\@@tmp{\ctikzvalof{#1}}%
+     \ifx\@@tmp\@@default\else
+        \ifx\@@tmp\@@none\else
+            \color{\@@tmp}%
+        \fi
+     \fi
+}
+
 %%>>>
 
 %% font changes compatible with plain/LaTeX/ConTeXt%<<<1

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -3380,6 +3380,8 @@
 \ctikzset{transistor bodydiode/relative thickness/.initial=1}
 \ctikzset{transistor bodydiode/color/.initial=default}
 \ctikzset{transistor bodydiode/dash/.initial=default}
+\ctikzset{transistor bodydiode/dot scale/.initial=0.7}
+\ctikzset{transistor solderdot scale/.initial=0.7}
 % this is unfortunate, but needed for backward compatibility
 \ctikzset{transistor bodydiode/scale/.code={%
     \ctikzset{tripoles/nmos/bodydiode scale=#1}%
@@ -3945,33 +3947,46 @@
             \pgf@circ@setcolor
             %
             \ifnum \ctikzvalof{tripoles/#1/curr direction} > 0
-            \pgf@circuit@trans@ntypetrue
+                \pgf@circuit@trans@ntypetrue
             \else
-            \pgf@circuit@trans@ntypefalse
-        \fi
-        \northeast
-        \pgf@circ@res@up = \pgf@y
-        \pgf@circ@res@down = -\pgf@y
-        \pgf@circ@res@right = \pgf@x
-        \left
-        \pgf@circ@res@left = \pgf@x
-        \pgf@circ@scaled@Rlen=\scaledRlen
-        %
-        #3%
-        % BODY DIODE
-        \ifpgf@circuit@fet@bodydiode
-            \pgfscope
-                \pgfsetlinewidth{\ctikzvalof{transistor bodydiode/relative thickness}\pgflinewidth}
-                \pgf@circ@subset@color@dash{transistor bodydiode}
+                \pgf@circuit@trans@ntypefalse
+            \fi
+            \northeast
+            \pgf@circ@res@up = \pgf@y
+            \pgf@circ@res@down = -\pgf@y
+            \pgf@circ@res@right = \pgf@x
+            \left
+            \pgf@circ@res@left = \pgf@x
+            \pgf@circ@scaled@Rlen=\scaledRlen
+            %
+            #3%
+            % BODY DIODE
+            \ifpgf@circuit@fet@bodydiode
                 \drawbodydiode{#1}
-            \endpgfscope
-        \fi
-        %
+            \fi
+            %
+        }
     }
 }
+
+\def\drawdobydiodedot#1#2{
+    % retrieve dot scale
+    \edef\@@tmp{\ctikzvalof{transistor bodydiode/dot scale}}
+    \ifdim\@@tmp pt>0pt
+        \pgfscope
+            \pgftransformshift{\pgfpoint{\pgf@circ@res@right}
+                {\ctikzvalof{tripoles/#1/bodydiode conn}#2}}
+            \pgftransformscale{\@@tmp}
+            % I'm not sure why this is needed, but...
+            \pgf@circ@maybe@color{transistor bodydiode/color}
+            \pgfnode{circ}{center}{}{}{\pgfusepath{draw,fill}}
+        \endpgfscope
+    \fi
 }
 
 \long\def\drawbodydiode#1{
+    \pgfsetlinewidth{\ctikzvalof{transistor bodydiode/relative thickness}\pgflinewidth}
+    \pgf@circ@subset@color@dash{transistor bodydiode}
     \pgfscope
         \pgftransformshift{\pgfpoint{-\ctikzvalof{tripoles/#1/bodydiode distance}\pgf@circ@res@left}{\pgf@circ@res@up+\pgf@circ@res@down}}
         \pgftransformrotate{90}
@@ -3999,23 +4014,14 @@
     {\ctikzvalof{tripoles/#1/bodydiode conn}\pgf@circ@res@up}}
     \pgfpathlineto{\pgfpointanchor{pgf@bodydiode}{east}}
     \pgfusepath{draw}
-    \pgfscope
-        \pgftransformshift{\pgfpoint{\pgf@circ@res@right}
-        {\ctikzvalof{tripoles/#1/bodydiode conn}\pgf@circ@res@up}}
-        \pgftransformscale{0.5}
-        \pgfnode{circ}{center}{}{}{\pgfusepath{fill}}
-    \endpgfscope{}
+    \drawdobydiodedot{#1}{\pgf@circ@res@up}
     %Draw lower connection to body diode
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}
     {\ctikzvalof{tripoles/#1/bodydiode conn}\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{-\ctikzvalof{tripoles/#1/bodydiode distance}\pgf@circ@res@left}{\ctikzvalof{tripoles/#1/bodydiode conn}\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpointanchor{pgf@bodydiode}{west}}
     \pgfusepath{draw}
-    \pgfscope
-        \pgftransformshift{\pgfpoint{\pgf@circ@res@right}		        	       {\ctikzvalof{tripoles/#1/bodydiode conn}\pgf@circ@res@down}}
-        \pgftransformscale{0.5}
-        \pgfnode{circ}{center}{}{}{\pgfusepath{fill}}
-    \endpgfscope
+    \drawdobydiodedot{#1}{\pgf@circ@res@down}
 }
 
 \long\def\declarebpt#1{
@@ -5601,6 +5607,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/nigfete/gate height}\pgf@circ@res@down}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
     \endpgfscope{}
 \fi
@@ -5615,6 +5622,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/nigfetebulk/gate height}\pgf@circ@res@down}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
         \endpgfscope{}
     \fi
@@ -5635,6 +5643,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/nigfete/gate height}\pgf@circ@res@down}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
         \endpgfscope{}
     \fi
@@ -5657,6 +5666,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/pigfete/gate height}\pgf@circ@res@up}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
         \endpgfscope
     \fi
@@ -5684,6 +5694,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/nigfete/gate height}\pgf@circ@res@up}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
         \endpgfscope{}
     \fi
@@ -5891,6 +5902,7 @@
         \pgfscope
             \pgftransformshift{\pgfpoint{\pgf@circ@res@right}{
             \ctikzvalof{tripoles/nigfete/gate height}\pgf@circ@res@down}}
+            \pgftransformscale{\ctikzvalof{transistor solderdot scale}}
             \pgfnode{circ}{center}{}{}{}
         \endpgfscope{}
     \fi


### PR DESCRIPTION
Add options to change the size of solder and bodydiode poles size.
Fix the color of bodydiode connection dots when the transistor bodydiode/color is set
Fix a puzzling displacement of documentation sections for the transistors.

![image](https://github.com/circuitikz/circuitikz/assets/6414907/d4eb60c5-07c2-4589-b8c7-94365d80818d)

![image](https://github.com/circuitikz/circuitikz/assets/6414907/d773cdf9-e98e-4cec-9bb9-e1eaaa0be76e)

![image](https://github.com/circuitikz/circuitikz/assets/6414907/8a06eb34-5bdf-4ff5-8979-fb38670114bb)


Fixes #720