### PR TITLE
Unrotate text in European logic ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.6.4 (unreleased)
 
+    A bit of enhancement and fixes for the European-style logic ports.
+
+    - The symbol in european logic ports is now rotation-invariant, and its font can be customizable (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/730))
+    - Added a couple of "blank" (no symbol) European logic ports
     - Documentation fixes
 
 * Version 1.6.3 (2023-06-23)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -6207,6 +6207,8 @@ The transmission gate (also known as ``bowtie'') components are not described in
     \circuitdesc*{european xnor port}{European \textsc{xnor} port}{}
     \circuitdesc*{european buffer port}{European \textsc{buffer} port}{}
     \circuitdesc*{european not port}{European \textsc{not} port}{}
+    \circuitdesc*{european blank port}{European blank port}{A}
+    \circuitdesc*{european blank not port}{European blank not port}{B}
 \end{groupdesc}
 
 \begin{framed}
@@ -6767,7 +6769,30 @@ The anchors for the tgate's control point are called \texttt{gate} and \texttt{n
 
 \subsubsection{European logic port usage}
 
-European logic port are the same class as american and IEEE-style ones, and they obey the same class modifier. Moreover, you can use the \texttt{no inputs pin} as in the other logic ports to suppress input pins.
+European logic port are in the same class as american and IEEE-style ones, and they obey the same class modifier. Moreover, you can use the \texttt{no inputs pin} as in the other logic ports to suppress input pins.
+
+The standard text inside the port does not rotate (not flip) with the component\footnote{since \texttt{1.6.4}, thanks to a suggestion by \href{https://github.com/circuitikz/circuitikz/issues/730}{user \texttt{@sputeanus} on GitHub}.}, but you can change the font (and color and so on) with the key \texttt{european ports font} (default nothing, which means it uses the standard font and color).
+For more complex customization, you can use the two ``blank'' European ports, and add the text you want on them.
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{tikzpicture}
+    \ctikzset{
+        logic ports=european,
+        logic ports origin=center,
+        logic ports/scale=1.5,
+        tripoles/european not symbol=ieee circle,
+    }
+    % Draw the Nand with big AND symbol
+    \ctikzset{european ports font=\Huge\color{red}}
+    \draw(0,0) node [nand port, rotate=90,
+        number inputs=4]{};
+    \draw(3,0) node [nand port, xscale=-1]{};
+    % the un-rotation is not automatic for node text!
+    \draw(0,-3) node [blank port, rotate=90,
+        ]{\rotatebox{-90}{\Huge ?}};
+    \draw(3,-3) node [blank not port, xscale=-1]{?};
+\end{tikzpicture}
+\end{LTXexample}
 
 \paragraph{European logic port customization} Normally the European-style logic port with inverted output are marked with a small triangle; if you want you can change it with the key \texttt{tripoles/european not symbol}; its default is \texttt{triangle} but you can set it to \texttt{circle} like in the following example. As you can see, the circle size is the same as the circuit poles; if you prefer the size used in the IEEE standard ports, you can use set it to \texttt{ieee circle}.
 

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -25,7 +25,8 @@
 %
 \pgfkeys{/tikz/number inputs/.initial=0}
 \pgfkeys{/tikz/number inputs/.default=0}
-
+% by default, use the default font (and color, etc.)
+\ctikzset{european ports font/.initial={}}
 \newif\ifpgf@circuit@europeanlogicport
 \ctikzset{logic ports/.is choice}
 \ctikzset{logic ports/european/.code= {\pgf@circuit@europeanlogicporttrue
@@ -37,6 +38,8 @@
     \tikzset{nand port/.style={shape=european nand port}}%
     \tikzset{nor port/.style={shape=european nor port}}%
     \tikzset{xnor port/.style={shape=european xnor port}}%
+    \tikzset{blank port/.style={shape=european blank port}}%
+    \tikzset{blank not port/.style={shape=european blank not port}}%
     % there is no Schmitt ports in european style (yet)
     \tikzset{schmitt port/.style={shape=schmitt}}%
     \tikzset{invschmitt port/.style={shape=invschmitt}}%
@@ -52,6 +55,9 @@
     \tikzset{xnor port/.style={shape=american xnor port}}%
     \tikzset{schmitt port/.style={shape=schmitt}}%
     \tikzset{invschmitt port/.style={shape=invschmitt}}%
+    %%% there are no blank ports for american (no sense to have them)
+    \tikzset{blank port/.style={shape=european blank port}}%
+    \tikzset{blank not port/.style={shape=european blank not port}}%
 }}
 
 \ctikzset{logic ports origin/.is choice}
@@ -70,6 +76,8 @@
     \ctikzset{tripoles/european xnor port/origin/.initial=0.8}%
     \ctikzset{tripoles/european buffer port/origin/.initial=0.8}%
     \ctikzset{tripoles/european not port/origin/.initial=0.8}%
+    \ctikzset{tripoles/european blank port/origin/.initial=0.8}%
+    \ctikzset{tripoles/european blank not port/origin/.initial=0.8}%
     }%
 }
 \ctikzset{logic ports origin/center/.code={%
@@ -87,6 +95,8 @@
     \ctikzset{tripoles/european xnor port/origin/.initial=0}%
     \ctikzset{tripoles/european buffer port/origin/.initial=0}%
     \ctikzset{tripoles/european not port/origin/.initial=0}%
+    \ctikzset{tripoles/european blank port/origin/.initial=0}%
+    \ctikzset{tripoles/european blank not port/origin/.initial=0}%
     }%
 }
 
@@ -195,7 +205,7 @@
 \ctikzset{tripoles/american xnor port/inputs/.initial=2}
 \ctikzset{tripoles/american xnor port/angle/.initial=70}
 \ctikzset{tripoles/american xnor port/inner/.initial=0.3}
-
+%
 \ctikzset{tripoles/european and port/width/.initial=1.4}
 \ctikzset{tripoles/european and port/height/.initial=.65}
 \ctikzset{tripoles/european and port/reserved/.initial=.6}
@@ -255,6 +265,21 @@
 \ctikzset{tripoles/european buffer port/inputs/.initial=1}%
 \ctikzset{tripoles/european not port/origin/.initial=0.8}
 \ctikzset{tripoles/european not port/inputs/.initial=1}%
+%% "blank" ports
+\ctikzset{tripoles/european blank port/width/.initial=1.4}
+\ctikzset{tripoles/european blank port/height/.initial=.65}
+\ctikzset{tripoles/european blank port/reserved/.initial=.6}
+\ctikzset{tripoles/european blank port/input height/.initial=.6}
+\ctikzset{tripoles/european blank not port/width/.initial=1.4}
+\ctikzset{tripoles/european blank not port/not height/.initial=.3}
+\ctikzset{tripoles/european blank not port/not width/.initial=.9}
+\ctikzset{tripoles/european blank not port/height/.initial=.65}
+\ctikzset{tripoles/european blank not port/reserved/.initial=.6}
+\ctikzset{tripoles/european blank not port/input height/.initial=.6}
+\ctikzset{tripoles/european blank port/origin/.initial=0.8}
+\ctikzset{tripoles/european blank port/inputs/.initial=2}
+\ctikzset{tripoles/european blank not port/origin/.initial=0.8}
+\ctikzset{tripoles/european blank not port/inputs/.initial=2}
 %%% parameters that are not used anymore after multi-input
 %%% gates --- left for compatibility of source code.
 \ctikzset{tripoles/american xor port/aaa/.initial=.6}
@@ -1547,8 +1572,11 @@
         \fi
         \pgf@circ@text@strokecolor
         \pgfpathmoveto{\pgfpointorigin}
-        \pgftext{#2}
-        %
+        \pgfscope
+            % text is always in standard direction
+            \pgftransformresetnontranslations
+            \pgftext{\ctikzvalof{european ports font}#2}%
+        \endpgfscope
         }
     }
 }
@@ -1560,7 +1588,8 @@
 \pgfcircdeclareeurologicport{nand}{\&}{\pgf@circ@res@count}{not}
 \pgfcircdeclareeurologicport{nor}{$\ge 1$}{\pgf@circ@res@count}{not}
 \pgfcircdeclareeurologicport{xnor}{$=1$}{\pgf@circ@res@count}{not}
-
+\pgfcircdeclareeurologicport{blank}{}{\pgf@circ@res@count}{}
+\pgfcircdeclareeurologicport{blank not}{}{\pgf@circ@res@count}{not}
 %% end european logic ports
 % %>>>
 


### PR DESCRIPTION
In addition, make the font used configurable; add a couple of "blank" ports that can be filled with the node text.

Thanks to user @sputeanus
Fixes #730

![image](https://github.com/circuitikz/circuitikz/assets/6414907/4e01f5ad-c135-48ba-9bdf-50265a8f6d0d)

![image](https://github.com/circuitikz/circuitikz/assets/6414907/1836e24e-0e12-4805-8c51-c4e980d24639)

![image](https://github.com/circuitikz/circuitikz/assets/6414907/7686b9e8-4459-4342-b239-cc92434f95f8)
