### PR TITLE
Add open shape to sinusoidal current source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added a couple of "blank" (no symbol) European logic ports
     - Added for new "traditional" switches (contributed by Jakob "DraUX" on GitHub)(https://github.com/circuitikz/circuitikz/issues/734)
     - Added configurability (color, thickness, dash) to switch arrows
+    - Added configurable open shape to the sinusoidal current source (contributed by [Maximilian Martin](https://github.com/circuitikz/circuitikz/pull/737))
     - Documentation fixes
 
 * Version 1.6.3 (2023-06-23)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2611,17 +2611,20 @@ Similarly, if (default behavior) \texttt{europeanvoltages} option is active (or 
 \end{framed}
 
 
-\subsubsection{Sinusoidal sources}\label{sec:sinusoidal-vi} These two are basically the same symbol; to distinguish among them, you have to add a label, which will be a voltage or a current.
+\subsubsection{Sinusoidal sources}\label{sec:sinusoidal-vi} These two are basically the same symbol; to distinguish among them, you have to add a label, which will be a voltage or a current. Another option would be to configure the \texttt{sinusoidal current source} as an open shape using \texttt{\textbackslash ctikzset\string{bipoles/isourcesin/angle=80\string}} similar to the \texttt{dcisource} in section~\ref{sec:dc-sources}.
 
 \begin{groupdesc}
     \circuitdescbip*[vsourcesin]{sinusoidal voltage source}{Sinusoidal voltage source}{vsourcesin, sV}
-    \circuitdescbip*[isourcesin]{sinusoidal current source}{Sinusoidal current source}{isourcesin, sI}
+    \circuitdescbip*[isourcesin]{sinusoidal current source}{Sinusoidal current source\footnotemark}{isourcesin, sI}
+      \footnotetext{The configurable open shape of the \texttt{sinusoidal current source} has been added by \href{https://github.com/circuitikz/circuitikz/pull/737}{Maximilian Martin}}.
 \end{groupdesc}
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[american]
-   \draw (0,1) to[sV=$V$] ++(3,0);
-   \draw (0,0) to[sI=$I$] ++(3,0);
+   \draw (0,2) to[sV=$V$] ++(3,0);
+   \draw (0,1) to[sI=$I$] ++(3,0);
+   \ctikzset{bipoles/isourcesin/angle=80}
+   \draw (0,0) to[sI] ++(3,0);
 \end{circuitikz}
 \end{LTXexample}
 
@@ -2780,7 +2783,7 @@ The symbol shapes used here seems to be the most common in publications; if you 
 \end{tikzpicture}
 \end{LTXexample}
 
-\subsubsection{DC sources}
+\subsubsection{DC sources}\label{sec:dc-sources}
 \begin{groupdesc}
     \circuitdescbip*{dcvsource}{DC voltage source}{}
     \circuitdescbip*{dcisource}{DC current source}{}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1884,6 +1884,7 @@
 \ctikzset{bipoles/vsourceam/height/.initial=.60}
 \ctikzset{bipoles/vsourceam/width/.initial=.60}
 \ctikzset{bipoles/vsourceam/margin/.initial=.7}
+\ctikzset{bipoles/isourcesin/angle/.initial=90}
 \ctikzset{bipoles/isourcesin/height/.initial=.60}
 \ctikzset{bipoles/isourcesin/width/.initial=.60}
 \ctikzset{bipoles/vsourcesin/height/.initial=.60}
@@ -2815,7 +2816,7 @@
     \endpgfscope
 }
 
-%% Independent sinusoidal current source
+%% Independent sinusoidal current source with open shape
 \pgfcircdeclarebipolescaled{sources}
 {}
 {\ctikzvalof{bipoles/isource/height}}
@@ -2825,8 +2826,16 @@
 {
     \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
-    \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
-    \pgf@circ@draworfill
+    \pgfscope
+        \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
+        \pgf@circ@maybefill
+    \endpgfscope
+    \edef\@@angle{\ctikzvalof{bipoles/isourcesin/angle}}
+    \pgfpathmoveto{\pgfpointpolar{\@@angle}{\pgf@circ@res@up}}
+    \pgfpatharc{\@@angle}{-\@@angle}{\pgf@circ@res@up}
+    \pgfpathmoveto{\pgfpointpolar{180-\@@angle}{\pgf@circ@res@up}}
+    \pgfpatharc{180-\@@angle}{180+\@@angle}{\pgf@circ@res@up}
+    \pgfusepath{draw}
 
     \pgf@circ@res@up = .5\pgf@circ@res@up
     \pgfscope


### PR DESCRIPTION
In Germany, an open shape is usually added to sinusoidal current sources, similar to DC current sources. This has the advantage that it makes them distinguishable from sinusoidal voltage sources.