### PR TITLE
Add eyw-symbol (reverse star symbol) for ootransformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added a couple of "blank" (no symbol) European logic ports
     - Added for new "traditional" switches (contributed by Jakob "DraUX" on GitHub)(https://github.com/circuitikz/circuitikz/issues/734)
     - Added configurability (color, thickness, dash) to switch arrows
+    - Added "eyw"-symbol (reverse star) for "oo"-type sources [https://github.com/circuitikz/circuitikz/pull/742](contributed by Jakob «DraUX» on GitHub)
     - Added configurable open shape to the sinusoidal current source (contributed by [Maximilian Martin](https://github.com/circuitikz/circuitikz/pull/737))
     - Documentation fixes
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2719,7 +2719,7 @@ Notice that if you choose the dashed style, the noise sources are fillable:
     \endgroup
 \end{groupdesc}
 
-The transformer shapes vector group options can be specified for the primary (\texttt{prim=\emph{value}}), the secondary (\texttt{sec=\emph{value}}) and tertiary (\texttt{tert=\emph{value}}) three-phase vector groups: the value can be one of \texttt{delta}, \texttt{wye}, \texttt{eyw}\footnote{The \texttt{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob «DraUX» on GitHub} and \texttt{zig}.
+The transformer shapes vector group options can be specified for the primary (\texttt{prim=\emph{value}}), the secondary (\texttt{sec=\emph{value}}) and tertiary (\texttt{tert=\emph{value}}) three-phase vector groups: the value can be one of \texttt{delta}, \texttt{wye}, \texttt{eyw}\footnote{The \texttt{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob «DraUX» on GitHub}} and \texttt{zig}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2719,13 +2719,13 @@ Notice that if you choose the dashed style, the noise sources are fillable:
     \endgroup
 \end{groupdesc}
 
-The transformer shapes vector group options can be specified for the primary (\texttt{prim=\emph{value}}), the secondary (\texttt{sec=\emph{value}}) and tertiary (\texttt{tert=\emph{value}}) three-phase vector groups: the value can be one of \texttt{delta}, \texttt{wye} and \texttt{zig}.
+The transformer shapes vector group options can be specified for the primary (\texttt{prim=\emph{value}}), the secondary (\texttt{sec=\emph{value}}) and tertiary (\texttt{tert=\emph{value}}) three-phase vector groups: the value can be one of \texttt{delta}, \texttt{wye}, \texttt{eyw}\footnote{The \texttt{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob «DraUX» on GitHub} and \texttt{zig}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
     \draw (0,0) to[oosourcetrans, prim=zig, sec=delta, o-] ++(2,0)
     to[oosourcetrans, prim=delta, sec=wye,-o] ++(0,-2)
-    to[ooosource, prim=wye, sec=zig, tert=delta] (0,0);
+    to[ooosource, prim=eyw, sec=zig, tert=delta] (0,0);
 \end{circuitikz}
 \end{LTXexample}
 
@@ -2736,7 +2736,7 @@ These two ``sources'' have additional anchors that reach the center of the symbo
     smalldot/.style={draw, circle,red, inner sep=0.2pt}]
     \draw (0,0) to[oosourcetrans, name=A,
             prim=delta, sec=wye] ++(1,0)
-        to[ooosource, name=B, prim=wye, sec=zig,
+        to[ooosource, name=B, prim=eyw, sec=zig,
             tert=delta] ++(1,0)
         (A.symbolsec) -- ++(-45:0.5) node[ground]{};
     \node [smalldot] at (A.symbolprim) {};
@@ -2856,9 +2856,9 @@ You can do the same with the \texttt{american controlled voltage sources}, subst
 \end{LTXexample}
 
 \paragraph{Three-phase symbols.}
-The three-phase symbols \texttt{delta}, \texttt{wye}, and \texttt{zig} follows the line thickness exactly as
+The three-phase symbols \texttt{delta}, \texttt{wye}, \texttt{eyw}, and \texttt{zig} follows the line thickness exactly as
 the waveform ones (see above). Additionally, you can scale them up and down by changing the value of the keys
-\texttt{sources/symbol/delta scale}, \texttt{.../wye scale}, and \texttt{.../zig scale} (default \texttt{1}).
+\texttt{sources/symbol/delta scale}, \texttt{.../wye scale}, \texttt{.../eyw scale}, and \texttt{.../zig scale} (default \texttt{1}).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[scale=1.8, transform shape]

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2579,7 +2579,7 @@
             \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@left}
             \pgf@circ@zig{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
         \endpgfscope
-    \fi\fi\fi
+    \fi\fi\fi\fi
 
     %%secondary winding
     \ifpgf@circ@sec@delta
@@ -2605,7 +2605,7 @@
             \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@right}
             \pgf@circ@zig{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
         \endpgfscope
-    \fi\fi\fi
+    \fi\fi\fi\fi
 }
 
 
@@ -2793,7 +2793,7 @@
             \pgftransformxshift{.6\pgf@circ@res@left}
             \pgf@circ@zig{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
-    \fi\fi\fi
+    \fi\fi\fi\fi
 
 % %     secondary winding
     \ifpgf@circ@sec@delta
@@ -2820,7 +2820,7 @@
             \pgftransformshift{\pgfpointpolar{60}{0.6\pgf@circ@res@right}}
             \pgf@circ@zig{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
-    \fi\fi\fi
+    \fi\fi\fi\fi
 
 % %     tertiary winding
     \ifpgf@circ@tert@delta
@@ -2846,7 +2846,7 @@
             \pgftransformshift{\pgfpointpolar{-60}{0.6\pgf@circ@res@right}}
             \pgf@circ@zig{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
-    \fi\fi\fi
+    \fi\fi\fi\fi
 }
 
 %% Independent current source - American

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -1915,7 +1915,7 @@
 % noise sources
 \ctikzset{bipoles/noise sources/fillcolor/.initial=gray!50}
 
-% for special symbols in the sources: sin, square, triangle, delta, wye, zig, etc.
+% for special symbols in the sources: sin, square, triangle, delta, wye, eyw, zig, etc.
 \ctikzset{sources/symbol/thickness/.initial={1}}
 \ctikzset{csources/symbol/thickness/.initial={1}}
 \ctikzset{sources/symbol/rotate/.initial={90}}
@@ -1937,28 +1937,34 @@
 % % % primary windings
 \newif\ifpgf@circ@prim@delta
 \newif\ifpgf@circ@prim@wye
+\newif\ifpgf@circ@prim@eyw
 \newif\ifpgf@circ@prim@zig
 \pgfkeys{tikz/prim/.is choice}
 \pgfkeys{tikz/prim/delta/.add code={}{\pgf@circ@prim@deltatrue}}
 \pgfkeys{tikz/prim/wye/.add code={}{\pgf@circ@prim@wyetrue}}
+\pgfkeys{tikz/prim/eyw/.add code={}{\pgf@circ@prim@eywtrue}}
 \pgfkeys{tikz/prim/zig/.add code={}{\pgf@circ@prim@zigtrue}}
 
 % % % secondary windings
 \newif\ifpgf@circ@sec@delta
 \newif\ifpgf@circ@sec@wye
+\newif\ifpgf@circ@sec@eyw
 \newif\ifpgf@circ@sec@zig
 \pgfkeys{tikz/sec/.is choice}
 \pgfkeys{tikz/sec/delta/.add code={}{\pgf@circ@sec@deltatrue}}
 \pgfkeys{tikz/sec/wye/.add code={}{\pgf@circ@sec@wyetrue}}
+\pgfkeys{tikz/sec/eyw/.add code={}{\pgf@circ@sec@eywtrue}}
 \pgfkeys{tikz/sec/zig/.add code={}{\pgf@circ@sec@zigtrue}}
 
 % % % tertiary windings (ooosource)
 \newif\ifpgf@circ@tert@delta
 \newif\ifpgf@circ@tert@wye
+\newif\ifpgf@circ@tert@eyw
 \newif\ifpgf@circ@tert@zig
 \pgfkeys{tikz/tert/.is choice}
 \pgfkeys{tikz/tert/delta/.add code={}{\pgf@circ@tert@deltatrue}}
 \pgfkeys{tikz/tert/wye/.add code={}{\pgf@circ@tert@wyetrue}}
+\pgfkeys{tikz/tert/eyw/.add code={}{\pgf@circ@tert@eywtrue}}
 \pgfkeys{tikz/tert/zig/.add code={}{\pgf@circ@tert@zigtrue}}%
 
 % nullator and norator
@@ -2110,7 +2116,7 @@
 %% Round and diamond sources
 %%%%%%%%%%%
 
-% % % symbol drawing macros (NOT for delta, wye, zig)
+% % % symbol drawing macros (NOT for delta, wye, eyw, zig)
 \def\pgf@circ@sources@symbol@setup{% called in a pgfscope
     \edef\@@@auto{auto}\edef\@@@rotate{\ctikzvalof{\ctikzclass/symbol/rotate}}
     \ifx\@@@auto\@@@rotate
@@ -2425,6 +2431,7 @@
 % % % winding symbols
 \ctikzset{sources/symbol/delta scale/.initial={1}}
 \ctikzset{sources/symbol/wye scale/.initial={1}}
+\ctikzset{sources/symbol/eyw scale/.initial={1}}
 \ctikzset{sources/symbol/zig scale/.initial={1}}
 % triangle
 \def\pgf@circ@delta#1{
@@ -2462,6 +2469,24 @@
         \pgfpathlineto{\pgfpointpolar{-150}{\pgf@circ@res@down}}
         \pgfusepath{stroke}
     \endpgfscope
+}
+
+% reverse star
+\def\pgf@circ@eyw#1{
+	\pgfscope
+	\pgftransformscale{-.015*\ctikzvalof{\ctikzclass/symbol/eyw scale}*\pgf@circ@res@left*#1}
+	\def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+	\pgftransformrotate{-\pgfcircmathresult}
+	
+	\pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
+	\pgf@circ@set@relative@thickness{symbol/thickness}
+	\pgfpathmoveto{\pgfpoint{0}{\pgf@circ@res@up}}
+	\pgfpathlineto{\pgfpointorigin}
+	\pgfpathlineto{\pgfpointpolar{30}{\pgf@circ@res@down}}
+	\pgfpathmoveto{\pgfpointorigin}
+	\pgfpathlineto{\pgfpointpolar{150}{\pgf@circ@res@down}}
+	\pgfusepath{stroke}
+	\endpgfscope
 }
 
 % zigzag
@@ -2542,6 +2567,12 @@
             \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@left}
             \pgf@circ@wye{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
         \endpgfscope
+        
+        \else\ifpgf@circ@prim@eyw
+        \pgfscope
+        \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@left}
+        \pgf@circ@eyw{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
+        \endpgfscope
 
     \else\ifpgf@circ@prim@zig
         \pgfscope
@@ -2561,6 +2592,12 @@
         \pgfscope
             \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@right}
             \pgf@circ@wye{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
+        \endpgfscope
+        
+        \else\ifpgf@circ@sec@eyw
+        \pgfscope
+        \pgftransformxshift{\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@right}
+        \pgf@circ@eyw{\ctikzvalof{bipoles/oosourcetrans/vectorgroupscale}}
         \endpgfscope
 
     \else\ifpgf@circ@sec@zig
@@ -2744,6 +2781,12 @@
             \pgftransformxshift{.6\pgf@circ@res@left}
             \pgf@circ@wye{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
+        
+        \else\ifpgf@circ@prim@eyw
+        \pgfscope
+        \pgftransformxshift{.6\pgf@circ@res@left}
+        \pgf@circ@eyw{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
+        \endpgfscope
 
     \else\ifpgf@circ@prim@zig
         \pgfscope
@@ -2765,6 +2808,12 @@
             \pgftransformshift{\pgfpointpolar{60}{0.6\pgf@circ@res@right}}
             \pgf@circ@wye{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
+        
+        \else\ifpgf@circ@sec@eyw
+        \pgfscope
+        \pgftransformshift{\pgfpointpolar{60}{0.6\pgf@circ@res@right}}
+        \pgf@circ@eyw{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
+        \endpgfscope
 
     \else\ifpgf@circ@sec@zig
         \pgfscope
@@ -2784,6 +2833,12 @@
         \pgfscope
             \pgftransformshift{\pgfpointpolar{-60}{0.6\pgf@circ@res@right}}
             \pgf@circ@wye{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
+        \endpgfscope
+        
+        \else\ifpgf@circ@tert@eyw
+        \pgfscope
+        \pgftransformshift{\pgfpointpolar{-60}{0.6\pgf@circ@res@right}}
+        \pgf@circ@eyw{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
 
     \else\ifpgf@circ@tert@zig

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2474,18 +2474,18 @@
 % reverse star
 \def\pgf@circ@eyw#1{
 	\pgfscope
-	\pgftransformscale{-.015*\ctikzvalof{\ctikzclass/symbol/eyw scale}*\pgf@circ@res@left*#1}
-	\def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
-	\pgftransformrotate{-\pgfcircmathresult}
+		\pgftransformscale{-.015*\ctikzvalof{\ctikzclass/symbol/eyw scale}*\pgf@circ@res@left*#1}
+		\def\pgfcircmathresult{\expandafter\pgf@circ@stripdecimals\pgf@circ@direction\pgf@nil}
+			\pgftransformrotate{-\pgfcircmathresult}
 	
-	\pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
-	\pgf@circ@set@relative@thickness{symbol/thickness}
-	\pgfpathmoveto{\pgfpoint{0}{\pgf@circ@res@up}}
-	\pgfpathlineto{\pgfpointorigin}
-	\pgfpathlineto{\pgfpointpolar{30}{\pgf@circ@res@down}}
-	\pgfpathmoveto{\pgfpointorigin}
-	\pgfpathlineto{\pgfpointpolar{150}{\pgf@circ@res@down}}
-	\pgfusepath{stroke}
+		\pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
+		\pgf@circ@set@relative@thickness{symbol/thickness}
+		\pgfpathmoveto{\pgfpoint{0}{\pgf@circ@res@up}}
+		\pgfpathlineto{\pgfpointorigin}
+		\pgfpathlineto{\pgfpointpolar{30}{\pgf@circ@res@down}}
+		\pgfpathmoveto{\pgfpointorigin}
+		\pgfpathlineto{\pgfpointpolar{150}{\pgf@circ@res@down}}
+		\pgfusepath{stroke}
 	\endpgfscope
 }
 


### PR DESCRIPTION
I just starting to work with git, so I accidentally deleted my last pr. This one should now be less confusing. Here my original pr:

I often see the Y-symbol in transformers turned around (with the vertical line upwards) and prefer it that way. I guess the easiest way is to just add another symbol for the ootransformers with the 180°-rotated Y-symbol. I hope you like it.

![image](https://github.com/circuitikz/circuitikz/assets/86589394/61f47f71-446a-47af-863b-131c0f68134c)
