### PR TITLE
CTAN release 1.6.4 (2023-10-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.4 (unreleased)
+* Version 1.6.4 (2023-10-10)
 
-    A bit of enhancement and fixes for the European-style logic ports, more switches (and a bit more configurability).
+    A bit of enhancement and fixes for the European-style logic ports, more switches (and a bit more configurabilityi for them), more option for some sources.
 
     - The symbol in European logic ports is now rotation-invariant, and its font can be customized (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/730))
     - Added a couple of "blank" (no symbol) European logic ports

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.4-unreleased}
-\def\pgfcircversiondate{2023/07/28}
+\def\pgfcircversion{1.6.4}
+\def\pgfcircversiondate{2023/10/10}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.4-unreleased}
-\def\pgfcircversiondate{2023/07/28}
+\def\pgfcircversion{1.6.4}
+\def\pgfcircversiondate{2023/10/10}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
A bit of enhancements and fixes for the European-style logic ports, more switches (and a bit more configurability for them), and more option for some sources.

- The symbol in European logic ports is now rotation-invariant, and its font can be customized (#730)
- Added a couple of "blank" (no symbol) European logic ports
- Added new "traditional" switches (#734)
- Added configurability (color, thickness, dash) to switch arrows
- Added "eyw"-symbol (reverse star) for "oo"-type sources (#742)
- Added configurable open shape to the sinusoidal current source (#737)
- Several documentation fixes