### PR TITLE
Fix `open`+`straightvoltages` label position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added optional and configurable inner, outer and border labels to the `muxdemux` shapes
     - Added optional clock wedge and negation signs to the pins of `muxdemux` shapes
     - Added the possibility to add a background drawing to `muxdemux` shapes
+    - Fixed a [bug](https://github.com/circuitikz/circuitikz/issues/748) with `straightvoltages` and `open`
 
 * Version 1.6.4 (2023-10-10)
 

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -191,6 +191,13 @@
             \def\pgf@circ@bipole@voltage@label@anchor{center}
             \pgfmathsetlength{\absvshift}{\absvshift+sign(\absvshift)*height{"Q"}} % with the current font.
         \fi
+        % apply the same shift to open "straight" voltage as raised
+        \ifpgf@circuit@bipole@voltage@straight
+            \ifx\@@kind\@@open
+                \def\pgf@circ@bipole@voltage@label@anchor{center}
+                \pgfmathsetlength{\absvshift}{\absvshift+sign(\absvshift)*height{"Q"}} % with the current font.
+            \fi
+        \fi
     }
     % %\pgf@circ@Rlen/\ctikzvalof{current arrow scale} is equal to the length of the currarrow
     %absolute move, minimum space is length of arrowhead


### PR DESCRIPTION
Fix position of voltage labels for open components when voltage=straigth Fixes #748