### PR TITLE
Workaround: add a tunable for source voltage shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Added optional clock wedge and negation signs to the pins of `muxdemux` shapes
     - Added the possibility to add a background drawing to `muxdemux` shapes
     - Fixed a [bug](https://github.com/circuitikz/circuitikz/issues/748) with `straightvoltages` and `open`
+    - Added an (ugly) workaround for a [voltage shift mismatch](https://github.com/circuitikz/circuitikz/issues/747) for sources
 
 * Version 1.6.4 (2023-10-10)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -8664,6 +8664,25 @@ Negative values do work as expected:
 \end{circuitikz}
 \end{LTXexample}
 
+Unfortunately\footnote{see \href{https://github.com/circuitikz/circuitikz/issues/747}{this bug report}.} the amount of shift given by \texttt{voltage shift} is not always the same between sources and passive bipoles, especially if the sizes of the component is very different from the default. Although this qualifies as a bug, and should be fixed in a more comprehensive way, a workaround is available with the key \texttt{voltage shift sources adjust} (default: \texttt{\ctikzvalof{voltage shift sources adjust}}). A smaller value is better for smaller components, as you can see in the example below.
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\newcommand{\example}[2][]{\draw[#1] (#2)
+        to [V_=$U$] ++(0, -1) (#2) ++(2,0)
+        to [R,v=$U_R$] ++(0,-1);
+    }
+\ctikzset{resistors/scale=0.55,inductors/scale=0.55,
+    capacitors/scale=0.6,sources/scale=.8}
+\begin{circuitikz}[circuitikz/voltage=straight,
+    voltage dir=EF]
+    \example{0,4}
+    \ctikzset{voltage shift=2}
+    \example[color=red]{0,2}
+    \ctikzset{voltage shift sources adjust=0.2}
+    \example[color=blue]{0,0}
+\end{circuitikz}
+\end{LTXexample}
+
 You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \texttt{voltage/shift} (default \texttt{0.0} for the former and \texttt{voltage/american label distance} (the distance of the label from the lines of the symbols, default \texttt{1.4}) for the latter.
 
 \begin{LTXexample}[varwidth=true]

--- a/tex/pgfcircvoltage.tex
+++ b/tex/pgfcircvoltage.tex
@@ -366,6 +366,8 @@
 % %>>>
 
 %% Output routine for voltage sources%<<<
+% (ugly) workaround for https://github.com/circuitikz/circuitikz/issues/747
+\ctikzset{voltage shift sources adjust/.initial=0.5} % coefficient added "by feel". Sorry.
 \def\pgf@circ@drawvoltagegenerator{
     % the following is affected indirectly by voltage/shift, you can move the arrow with voltage/bump a.
     % it's not perfect, but I can't find the way to do it correctly...
@@ -389,7 +391,7 @@
         {
             \edef\addvshift{0}
         }
-        \pgfmathsetmacro{\bumpaplus}{\bumpa + 0.5*\shiftv} % coefficient added "by feel". Sorry.
+        \pgfmathsetmacro{\bumpaplus}{\bumpa + \ctikzvalof{voltage shift sources adjust}*\shiftv}
     }
     \ifpgf@circuit@bipole@voltage@below
         coordinate (pgfcirc@Vfrom0) at ($(\ctikzvalof{bipole/name}.center) ! \bumpaplus ! (\ctikzvalof{bipole/name}.-120)$)


### PR DESCRIPTION
As you can see in issue #747, the `voltage shift` factor is not always coherent when applied to normal bipoles and sources, especially if the standard size of the component is different. Changing the positioning of the voltage elements maintaining backward compatibility is too difficult for a minor review. Added a tunable to adjust the amount added for sources.

Fixes #747

![image](https://github.com/circuitikz/circuitikz/assets/6414907/b35fbab1-d58b-4f40-ac45-dbfc9fcc1186)
