### PR TITLE
Prepare for CTAN version 1.6.5 (2023-10-29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.5 (unreleased)
+* Version 1.6.5 (2023-10-29)
 
-   This version features an important overhaul of the `muxdemux` configurable component/shape, making it much more flexible and powerful.
+   This version features an important overhaul of the `muxdemux` configurable component/shape, making it much more flexible and powerful, by adding configurable labels and negation and clock symbols to the pins.
+   Also, a couple of minor fixes/workarounds.
 
     - Added optional and configurable inner, outer and border labels to the `muxdemux` shapes
     - Added optional clock wedge and negation signs to the pins of `muxdemux` shapes

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.5-unreleased}
-\def\pgfcircversiondate{2023/10/14}
+\def\pgfcircversion{1.6.5}
+\def\pgfcircversiondate{2023/10/29}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.5-unreleased}
-\def\pgfcircversiondate{2023/10/14}
+\def\pgfcircversion{1.6.5}
+\def\pgfcircversiondate{2023/10/29}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
This version features an important overhaul of the `muxdemux` configurable component/shape, making it much more flexible and powerful by adding configurable labels and negation and clock symbols to the pins.
Also, a couple of minor fixes/workarounds.

- Added optional and configurable inner, outer and border labels to the `muxdemux` shapes
- Added optional clock wedge and negation signs to the pins of `muxdemux` shapes
- Added the possibility to add a background drawing to `muxdemux` shapes
- Fixed a [bug](https://github.com/circuitikz/circuitikz/issues/748) with `straightvoltages` and `open`
- Added an (ugly) workaround for a [voltage shift mismatch](https://github.com/circuitikz/circuitikz/issues/747) for sources