### PR TITLE
CTAN release 1.6.6 (2023-12-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.6 (unreleased)
+* Version 1.6.6 (2023-12-09)
 
     Several new components.
 

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.6-unreleased}
-\def\pgfcircversiondate{2023/10/30}
+\def\pgfcircversion{1.6.6}
+\def\pgfcircversiondate{2023/12/09}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
Several new components.

- Added the symbol for metal-oxide varistor `mov`
- Added another symbol for fuse (wiggly fuse `wfuse`)