### PR TITLE
Fix a misleading documentation about resistor's shape

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1436,14 +1436,29 @@ for example changing the parameter \texttt{bipoles/thickness} (default 2). The n
 \paragraph{Shape of the components} (on a per-component-class basis)
 
 The shape of the components are adjustable with a lot of parameters; in this manual we will comment the main ones, but you can look into the source files specified above to find more.
+Notice however that the ``internal'' parameters, the ones not commented in this manual, are not part of the public interface so they can disappear or change in future versions.
+
+It is recommended to use the styling parameters to change the shapes; they are not so fine-grained (for example, you can change the width of resistor), but they are more stable and coherent across your circuit.
+
 \begin{LTXexample}[varwidth=true]
-    \tikz \draw (0,0) to[R=1<\ohm>] (2,0); \par
-    \ctikzset{bipoles/resistor/height=.6}
-    \tikz \draw (0,0) to[R=1<\ohm>] (2,0);
+    \tikz \draw (0,0) to[R=1<\ohm>] (3,0); \par
+    \ctikzset{resistors/width=2}
+    \tikz \draw (0,0) to[R=1<\ohm>] (3,0);
 \end{LTXexample}
 
-It is recommended to use the styling parameters to change the shapes; they are not so fine-grained (for example, you can change the width of resistor, not the height at the moment), but they are more stable and coherent across your circuit.
+To change the height, you can use (locally) the class scale parameter and the width; you can even define a style that will work across the resistor styles:
 
+\begin{LTXexample}[varwidth=true]
+    \ctikzset{american}
+    \tikz \draw (0,0) to[R=1<\ohm>] (4,0);
+
+    \ctikzset{tallR/.style={
+        resistors/scale=2, resistors/width=0.4}}
+    \tikz \draw (0,0) to[R=1<\ohm>, tallR] (4,0);
+
+    \ctikzset{european}
+    \tikz \draw (0,0) to[R=1<\ohm>, tallR] (4,0);
+\end{LTXexample}
 \subsubsection{Descriptions}
 
 The typical entry in the component list will be like this:


### PR DESCRIPTION
Thanks to @quark67
Fixes #765

![image](https://github.com/circuitikz/circuitikz/assets/6414907/311f2b71-d2a0-49de-ba84-492a5c0c82b3)
