### PR TITLE
Add key to configure block lateral anchors position.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Added `saturation` block (contributed by [P. Sacco <paul.sacco@estaca.eu>](https://github.com/circuitikz/circuitikz/issues/758)
     - Added `iamp`, `sigmoid`, and `allornothing` blocks
+    - Now the position of the lateral anchors (`left up` and similar) of blocks is configurable (suggested by [user "sputeanus" on GitHub](https://github.com/circuitikz/circuitikz/issues/769))
 
 * Version 1.6.6 (2023-12-09)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3648,20 +3648,36 @@ In addition, since \texttt{v1.6.0},  most blocks also have the \texttt{left up},
     (bp.left up) node[circ, red]{}
     (bp.left down) node[circ, blue]{}
     (bp.right up) node[circ, green]{}
-    (bp.right down) node[circ, yellow]{}
+    (bp.right down) node[circ, orange]{}
 ;\end{circuitikz}
 \end{LTXexample}
 
-You can use those anchors to build ``mixed-type'' circuits, positioning the node-shapes:
+Since \texttt{1.6.7} you can change the relative position of the lateral generic anchors\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/769}{user @sputeanus} on GitHub} using the keys \texttt{block left anchors pos} and \texttt{block right anchor pos} (default \texttt{0.5}, as in previous releases) which set the position as a fraction of the top to center segment.
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz}
+    \ctikzset{block left anchors pos=0.8, block right anchors pos=0.2}
+    \draw (0,0) to[bandpass, name=bp] ++(2,0)
+    (bp.left up) node[circ, red]{}
+    (bp.left down) node[circ, blue]{}
+    (bp.right up) node[circ, green]{}
+    (bp.right down) node[circ, orange]{}
+;\end{circuitikz}
+\end{LTXexample}
+
+To set both left and right at the same value, you can use the key \texttt{block lateral anchors pos}, which set both to the same number.
+You can use those anchors to build ``mixed-type'' circuits, using the node-shapes (the following drawing is a bit silly, but shows that the anchor position can be changed locally):
 \begin{LTXexample}[pos=t, varwidth=true]
 \begin{tikzpicture}[
     big/.style={circuitikz/blocks/scale=1.5},
     long/.style={circuitikz/bipoles/twoportsplit/width=1.5}]
-    \path (0,0) node[sacdcshape, big](A){}
+    \ctikzset{block lateral anchors pos=0.8}
+    \path (0,0) node[sacdcshape, big, circuitikz/block right anchors pos=0.2](A){}
         (5,0) node[twoportsplitshape, big, long, t1=LNA, t2=Digital](B){};
     \draw (A.right up) -- (B.left up) (A.right down) to[cute choke] (B.left down);
 \end{tikzpicture}
 \end{LTXexample}
+
 Notice also from the previous example that the generic blocks (\texttt{twoport} and \texttt{twoportsplit}) can be made ``longer'' by setting different \texttt{width} and \texttt{height} (the other blocks are square, and just use the \texttt{width} key for both dimensions).
 
 Also, for \texttt{amp} and \texttt{vamp}, the \texttt{up} and \texttt{down} anchors follow the shape when they are not boxed.

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -639,11 +639,19 @@
     \fi
 }
 %%% blocks additional anchors
+\ctikzset{block left anchors pos/.initial=0.5}
+\ctikzset{block right anchors pos/.initial=0.5}
+\ctikzset{block lateral anchors pos/.code={
+    \ctikzset{block left anchors pos=#1}%
+    \ctikzset{block right anchors pos=#1}%
+}}
 \def\pgcirc@twoport@additional@anchors{%
-    \anchor{right down}{\northeast\pgf@y=-0.5\pgf@y}
-    \anchor{left down}{\northeast\pgf@x=-\pgf@x\pgf@y=-0.5\pgf@y}
-    \anchor{left up}{\northeast\pgf@x=-\pgf@x\pgf@y=0.5\pgf@y}
-    \anchor{right up}{\northeast\pgf@y=0.5\pgf@y}
+    \savedmacro{\blockleftanchorpos}{\edef\blockleftanchorpos{\ctikzvalof{block left anchors pos}}}
+    \savedmacro{\blockrightanchorpos}{\edef\blockrightanchorpos{\ctikzvalof{block right anchors pos}}}
+    \anchor{right down}{\northeast\pgf@y=-\blockrightanchorpos\pgf@y}
+    \anchor{left down}{\northeast\pgf@x=-\pgf@x\pgf@y=-\blockleftanchorpos\pgf@y}
+    \anchor{left up}{\northeast\pgf@x=-\pgf@x\pgf@y=\blockleftanchorpos\pgf@y}
+    \anchor{right up}{\northeast\pgf@y=\blockrightanchorpos\pgf@y}
     \anchor{up}{\northeast\pgf@x=0pt\relax}
     \anchor{down}{\northeast\pgf@y=-\pgf@y\pgf@x=0pt\relax}
 }


### PR DESCRIPTION
Now the position of the lateral anchors (`left up` and similar) of blocks is configurable.
suggested by @sputeanus, Fixes #769

![image](https://github.com/circuitikz/circuitikz/assets/6414907/74a2e6b0-9e2a-4579-96da-55f8ed8229fb)
