### PR TITLE
Preparing for CTAN release 1.6.7 (2024-02-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.7 (unreleased)
+* Version 1.6.7 (2024-02-09)
 
     Several new blocks, more flexible generic anchors for blocks, and a new option to align the signs on american-style voltage sources.
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.7-unreleased}
-\def\pgfcircversiondate{2023/12/15}
+\def\pgfcircversion{1.6.7}
+\def\pgfcircversiondate{2024/02/09}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.7-unreleased}
-\def\pgfcircversiondate{2023/12/15}
+\def\pgfcircversion{1.6.7}
+\def\pgfcircversiondate{2024/02/09}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
Several new blocks, more flexible generic anchors for blocks, and a new option to align the signs on american-style voltage sources.

- Added `saturation` block (contributed by [P. Sacco <paul.sacco@estaca.eu>](https://github.com/circuitikz/circuitikz/issues/758))
- Added `iamp`, `sigmoid`, and `allornothing` blocks
- Added optical fiber `fiber` (contributed by [Christopher Beck](https://github.com/circuitikz/circuitikz/pull/771))
- Now the position of the lateral anchors (`left up` and similar) of blocks is configurable (suggested by [user "sputeanus" on GitHub](https://github.com/circuitikz/circuitikz/issues/769))
- Now you can choose how the signs on american-style sources rotate when the source is not vertical (suggested by [jotagah on GitHub](https://github.com/circuitikz/circuitikz/issues/773))
- New section in the manual about related packages