### PR TITLE
Add `mid` anchor to traditional switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.6.8 (unreleased)
 
+    - Added `mid` anchor to all traditional switches
     - Switch the default compiler to pdflatex (see https://tex.stackexchange.com/q/709273/38080)
-    - Add a warning about color and engine in the documentation
+    - Added a warning about color and engine in the documentation
 
 * Version 1.6.7 (2024-02-09)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -5832,28 +5832,28 @@ The switches can be scaled with the key \texttt{switches/scale} (default \texttt
 These are all of the to-style type:
 
 \begin{groupdesc}
-    \circuitdescbip[cspst]{switch}{Switch}{spst}
+    \circuitdescbip[cspst]{switch}{Switch}{spst}(left/135/0.1, right/45/0.1, mid/90/0.3)
     \circuitdescbip[cspst]{closing switch}{Closing switch}{cspst}
     \circuitdescbip[ospst]{opening switch}{Opening switch}{ospst}
-    \circuitdescbip[nos]{normal open switch}{Normally open switch}{nos}
+    \circuitdescbip[nos]{normal open switch}{Normally open switch}{nos}(left/135/0.1, right/45/0.1, mid/90/0.3)
     \circuitdescbip[ncs]{normal closed switch}{Normally closed switch}{ncs}
     \circuitdescbip[oncs]{opening normal closed switch}{Opening normally closed switch}{oncs}
     \circuitdescbip[cncs]{closing normal closed switch}{Closing normally closed switch}{cncs}
     \circuitdescbip[onos]{opening normal open switch}{Opening normally open switch}{onos}
     \circuitdescbip[cnos]{closing normal open switch}{Closing normally open switch\footnotemark}{cnos}
     \footnotetext{These last four were contributed by \href{https://tex.stackexchange.com/questions/693446/new-switch-components-for-circuitikz}{Jakob «DraUX»}}
-    \circuitdescbip[pushbutton]{push button}{Normally open push button}{normally open push button, nopb}(tip/0/0.2)
-    \circuitdescbip[ncpushbutton]{normally closed push button}{Normally closed push button}{ncpb}(tip/0/0.2)
-    \circuitdescbip[pushbuttonc]{normally open push button closed}{Normally open push button (in closed position)}{nopbc}(tip/0/0.2)
-    \circuitdescbip[ncpushbuttono]{normally closed push button open}{Normally closed push button (in open position)}{ncpbo}(tip/0/0.2)
-    \circuitdescbip[toggleswitch]{toggle switch}{Toggle switch}{}
-    \circuitdescbip*{reed}{Reed switch}{}
+    \circuitdescbip[pushbutton]{push button}{Normally open push button}{normally open push button, nopb}(tip/0/0.2, mid/-90/0.2)
+    \circuitdescbip[ncpushbutton]{normally closed push button}{Normally closed push button}{ncpb}(tip/0/0.2, mid/-90/0.2)
+    \circuitdescbip[pushbuttonc]{normally open push button closed}{Normally open push button (in closed position)}{nopbc}(tip/0/0.2, mid/-90/0.2)
+    \circuitdescbip[ncpushbuttono]{normally closed push button open}{Normally closed push button (in open position)}{ncpbo}(tip/0/0.2, mid/-90/0.2)
+    \circuitdescbip[toggleswitch]{toggle switch}{Toggle switch}{}(out 1/0/0.2, out 2/0/0.2, in/135/0.1, mid/-90/0.2)
+    \circuitdescbip*{reed}{Reed switch}{}(left/135/0.1, right/45/0.1, mid/90/0.3)
 \end{groupdesc}
 
 while this is a node-style component:
 
 \begin{groupdesc}
-        \circuitdesc{spdt}{spdt}{}( in/180/0.2, out 1/0/0.2, out 2/0/0.2 )
+        \circuitdesc{spdt}{spdt}{}(in/180/0.2, out 1/0/0.2, out 2/0/0.2, mid/90/0.2)
 \end{groupdesc}
 
 \begin{LTXexample}[varwidth=true]

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -4809,12 +4809,22 @@
     \pgf@circ@subset@color@dash{switch arrows}
     \pgfcirc@set@arrows{switch}{}{latexslim}
     }
+\def\pgf@circ@savedanchor@trad@midlever#1#2{% #1 -> name #2 -> relative height
+    \savedanchor\midlever{% this is the full height of the "handle" of switch
+        \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
+        \pgf@y=\ctikzvalof{bipoles/#1/height}\pgf@circ@scaled@Rlen
+        \pgf@x=0pt\pgf@y=0.5\pgf@y
+    }
+    \anchor{mid}{\midlever\pgf@y=#2\pgf@y}
+}
 %%>>>
 
 %% Shapes Node for bipoles switches and similar things%<<<
 %% (Closing) SPST
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+    \pgf@circ@savedanchor@trad@midlever{spst}{0.6}
+}
 {\ctikzvalof{bipoles/spst/depth}}
 {cspst}
 {\ctikzvalof{bipoles/spst/height}}
@@ -4836,7 +4846,9 @@
 
 %% Opening SPST
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+    \pgf@circ@savedanchor@trad@midlever{spst}{0.6}
+}
 {\ctikzvalof{bipoles/spst/depth}}
 {ospst}
 {\ctikzvalof{bipoles/spst/height}}
@@ -4858,7 +4870,9 @@
 
 %% Normal open Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{nos}{0.5}
+}
 {\ctikzvalof{bipoles/nos/depth}}
 {nos}
 {\ctikzvalof{bipoles/nos/height}}
@@ -4873,7 +4887,9 @@
 
 %% Normal closed Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{ncs}{0.5}
+}
 {\ctikzvalof{bipoles/ncs/depth}}
 {ncs}
 {\ctikzvalof{bipoles/ncs/height}}
@@ -4892,7 +4908,9 @@
 
 % Opening normal closed Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{ncs}{0.5}
+}
 {\ctikzvalof{bipoles/ncs/depth}}
 {oncs}
 {\ctikzvalof{bipoles/ncs/height}}
@@ -4920,7 +4938,9 @@
 
 %% Closing normal closed Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{ncs}{0.5}
+}
 {\ctikzvalof{bipoles/ncs/depth}}
 {cncs}
 {\ctikzvalof{bipoles/ncs/height}}
@@ -4948,7 +4968,9 @@
 
 %% Opening normal open Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{ncs}{0.5}
+}
 {\ctikzvalof{bipoles/ncs/depth}}
 {onos}
 {\ctikzvalof{bipoles/ncs/height}}
@@ -4976,7 +4998,9 @@
 
 %% Closing normal open Switch
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{ncs}{0.5}
+}
 {\ctikzvalof{bipoles/ncs/depth}}
 {cnos}
 {\ctikzvalof{bipoles/ncs/height}}
@@ -5006,6 +5030,8 @@
 \pgfcircdeclarebipolescaled{switches}
 {
     \anchor{tip}{\northeast\pgf@x=0pt\relax}
+    % we can use the generic here, the "bar" is related to bipoles/*/height
+    \pgf@circ@savedanchor@trad@midlever{pushbutton}{0.5}
 }
 {\ctikzvalof{bipoles/pushbutton/height 2}}
 {pushbutton}
@@ -5029,6 +5055,11 @@
 \pgfcircdeclarebipolescaled{switches}
 {
     \anchor{tip}{\northeast\pgf@x=0pt\relax}
+    \savedanchor{\nodeheight}{
+        \pgf@x=0pt\pgf@y=\ctikzvalof{nodes width}\pgf@circ@Rlen
+    }
+    \anchor{mid}{\nodeheight\pgf@y=-\pgf@y}
+    % \pgf@circ@savedanchor@trad@midlever{pushbutton}{0.5}
 }
 {\ctikzvalof{bipoles/pushbutton/height 2}}
 {ncpushbutton}
@@ -5054,11 +5085,15 @@
 %% https://github.com/circuitikz/circuitikz/issues/128#issuecomment-731771299
 \pgfcircdeclarebipolescaled{switches}
 {
+    \savedanchor{\nodeheight}{
+        \pgf@x=0pt\pgf@y=\ctikzvalof{nodes width}\pgf@circ@Rlen
+    }
     \anchor{tip}{
-        \pgf@circ@res@temp=\ctikzvalof{nodes width}\pgf@circ@Rlen
+        \nodeheight\pgf@circ@res@temp=\pgf@y
         \northeast\divide\pgf@y by 2\advance\pgf@y by \pgf@circ@res@temp
         \pgf@x=0pt\relax
     }
+    \anchor{mid}{\nodeheight}
 }
 {\ctikzvalof{bipoles/pushbutton/height 2}}
 {pushbuttonc}
@@ -5082,11 +5117,15 @@
 %% Normally closed Push Button now open
 \pgfcircdeclarebipolescaled{switches}
 {
+    \savedanchor{\nodeheight}{
+        \pgf@x=0pt\pgf@y=\ctikzvalof{nodes width}\pgf@circ@Rlen
+    }
     \anchor{tip}{
-        \pgf@circ@res@temp=\ctikzvalof{nodes width}\pgf@circ@Rlen
+        \nodeheight\pgf@circ@res@temp=\pgf@y
         \northeast\divide\pgf@y by 2\advance\pgf@y by \pgf@circ@res@temp
         \pgf@x=0pt\relax
     }
+    \anchor{mid}{\northeast\pgf@x=0pt\pgf@y=-0.5\pgf@y}
 }
 {\ctikzvalof{bipoles/pushbutton/height 2}}
 {ncpushbuttono}
@@ -5110,7 +5149,9 @@
 }
 %%% reed switches
 \pgfcircdeclarebipolescaled{switches}
-{}
+{
+        \pgf@circ@savedanchor@trad@midlever{nos}{0.5}
+}
 {\ctikzvalof{bipoles/reed/depth}}
 {reed}
 {\ctikzvalof{bipoles/reed/height}}
@@ -5237,14 +5278,10 @@
     }
 
 \pgfcircdeclarebipole{
-    \anchor{out 1}{
-        \northeast
-        \pgf@y=0cm
-    }
-    \anchor{out 2}{
-        \northeast
-        \pgf@y=.8\pgf@y
-    }
+    \anchor{out 1}{\northeast\pgf@y=0pt\relax}
+    \anchor{out 2}{\northeast\pgf@y=.8\pgf@y}
+    \anchor{in}{\northeast\pgf@y=0pt\pgf@x=-\pgf@x}
+    \anchor{mid}{\northeast\pgf@x=0.2\pgf@x\pgf@y=0.25\pgf@y}
 }
 {\ctikzvalof{tripoles/toggleswitch/height 2}}
 {toggleswitch}
@@ -5304,82 +5341,30 @@
         \pgf@x=-\ctikzvalof{tripoles/spdt/width}\pgf@circ@scaled@Rlen
         \pgf@x=.5\pgf@x
     }
-    \anchor{left}{%
-        \northwest
-        \pgf@y=0pt
-    }
-    \anchor{in}{
-        \northwest
-        \pgf@y=0pt
-    }
-    \anchor{out 1}{
-        \northwest
-        \pgf@x=-\pgf@x
-    }
-    \anchor{out 2}{
-        \northwest
-        \pgf@x=-\pgf@x
-        \pgf@y=-\pgf@y
-    }
-    \anchor{center}{
-        \pgf@y=0pt
-        \pgf@x=0pt
-    }
-    \anchor{east}{
-        \northwest
-        \pgf@y=0pt
-        \pgf@x=-\pgf@x
-    }
-    \anchor{west}{
-        \northwest
-        \pgf@y=0pt
-    }
-    \anchor{south}{
-        \northwest
-        \pgf@x=0pt
-        \pgf@y=-\pgf@y
-    }
-    \anchor{north}{
-        \northwest
-        \pgf@x=0pt
-    }
-    \anchor{south west}{
-        \northwest
-        \pgf@y=-\pgf@y
-    }
-    \anchor{north east}{
-        \northwest
-        \pgf@x=-\pgf@x
-    }
-    \anchor{north west}{
-        \northwest
-    }
-    \anchor{south east}{
-        \northwest
-        \pgf@x=-\pgf@x
-        \pgf@y=-\pgf@y
-    }
+    \pgfcirc@northwest@symmetric@geoanchors
+    \anchor{in}{\northwest\pgf@y=0pt}
+    \anchor{out 1}{\northwest\pgf@x=-\pgf@x}
+    % this is "by eye", it'll be wrong with non-standard ocirc
+    \anchor{mid}{\northwest\pgf@x=0pt\pgf@y=0.37\pgf@y}
+    \anchor{out 2}{\northwest\pgf@x=-\pgf@x \pgf@y=-\pgf@y}
+    \anchor{center}{\pgf@y=0pt\pgf@x=0pt}
     \pgf@circ@draw@component{
         \pgf@circ@setcolor
-
         \northwest
         \pgf@circ@res@up = \pgf@y
         \pgf@circ@res@down = -\pgf@y
         \pgf@circ@res@right = -\pgf@x
         \pgf@circ@res@left = \pgf@x
         \pgf@circ@res@other = \ctikzvalof{tripoles/spdt/margin}\pgf@circ@res@left
-
-
+        %
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
         \pgfpathlineto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
         \pgfpathlineto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@down}}
-
+        %
         \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
         \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{0pt}}
-
         \pgfusepath{draw}
-
         \pgfscope
             \pgftransformshift{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
             \pgfnode{ocirc}{center}{}{spdt1}{\pgfusepath{stroke}}
@@ -5392,7 +5377,6 @@
             \pgftransformshift{\pgfpoint{\pgf@circ@res@other}{0pt}}
             \pgfnode{ocirc}{center}{}{spdt2}{\pgfusepath{stroke}}
         \endpgfscope
-
         \pgfscope
             \pgfpathmoveto{\pgfpointshapeborder{spdt2}{\pgfpointorigin}}
             \pgfpathlineto{


### PR DESCRIPTION
Fix/stabilize the `tip` anchors in case of changes in pole size.

![image](https://github.com/circuitikz/circuitikz/assets/6414907/26c52279-2fea-44bf-9f59-b0d5beb37c35)
![image](https://github.com/circuitikz/circuitikz/assets/6414907/97d572cb-87f0-487d-9669-e2f50d315602)
![image](https://github.com/circuitikz/circuitikz/assets/6414907/11cb04a1-66fe-4974-a5b9-798e1184e995)
![image](https://github.com/circuitikz/circuitikz/assets/6414907/e9c039c4-0fb2-4abc-88b6-e8b4e9226403)
