### PR TITLE
Prepare release 1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.6.8 (unreleased)
+* Version 1.6.8 (2024-05-05)
+
+    Several new components, more anchors, a bit of documentation enhancement; maybe the biggest change is the new "flexible" tube.
 
     - Added `mid` anchor to all traditional switches
     - Added a slashed generic European-style resistor (thanks to [Jana](https://tex.stackexchange.com/q/711702/38080))

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.6.8-unreleased}
-\def\pgfcircversiondate{2024/02/11}
+\def\pgfcircversion{1.6.8}
+\def\pgfcircversiondate{2024/05/05}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.6.8-unreleased}
-\def\pgfcircversiondate{2024/02/11}
+\def\pgfcircversion{1.6.8}
+\def\pgfcircversiondate{2024/05/05}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
Several new components, more anchors, a bit of documentation enhancement; maybe the biggest change is the new "flexible" tube.

- Added `mid` anchor to all traditional switches
- Added a slashed generic European-style resistor (thanks to [Jana](https://tex.stackexchange.com/q/711702/38080))
- Added a multi-anode tube for implementing nixies and vfd (thanks to [GitHub user nogger33](https://github.com/circuitikz/circuitikz/issues/785))
- Switch the default compiler to pdflatex (see https://tex.stackexchange.com/q/709273/38080)
- Added a warning about color and engine in the documentation
- Enhanced the documentation for instruments (thanks to [Github user mxxmxm](https://github.com/circuitikz/circuitikz/issues/787))