### PR TITLE
Add Relais-Shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
+* Version 1.6.9
+
+    Several new components
+
+    - Added a Relais-Shape (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/issues/734))
+
 * Version 1.6.8 (2024-05-05)
 
     Several new components, more anchors, a bit of documentation enhancement; maybe the biggest change is the new "flexible" tube.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     Several new components
 
-    - Added a Relais-Shape (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/issues/734))
+    - Added a Relais-Shape (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/pull/795))
 
 * Version 1.6.8 (2024-05-05)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3267,7 +3267,7 @@ Here you'll find bipoles that are not easily grouped in the categories above.
     \circuitdescbip*{afuse}{Asymmetric fuse}{asymmetric fuse}
     \circuitdescbip{wfuse}{``wiggly'' fuse}{wiggly fuse}()[left/110/0.2, right/70/0.2]
     \circuitdescbip*{relais}{Relais\footnotemark}{}
-    \footnotetext{Contributed by \href{}{Jakob «DraUX»}}
+    \footnotetext{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/795}{Jakob «DraUX»}}
     \circuitdescbip{squid}{Squid}{}
     \circuitdescbip{barrier}{Barrier}{}
     \circuitdescbip{openbarrier}{Open barrier}{}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3266,6 +3266,8 @@ Here you'll find bipoles that are not easily grouped in the categories above.
     \circuitdescbip*{fuse}{Fuse}{}
     \circuitdescbip*{afuse}{Asymmetric fuse}{asymmetric fuse}
     \circuitdescbip{wfuse}{``wiggly'' fuse}{wiggly fuse}()[left/110/0.2, right/70/0.2]
+    \circuitdescbip*{relais}{Relais\footnotemark}{}
+    \footnotetext{Contributed by \href{}{Jakob «DraUX»}}
     \circuitdescbip{squid}{Squid}{}
     \circuitdescbip{barrier}{Barrier}{}
     \circuitdescbip{openbarrier}{Open barrier}{}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -6977,7 +6977,7 @@
 \ctikzset{bipoles/tlmic/width/.initial=.5}% it MUST be mic width *5/8
 \ctikzset{bipoles/mic/bar thickness/.initial=1}
 
-% arresters, fuses, lamps, etc
+% arresters, fuses, relais, lamps, etc
 
 \ctikzset{bipoles/european gas filled surge arrester/height/.initial=.30}
 \ctikzset{bipoles/european gas filled surge arrester/width/.initial=.80}
@@ -7000,6 +7000,9 @@
 \newif\ifpgf@circ@wfuse@dots\pgf@circ@wfuse@dotstrue
 \ctikzset{bipoles/wfuse/dots/.is choice}
 \ctikzset{bipoles/wfuse/dots/.is if=pgf@circ@wfuse@dots}
+%
+\ctikzset{bipoles/relais/height/.initial=.8}
+\ctikzset{bipoles/relais/width/.initial=.3}
 %
 \ctikzset{bipoles/lamp/width/.initial=.60}
 \ctikzset{bipoles/bulb/height/.initial=.8}
@@ -7233,6 +7236,25 @@
         \pgfnode{\cshape}{center}{}{\thisshape-right}{\pgfusepath{draw}}
     \fi
 }
+
+%% Relais
+\pgfcircdeclarebipolescaled{misc}
+{}
+{\ctikzvalof{bipoles/relais/height}}
+{relais}
+{\ctikzvalof{bipoles/relais/height}}
+{\ctikzvalof{bipoles/relais/width}}
+{
+	\pgfpathrectanglecorners{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+	\pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
+	\pgf@circ@draworfill
+	\pgfscope
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+	\pgfusepath{draw}
+	\endpgfscope
+}
+
 %% SQUID added by Cor Molenaar 5 March 2010
 \pgfcircdeclarebipolescaled{misc}
 {}
@@ -7355,6 +7377,7 @@
 \pgfcirc@style@to@style{asymmetric fuse}{afuse}
 \pgfcirc@activate@bipole@simple{l}{wfuse}
 \pgfcirc@activate@bipole{l}{wfuse}{wfuse}{wiggly fuse}
+\pgfcirc@activate@bipole@simple{l}{relais}
 \def\pgf@circ@gfsurgearrester@path#1{\ifpgf@circuit@europeangfsurgearrester\pgf@circ@europeangfsurgearrester@path{#1}\else\pgf@circ@americangfsurgearrester@path{#1}\fi}
 \pgfcirc@activate@bipole{l}{europeangfsurgearrester}{european gas filled surge arrester}{european gas filled surge arrester}
 \pgfcirc@activate@bipole{l}{americangfsurgearrester}{american gas filled surge arrester}{american gas filled surge arrester}


### PR DESCRIPTION
I needed to draw a relais like [asked in this question](https://tex.stackexchange.com/questions/711702/european-relay-with-circuitikz). I saw that the `sgeneric` shape was added in the last release, but it behaves like a normal resistor (along the path not across it). So I thought maybe it would be a good idea to add a `relais` shape to the package? I tried to code it, it looks like the following:
![image](https://github.com/circuitikz/circuitikz/assets/86589394/3f618c58-3977-4b47-a854-76aaf423c5c6)
