### PR TITLE
Correct key typo in the manual

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -6602,7 +6602,7 @@ with the parameter \texttt{number inputs} :
 \end{circuitikz}
 \end{LTXexample}
 
-You can suppress the drawing of the logic ports input leads by using the boolean key \texttt{logic ports draw input leads}  (default \texttt{true}) or, locally, with the style \texttt{no inputs leads} (that can be reverted with \texttt{input leads}),  like in the following example. The anchors do not change and you have to take responsibility to make the connection to the ``border''-anchors.
+You can suppress the drawing of the logic ports input leads by using the boolean key \texttt{logic ports draw input leads}  (default \texttt{true}) or, locally, with the style \texttt{no input leads} (that can be reverted with \texttt{input leads}),  like in the following example. The anchors do not change and you have to take responsibility to make the connection to the ``border''-anchors.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -7442,9 +7442,9 @@ External pins' length is controlled by the key \texttt{multipoles/external pins 
 like in chips. In addition, like in logic ports, you can suppress the
 drawing of the leads by using the boolean key
 \texttt{logic ports draw input leads} (default \texttt{true}) or, locally,
-with the style \texttt{no inputs leads} (that can be reverted with
+with the style \texttt{no input leads} (that can be reverted with
 \texttt{input leads}).
-The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no inputs lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
+The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no input lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
 
 You can draw only selected pins and leave out the rest by setting the keys
 \texttt{multipoles/draw only \emph{side} pins} and the corresponding style
@@ -7846,7 +7846,7 @@ You can, if you want, avoid printing the numbers of the pin with \texttt{hide nu
 \end{LTXexample}
 
 
-Also, you can suppress the drawing of the pins, by using the style \texttt{no inputs leads} (that can be reverted with \texttt{input leads}). The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no inputs lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
+Also, you can suppress the drawing of the pins, by using the style \texttt{no input leads} (that can be reverted with \texttt{input leads}). The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no input lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
 
 For special use you can suppress the orientation mark with the key \texttt{no topmark} (default \texttt{topmark}).
 


### PR DESCRIPTION
It's "input leads", no "inputs lead"...