### PR TITLE
Fix barrier shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Fix for straight voltage on `open` bipoles (reported by [Oliver Wallscheid on GitHub](https://github.com/circuitikz/circuitikz/issues/821))
     - Fix a very, very old bug about aliases for american/european sources
     - Fix `barrier` wire linewidth (issue [#833](https://github.com/circuitikz/circuitikz/issues/833) by schtandard).
+    - Set `barrier` default width to 0 so it does not draw any wire.
     - Documentation enhacement (example of chopper macro)
 
 * Version 1.7.0 (2024-08-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Fix for straight voltage on `open` bipoles (reported by [Oliver Wallscheid on GitHub](https://github.com/circuitikz/circuitikz/issues/821))
     - Fix a very, very old bug about aliases for american/european sources
+    - Fix `barrier` wire linewidth (issue [#833](https://github.com/circuitikz/circuitikz/issues/833) by schtandard).
     - Documentation enhacement (example of chopper macro)
 
 * Version 1.7.0 (2024-08-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Fix for straight voltage on `open` bipoles (reported by [Oliver Wallscheid on GitHub](https://github.com/circuitikz/circuitikz/issues/821))
     - Fix a very, very old bug about aliases for american/european sources
     - Fix `barrier` wire linewidth (issue [#833](https://github.com/circuitikz/circuitikz/issues/833) by schtandard).
-    - Set `barrier` default width to 0 so it does not draw any wire.
+    - Reduce `barrier` and `openbarrier` default widths so no wire is drawn by default.
+        This breaks backward-compatibility and changes the meaning of some associated keys, but the appearance with the default settings remains unchanged. See [#835](https://github.com/circuitikz/circuitikz/pull/835) for rationale.
     - Documentation enhacement (example of chopper macro)
 
 * Version 1.7.0 (2024-08-03)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -268,6 +268,10 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompatibilities between different versions of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
 If unsure, you can check the version in your local installation by using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item In version \texttt{1.7.1}, the default widths of \texttt{barrier} and \texttt{openbarrier} were reduced so that no wire is drawn as part of the symbols by default.
+        This is accompanied by a change to the meanings of the configuration keys \texttt{bipoles/barrier/width}, \texttt{bipoles/barrier/height} and \texttt{bipoles/openbarrier/gap} (as well as the new key \texttt{bipoles/openbarrier/width}).
+        The change avoids problems when using barriers on short pieces of path or as nodes, cf.~the details in \href{https://github.com/circuitikz/circuitikz/pull/835}{the relevant pull request on GitHub}.
+        The new default values are chosen such that the components are identical to the default appearance before the change.
     \item Since version \texttt{1.6.3} the default symbol for the minus sign changed from the simple \verb|$-$| to \verb|$\vphantom{+}-$|. The reason is that in some (most?) font, the minus sign is enclosed in a smaller bounding box than the plus sign and that leads to poorly aligned minus symbols in \texttt{american} and \texttt{raised} voltages. This was not noticed before because the two symbols share the same bounding box in the default Computer Modern font. You can look at \href{https://github.com/circuitikz/circuitikz/issues/721}{this issue on GitHub} for more details; if you want to go back to the previous definitions you can write
         \begin{lstlisting}
             \ctikzset{amplifiers/minus=$-$}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3495,7 +3495,8 @@ Here you'll find bipoles that are not easily grouped in the categories above.
 \end{groupdesc}
 
 You can tune how big the gap in the \texttt{openbarrier} is by setting \texttt{bipole/openbarrier/gap} (default value \texttt{1} meaning full width).
-The default width \texttt{bipole/openbarrier/width} is \texttt{0.21}, while \texttt{bipole/barrier/width} is \texttt{0}, so using these components' node shapes does not draw any wire by default.
+The default width \texttt{bipole/openbarrier/width} is \texttt{0.21}, while \texttt{bipole/barrier/width} is \texttt{0}.
+These settings ensure minimal width without drawing any wire when the components' node shapes are used.
 
 \begin{groupdesc}
     \circuitdescbip*{european gas filled surge arrester}{European gas filled surge arrester}{}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3494,7 +3494,8 @@ Here you'll find bipoles that are not easily grouped in the categories above.
     \circuitdescbip{openbarrier}{Open barrier}{}
 \end{groupdesc}
 
-You can tune how big is the gap in the \texttt{openbarrier} component by setting the key \texttt{bipoles/openbarrier/gap} (default value \texttt{0.5}; \texttt{0} means no gap and \texttt{1} full gap).
+You can tune how big the gap in the \texttt{openbarrier} is by setting \texttt{bipole/openbarrier/gap} (default value \texttt{1} meaning full width).
+The default width \texttt{bipole/openbarrier/width} is \texttt{0.21}, while \texttt{bipole/barrier/width} is \texttt{0}, so using these components' node shapes does not draw any wire by default.
 
 \begin{groupdesc}
     \circuitdescbip*{european gas filled surge arrester}{European gas filled surge arrester}{}

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -7353,15 +7353,14 @@
 {\ctikzvalof{bipoles/barrier/height}}
 {\ctikzvalof{bipoles/barrier/width}}
 {
-    \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
-
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@step}}
+    \pgfusepath{draw}
+    \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@up}}
     \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@down}}
     \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@down}}
     \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@up}}
-
     \pgfusepath{draw}
 }
 

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -7076,9 +7076,10 @@
 %
 \ctikzset{bipoles/squid/height/.initial=.60}
 \ctikzset{bipoles/squid/width/.initial=.60}
-\ctikzset{bipoles/barrier/height/.initial=.60}
-\ctikzset{bipoles/barrier/width/.initial=.60}
-\ctikzset{bipoles/openbarrier/gap/.initial=0.5}
+\ctikzset{bipoles/barrier/height/.initial=.21}
+\ctikzset{bipoles/barrier/width/.initial=.0}
+\ctikzset{bipoles/openbarrier/width/.initial=.3}
+\ctikzset{bipoles/openbarrier/gap/.initial=1}
 \ctikzset{bipoles/thermocouple/height/.initial=.250}
 \ctikzset{bipoles/thermocouple/height 2/.initial=.60}
 \ctikzset{bipoles/thermocouple/width/.initial=.140}
@@ -7357,41 +7358,35 @@
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@step}}
     \pgfusepath{draw}
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
-    \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@down}}
-    \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@up}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@down}{\pgf@circ@res@up}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@up}{\pgf@circ@res@down}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@down}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@up}{\pgf@circ@res@up}}
     \pgfusepath{draw}
 }
 
-%
 % open version of the barrier symbol
 % suggested by Radványi Patrik Tamás <patrikradvanyi@gmail.com>
-%
 \pgfcircdeclarebipolescaled{misc}
 {}
 {\ctikzvalof{bipoles/barrier/height}}
 {openbarrier}
 {\ctikzvalof{bipoles/barrier/height}}
-{\ctikzvalof{bipoles/barrier/width}}
+{\ctikzvalof{bipoles/openbarrier/width}}
 {
-    % this is set with normal wire linewidth
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
     \pgfpathlineto{\pgfpoint{\ctikzvalof{bipoles/openbarrier/gap}*\pgf@circ@res@left}{0pt}}
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{0pt}}
     \pgfpathlineto{\pgfpoint{\ctikzvalof{bipoles/openbarrier/gap}*\pgf@circ@res@right}{0pt}}
     \pgfusepath{draw}
-
-    % do the cross part
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
-
-    \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@up}}
-    \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@down}}
-    \pgfpathmoveto{\pgfpoint{0.35*\pgf@circ@res@left}{0.35*\pgf@circ@res@down}}
-    \pgfpathlineto{\pgfpoint{0.35*\pgf@circ@res@right}{0.35*\pgf@circ@res@up}}
-
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@down}{\pgf@circ@res@up}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@up}{\pgf@circ@res@down}}
+    \pgfpathmoveto{\pgfpoint{\pgf@circ@res@down}{\pgf@circ@res@down}}
+    \pgfpathlineto{\pgfpoint{\pgf@circ@res@up}{\pgf@circ@res@up}}
     \pgfusepath{draw}
 }
+
 %% Lamp
 \pgfcircdeclarebipolescaled{misc}
 {}


### PR DESCRIPTION
The first commit closes #833 by drawing the barrier wire with normal linewidth instead of the bolder component linewidth.

However, there really shouldn't be any wire at all, just as a capacitor symbol doesn't contain any lead wires. The following MWE shows two problems arising due to that wire: The first tries to use barriers on circuit segments shorter than the component length (but not shorter than the cross, which is the intuitive length of the component). The second uses the barrier node shapes and tries to place curved wires.
```latex
\documentclass{article}

\usepackage{circuitikz}

\begin{document}

\begin{circuitikz}
  \draw (0,0)
    to [barrier] ++(.75,0)
    to [barrier] ++(0,.75)
    to [openbarrier] ++(.75,0)
    to [openbarrier] ++(0,.75);
\end{circuitikz}
\begin{circuitikz}
  \draw
    (0,0) coordinate [barriershape, rotate=30, name=one] {}
    (1,0) coordinate [openbarriershape, rotate=-50, name=two] {}
    (one.left) to [out=-150, in=-90] (-1,0)
    (one.right) to [out=30, in=130] (two.left)
    (two.right) to [out=-50, in=-90] (2,0);
\end{circuitikz}

\end{document}
```

Output with the current `circuitikz` version:
![image](https://github.com/user-attachments/assets/644042e2-0195-4141-8525-ca86c5f088ca)

Output with the proposed changes:
![image](https://github.com/user-attachments/assets/1c225396-344e-41b7-b87d-b1dd24f34f12)

Now I am aware that these changes are backward-incompatible. I do feel that they address serious shortcomings, so I think they are still worthwile. I chose the default parameter values such that the symbols look identical to the current state (except for the fixed linewidth) when used on a `to`-path, which should be their main usage. The changed parameters are
- `bipoles/barrier/height` is the height and width of the cross.
- `bipoles/barrier/width` is the component width which is `0` by default.
- `bipoles/openbarrier/width` (new) is the same for the open barrier, its default value `.3` corresponds to the gap width under the previous default settings.
- `bipoles/openbarrier/gap` is the gap width relative to the component width, it is `1` by default, so the whole width is gap.