### PR TITLE
Allow to set the index position for square instruments

### DIFF
--- a/tex/circuitikz-1.4.6-body.tex
+++ b/tex/circuitikz-1.4.6-body.tex
@@ -8953,10 +8953,12 @@
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
 \ctikzset{bipoles/smeter/height/.initial=.60}
 \ctikzset{bipoles/smeter/width/.initial=.60}
+\ctikzset{bipoles/smeter/index position/.initial=80}
 \ctikzset{bipoles/smeter/voltage/additional shift/.initial=1}
 \ctikzset{bipoles/qmeter/depth/.initial=.40}
 \ctikzset{bipoles/qmeter/height/.initial=.80}
 \ctikzset{bipoles/qmeter/width/.initial=.60}
+\ctikzset{bipoles/qmeter/index position/.initial=80}
 % this must be specified for each one
 \ctikzset{bipoles/qvprobe/voltage/additional shift/.initial=.5}
 \ctikzset{bipoles/qiprobe/voltage/additional shift/.initial=.5}
@@ -9286,8 +9288,9 @@
             \pgfpathlineto{\pgfpointpolar{\@stopa}{2.5\pgf@circ@res@up}}
             \pgfpatharc{\@stopa}{\@starta}{2.5\pgf@circ@res@up}
             \pgfclosepath
-            \pgfpathmoveto{\pgfpointpolar{80}{2\pgf@circ@res@up}}
-            \pgfpathlineto{\pgfpointpolar{80}{2.4\pgf@circ@res@up}}
+            \pgfmathsetmacro{\@indexa}{\@starta - \ctikzvalof{bipoles/smeter/index position}*(\@starta - \@stopa)/100}
+            \pgfpathmoveto{\pgfpointpolar{\@indexa}{2\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpointpolar{\@indexa}{2.4\pgf@circ@res@up}}
             \pgfusepath{draw}
         \endpgfscope
         \pgftext[center, y=0.5\pgf@circ@res@down]{\ctikzvalof{bipoles/twoport/text}}
@@ -9335,8 +9338,9 @@
                 \pgfpathlineto{\pgfpointpolar{\@stopa}{2.5\pgf@circ@res@up}}
                 \pgfpatharc{\@stopa}{\@starta}{2.5\pgf@circ@res@up}
                 \pgfclosepath
-                \pgfpathmoveto{\pgfpointpolar{83}{2.1\pgf@circ@res@up}}
-                \pgfpathlineto{\pgfpointpolar{83}{2.4\pgf@circ@res@up}}
+                \pgfmathsetmacro{\@indexa}{\@starta - \ctikzvalof{bipoles/qmeter/index position}*(\@starta - \@stopa)/100}
+                \pgfpathmoveto{\pgfpointpolar{\@indexa}{2.1\pgf@circ@res@up}}
+                \pgfpathlineto{\pgfpointpolar{\@indexa}{2.4\pgf@circ@res@up}}
                 \pgfusepath{draw}
                 \pgf@circ@draworfill
             \endpgfscope


### PR DESCRIPTION
Allow to set the index position for square instruments through 'bipoles/smeter/index position' and 'bipoles/qmeter/index position' keys.

Ref: https://tex.stackexchange.com/a/735011/