### PR TITLE
Set square instruments index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Fix leaking filament in `bulb` bipole
     - New component: Wiggly bulb (suggested by [Sebastiano](https://github.com/circuitikz/circuitikz/issues/845))
+    - Allow to set the index position for square instruments
 
 * Version 1.7.1 (2025-01-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Fix leaking filament in `bulb` bipole
     - New component: Wiggly bulb (suggested by [Sebastiano](https://github.com/circuitikz/circuitikz/issues/845))
-    - Allow to set the index position for square instruments
+    - Allow to set the index position for square instruments (by [Julien Labbé](https://github.com/circuitikz/circuitikz/pull/848))  
 
 * Version 1.7.1 (2025-01-10)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3264,6 +3264,30 @@ You can change the inner dot in several way, by changing the following keys unde
 \end{circuitikz}
 \end{LTXexample}
 
+\paragraph{Square instruments index position.} You can change the index position of square
+instruments with the key \texttt{bipoles/smeter/index position} (for \texttt{smeter}) or
+\texttt{bipoles/qmeter/index position} (for \texttt{qiprobe}, \texttt{qvprobe} and \texttt{qpprobe}).
+Use a value between \texttt{0} and \texttt{100} (the default is \texttt{80}).
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+\begin{circuitikz}
+  % Default
+  \foreach [count=\i] \inst in
+    {smeter, qiprobe, qvprobe, qpprobe} {
+    \draw ({1.5*\i},1.4) to[\inst]
+        ({1.5*(\i+1)},1.4);
+  }
+  % New indexes
+  \ctikzset{bipoles/smeter/index position=50}
+  \ctikzset{bipoles/qmeter/index position=25}
+  \foreach [count=\i] \inst in
+    {smeter, qiprobe, qvprobe, qpprobe} {
+    \draw ({1.5*\i},0) to[\inst]
+        ({1.5*(\i+1)},0);
+  }
+\end{circuitikz}
+\end{LTXexample}
+
 \paragraph{Oscilloscope waveform.} You can change the waveform shown in the oscilloscope ``screen''\footnote{Suggested by \href{https://tex.stackexchange.com/q/595062/38080}{Mario Tafur on TeX.SX}}. To change it, you just set the key \texttt{bipoles/oscope/waveform} to one of the available shape. You have available the shapes in the following list (the default is \texttt{ramps}):
 
 \begin{LTXexample}[pos=t, basicstyle=\small\ttfamily]

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -6112,10 +6112,12 @@
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
 \ctikzset{bipoles/smeter/height/.initial=.60}
 \ctikzset{bipoles/smeter/width/.initial=.60}
+\ctikzset{bipoles/smeter/index position/.initial=80}
 \ctikzset{bipoles/smeter/voltage/additional shift/.initial=1}
 \ctikzset{bipoles/qmeter/depth/.initial=.40}
 \ctikzset{bipoles/qmeter/height/.initial=.80}
 \ctikzset{bipoles/qmeter/width/.initial=.60}
+\ctikzset{bipoles/qmeter/index position/.initial=80}
 % this must be specified for each one
 \ctikzset{bipoles/qvprobe/voltage/additional shift/.initial=.5}
 \ctikzset{bipoles/qiprobe/voltage/additional shift/.initial=.5}
@@ -6457,8 +6459,9 @@
             \pgfpathlineto{\pgfpointpolar{\@stopa}{2.5\pgf@circ@res@up}}
             \pgfpatharc{\@stopa}{\@starta}{2.5\pgf@circ@res@up}
             \pgfpathclose
-            \pgfpathmoveto{\pgfpointpolar{80}{2\pgf@circ@res@up}}
-            \pgfpathlineto{\pgfpointpolar{80}{2.4\pgf@circ@res@up}}
+            \pgfmathsetmacro{\@indexa}{\@starta - \ctikzvalof{bipoles/smeter/index position}*(\@starta - \@stopa)/100}
+            \pgfpathmoveto{\pgfpointpolar{\@indexa}{2\pgf@circ@res@up}}
+            \pgfpathlineto{\pgfpointpolar{\@indexa}{2.4\pgf@circ@res@up}}
             \pgfusepath{draw}
         \endpgfscope
         \pgf@circ@text@strokecolor
@@ -6507,8 +6510,9 @@
                 \pgfpathlineto{\pgfpointpolar{\@stopa}{2.5\pgf@circ@res@up}}
                 \pgfpatharc{\@stopa}{\@starta}{2.5\pgf@circ@res@up}
                 \pgfpathclose
-                \pgfpathmoveto{\pgfpointpolar{83}{2.1\pgf@circ@res@up}}
-                \pgfpathlineto{\pgfpointpolar{83}{2.4\pgf@circ@res@up}}
+                \pgfmathsetmacro{\@indexa}{\@starta - \ctikzvalof{bipoles/qmeter/index position}*(\@starta - \@stopa)/100}
+                \pgfpathmoveto{\pgfpointpolar{\@indexa}{2.1\pgf@circ@res@up}}
+                \pgfpathlineto{\pgfpointpolar{\@indexa}{2.4\pgf@circ@res@up}}
                 \pgfusepath{draw}
                 \pgf@circ@draworfill
             \endpgfscope


### PR DESCRIPTION
After [my previous failed attemps](https://github.com/circuitikz/circuitikz/pull/842), here is a proposal to allow to set the index position for square instruments through 'bipoles/smeter/index position' and 'bipoles/qmeter/index position' keys.

Ref: https://tex.stackexchange.com/a/735011/

Hope this time I did things correctly (I modified the good file, added documentation in the manual and updated the changelog).