### PR TITLE
Fix double-zero source circle size

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -268,6 +268,7 @@ The \texttt{use fpu reciprocal} key seems to have no side effects, but given tha
 Here, we will provide a list of incompatibilities between different versions of \Circuitikz. We will try to hold this list short, but sometimes it is easier to break with old syntax than include a lot of switches and compatibility layers. In general, changes that would invalidate a circuit (changes of polarity of components and so on) are almost always protected by a flag; the same is not true for purely aesthetic changes.
 If unsure, you can check the version in your local installation by using the macro \verb!\pgfcircversion{}!.
 \begin{itemize}
+    \item In version \texttt{1.7.2}, the drawing of the ``double-zero'' source components \texttt{voosource}, \texttt{ioosource}, and \texttt{oosourcetran} changed so that now the circle radius depend on the height and not on the width. If you didn't play with internal parameters, that should be invisible.
     \item In version \texttt{1.7.1}, the default widths of \texttt{barrier} and \texttt{openbarrier} were reduced so that no wire is drawn as part of the symbols by default.
         This is accompanied by a change to the meanings of the configuration keys \texttt{bipoles/barrier/width}, \texttt{bipoles/barrier/height} and \texttt{bipoles/openbarrier/gap} (as well as the new key \texttt{bipoles/openbarrier/width}).
         The change avoids problems when using barriers on short pieces of path or as nodes, cf.~the details in \href{https://github.com/circuitikz/circuitikz/pull/835}{the relevant pull request on GitHub}.

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2566,13 +2566,13 @@
     \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosource/circleoffset}\pgf@circ@res@left}{0}}
-        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@left}
+        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@up}
     \pgf@circ@maybefill
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosource/circleoffset}\pgf@circ@res@right}{0}}
-        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@right}
+        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@up}
     \pgf@circ@draworfill
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosource/circleoffset}\pgf@circ@res@left}{0}}
-        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@left}
+        {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@up}
     \pgfusepath{draw}
 }
 
@@ -2694,13 +2694,13 @@
     \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosourcetrans/circleoffset}\pgf@circ@res@left}{0}}
-        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@left}
+        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@up}
     \pgf@circ@maybefill
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosourcetrans/circleoffset}\pgf@circ@res@right}{0}}
-        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@right}
+        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@up}
     \pgf@circ@draworfill
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosourcetrans/circleoffset}\pgf@circ@res@left}{0}}
-        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@left}
+        {\ctikzvalof{bipoles/oosourcetrans/circlesize}\pgf@circ@res@up}
     \pgfusepath{draw}
     % % %     % draw inner symbols
     %%primary winding
@@ -2880,7 +2880,7 @@
 {\ctikzvalof{bipoles/ooosource/height}}
 {ooosource}
 {\ctikzvalof{bipoles/ooosource/height}}
-{\ctikzvalof{bipoles/ooosource/height}}
+{\ctikzvalof{bipoles/ooosource/height}}% Notice that here right=down and left=up
 {
 %     \pgf@circ@res@other = \ctikzvalof{bipoles/ooosource/vectorgroup} \pgf@circ@scaled@Rlen
 


### PR DESCRIPTION
The circle size must depend on the vertical (height) parameter. That lets us use the width to change the width without changing the circle size.

This change potentially disrupts files when the user changes the height/width of the component using the unpublished interface.