### PR TITLE
Remove some wrong `\pgfpointorigin` from path building

### DIFF
--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -733,7 +733,7 @@
             \pgf@circ@scaled@Rlen=\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen
             \pgf@circ@res@down=-#3\pgf@circ@scaled@Rlen
             \pgf@circ@res@up=#5\pgf@circ@scaled@Rlen
-            \pgfpointorigin
+            \pgfpointorigin % this is ok, it loads \pgf@x\pgf@y
             \pgf@y=\pgf@circ@res@up
             \advance\pgf@y by\pgf@circ@res@down
             \pgf@y=.5\pgf@y

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -2412,7 +2412,6 @@
 {\ctikzvalof{bipoles/pvsource/height}}
 {\ctikzvalof{bipoles/pvsource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@up}}
@@ -2481,7 +2480,6 @@
 {\ctikzvalof{bipoles/esource/height}}
 {\ctikzvalof{bipoles/esource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgf@circ@draworfill
@@ -2525,7 +2523,6 @@
 {\ctikzvalof{bipoles/dcvsource/height}}
 {\ctikzvalof{bipoles/dcvsource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgf@circ@draworfill
@@ -2544,7 +2541,6 @@
 {\ctikzvalof{bipoles/isource/height}}
 {\ctikzvalof{bipoles/isource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@up}}
@@ -2572,7 +2568,6 @@
 {\ctikzvalof{bipoles/oosource/width}}
 {
     % the offset is relative to the width (...@left/@right), and the size to the height (...@up/@down)
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathcircle{\pgfpoint{\ctikzvalof{bipoles/oosource/circleoffset}\pgf@circ@res@left}{0}}
         {\ctikzvalof{bipoles/oosource/circlesize}\pgf@circ@res@up}
@@ -2954,13 +2949,11 @@
 
     % up
     \pgfscope
-        \pgfpointorigin
         \pgfpathcircle{\pgfpointpolar{60}{\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@right}}{\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@right}
         \pgf@circ@maybefill
     \endpgfscope
 %     down
     \pgfscope
-        \pgfpointorigin
         \pgfpathcircle{\pgfpointpolar{-60}{\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@right}}{\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@right}
         \pgf@circ@draworfill
     \endpgfscope
@@ -2972,7 +2965,6 @@
 
     % up
     \pgfscope
-        \pgfpointorigin
         \pgfpathcircle{\pgfpointpolar{60}{\ctikzvalof{bipoles/ooosource/circleoffset}\pgf@circ@res@right}}{\ctikzvalof{bipoles/ooosource/circlesize}\pgf@circ@res@right}
         \pgfusepath{draw}
     \endpgfscope
@@ -3008,7 +3000,6 @@
 % %     secondary winding
     \ifpgf@circ@sec@delta
         \pgfscope
-            \pgfpointorigin
             \pgftransformshift{\pgfpointpolar{60}{0.6\pgf@circ@res@right}}
             \pgf@circ@delta{\ctikzvalof{bipoles/ooosource/vectorgroupscale}}
         \endpgfscope
@@ -3067,7 +3058,6 @@
 {\ctikzvalof{bipoles/isourceam/height}}
 {\ctikzvalof{bipoles/isourceam/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgf@circ@draworfill
@@ -3089,7 +3079,6 @@
 {\ctikzvalof{bipoles/isource/height}}
 {\ctikzvalof{bipoles/isource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfscope
         \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
@@ -3321,7 +3310,6 @@
 {\ctikzvalof{bipoles/isource/height}}
 {\ctikzvalof{bipoles/isource/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgf@circ@draworfill
@@ -3439,7 +3427,6 @@
 {\ctikzvalof{bipoles/isource/height}}
 {\ctikzvalof{bipoles/isource/width}}
 {
-    \pgfpointorigin
     \pgfscope
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
@@ -3495,7 +3482,6 @@
 {\ctikzvalof{bipoles/nullator/height}}
 {\ctikzvalof{bipoles/nullator/width}}
 {
-    \pgfpointorigin
     \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
     \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
     \pgf@circ@draworfill
@@ -6406,7 +6392,6 @@
 {\ctikzvalof{bipoles/esource/height}}
 {\ctikzvalof{bipoles/esource/width}}
 {
-    \pgfpointorigin
     \pgfscope
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
@@ -6436,7 +6421,6 @@
 {\ctikzvalof{bipoles/esource/height}}
 {\ctikzvalof{bipoles/esource/width}}
 {
-    \pgfpointorigin
     \pgfscope
         \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
         \pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
@@ -7332,7 +7316,7 @@
 {\ctikzvalof{bipoles/american gas filled surge arrester/width}}{
 
     \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}
-    \pgfpointorigin \pgf@circ@res@other =  \pgf@x  \advance \pgf@circ@res@other by -\pgf@circ@res@up
+    \pgf@circ@res@other=-\pgf@circ@res@up
     \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@zero}}
     \pgfusepath{draw}
 

--- a/tex/pgfcircmonopoles.tex
+++ b/tex/pgfcircmonopoles.tex
@@ -1282,9 +1282,7 @@
     \anchor{north west}{\northeast\pgf@x=0cm\relax}
     \anchor{south east}{\northeast\pgf@y=0pt\relax}
     \anchor{south west}{\pgfpointorigin}
-    \anchor{center}{
-        \pgfpointorigin
-    }
+    \anchor{center}{\pgfpointorigin}
     \anchor{text}{
         \pgfmathsetlength{\pgf@circ@scaled@Rlen}{\ctikzvalof{\ctikzclass/scale}\pgf@circ@Rlen}
         \pgf@x=\ctikzvalof{monopoles/match/width}\pgf@circ@scaled@Rlen


### PR DESCRIPTION
Fixes #854

There are no differences in the compiled manual.