### PR TITLE
CTAN release 1.7.2 (2025-03-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.7.2 (unreleased)
+* Version 1.7.2 (2025-03-21)
+
+    A couple of new components (wiggly bulbs and a new "oO" type autotransformer), and several small corrections.
 
     - Fix leaking filament in `bulb` bipole
     - Fix small incoherence between width/height in oo-type sources
     - New component: Wiggly bulb (suggested by [Sebastiano](https://github.com/circuitikz/circuitikz/issues/845))
     - New component: "zero-type" autotransformer (suggested by [Max Börjesson ](https://github.com/circuitikz/circuitikz/issues/852))
-    - Allow to set the index position for square instruments (by [Julien Labbé](https://github.com/circuitikz/circuitikz/pull/848))  
+    - Allow to set the index position for square instruments (by [Julien Labbé](https://github.com/circuitikz/circuitikz/pull/848))
 
 * Version 1.7.1 (2025-01-10)
 
@@ -614,7 +616,7 @@ A detailed list of changes can be seen below.
     - Added Romano Giannetti as contributor
     - Added a CONTRIBUTING file
     - Added options for solving the voltage direction problems.
-	- Adjusted ground symbols to better match ISO standard, added new symbols
+    - Adjusted ground symbols to better match ISO standard, added new symbols
     - Added new sources (cute european versions, noise sources)
     - Added new types of amplifiers, and option to flip inputs and outputs
     - Added bidirectional diodes (diac) thanks to Andre Lucas Chinazzo
@@ -631,74 +633,74 @@ A detailed list of changes can be seen below.
     - Added viscoelastic element
     - Added a manual section on how to define new components
     - Fixed american voltage symbols and allow to customize them
-	- Fixed placement of straightlabels in several cases
+    - Fixed placement of straightlabels in several cases
     - Fixed a bug about straightlabels (thanks to @fotesan)
     - Fixed labels spacing so that they are independent on scale factor
     - Fixed the position of text labels in amplifiers
 
 * Version 0.8.3 (2017-05-28)
-	- Removed unwanted lines at to-paths if the starting point is a node without a explicit anchor.
-	- Fixed scaling option, now all parts are scaled by bipoles/length
-	- Surge arrester appears no more if a to path is used without []-options
-	- Fixed current placement now possible with paths at an angle of around 280°
-	- Fixed voltage placement now possible with paths at an angle of around 280°
-	- Fixed label and annotation placement (at some angles position not changable)
-	- Adjustable default distance for straight-voltages: 'bipoles/voltage/straight label distance'
-	- Added Symbol for bandstop filter
-	- New annotation type to show flows using f=... like currents, can be used for thermal, power or current flows
+    - Removed unwanted lines at to-paths if the starting point is a node without a explicit anchor.
+    - Fixed scaling option, now all parts are scaled by bipoles/length
+    - Surge arrester appears no more if a to path is used without []-options
+    - Fixed current placement now possible with paths at an angle of around 280°
+    - Fixed voltage placement now possible with paths at an angle of around 280°
+    - Fixed label and annotation placement (at some angles position not changable)
+    - Adjustable default distance for straight-voltages: 'bipoles/voltage/straight label distance'
+    - Added Symbol for bandstop filter
+    - New annotation type to show flows using f=... like currents, can be used for thermal, power or current flows
 
 * Version 0.8.2 (2017-05-01)
-	- Fixes pgfkeys error using alternatively specified mixed colors(see pgfplots manual section "4.7.5 Colors")
-	- Added new switches "ncs" and "nos"
-	- Reworked arrows at spst-switches
-	- Fixed direction of controlled american voltage source
-	- "v<=" and "i<=" do not rotate the sources anymore(see them as "counting direction indication", this can be different then the shape orientation); Use the option "invert" to change the direction of the source/apperance of the shape.
-	- current label "i=" can now be used independent of the regular label "l=" at current sources
-	- rewrite of current arrow placement. Current arrows can now also be rotated on zero-length paths
-	- New DIN/EN compliant operational amplifier symbol "en amp"
+    - Fixes pgfkeys error using alternatively specified mixed colors(see pgfplots manual section "4.7.5 Colors")
+    - Added new switches "ncs" and "nos"
+    - Reworked arrows at spst-switches
+    - Fixed direction of controlled american voltage source
+    - "v<=" and "i<=" do not rotate the sources anymore(see them as "counting direction indication", this can be different then the shape orientation); Use the option "invert" to change the direction of the source/apperance of the shape.
+    - current label "i=" can now be used independent of the regular label "l=" at current sources
+    - rewrite of current arrow placement. Current arrows can now also be rotated on zero-length paths
+    - New DIN/EN compliant operational amplifier symbol "en amp"
 
 * Version 0.8.1 (2017-03-25)
-	- Fixed unwanted line through components if target coordinate is a name of a node
-	- Fixed position of labels with subscript letters.
-	- Absolute distance calculation in terms of ex at rotated labels
-	- Fixed label for transistor paths (no label drawn)
+    - Fixed unwanted line through components if target coordinate is a name of a node
+    - Fixed position of labels with subscript letters.
+    - Absolute distance calculation in terms of ex at rotated labels
+    - Fixed label for transistor paths (no label drawn)
 
 * Version 0.8 (2017-03-08)
-	- Allow use of voltage label at a [short]
-	- Correct line joins between path components (to[...])
-	- New Pole-shape .-. to fill perpendicular joins
-	- Fixed direction of controlled american current source
-	- Fixed incorrect scaling of magnetron
-	- Fixed: Number of american inductor coils not adjustable
-	- Fixed Battery Symbols and added new battery2 symbol
-	- Added non-inverting Schmitttrigger
+    - Allow use of voltage label at a [short]
+    - Correct line joins between path components (to[...])
+    - New Pole-shape .-. to fill perpendicular joins
+    - Fixed direction of controlled american current source
+    - Fixed incorrect scaling of magnetron
+    - Fixed: Number of american inductor coils not adjustable
+    - Fixed Battery Symbols and added new battery2 symbol
+    - Added non-inverting Schmitttrigger
 
 * Version 0.7 (2016-09-08)
-	- Added second annotation label, showing, e.g., the value of an component
-	- Added new symbol: magnetron
-	- Fixed name conflict of diamond shape with tikz.shapes package
-	- Fixed varcap symbol at small scalings
-	- New packet-option "straightvoltages, to draw straight(no curved) voltage arrows
-	- New option "invert" to revert the node direction at paths
-	- Fixed american voltage label at special sources and battery
-	- Fixed/rotated battery symbol(longer lines by default positive voltage)
-	- New symbol Schmitttrigger
+    - Added second annotation label, showing, e.g., the value of an component
+    - Added new symbol: magnetron
+    - Fixed name conflict of diamond shape with tikz.shapes package
+    - Fixed varcap symbol at small scalings
+    - New packet-option "straightvoltages, to draw straight(no curved) voltage arrows
+    - New option "invert" to revert the node direction at paths
+    - Fixed american voltage label at special sources and battery
+    - Fixed/rotated battery symbol(longer lines by default positive voltage)
+    - New symbol Schmitttrigger
 
 * Version 0.6 (2016-06-06)
-	- Added Mechanical Symbols (damper,mass,spring)
-	- Added new connection style diamond, use (d-d)
-	- Added new sources voosource and ioosource (double zero-style)
-	- All diode can now drawn in a stroked way, just use globel option "strokediode" or stroke instead of full/empty, or D-. Use this option for compliance with DIN standard EN-60617
-	- Improved Shape of Diodes:tunnel diode, Zener diode, schottky diode (bit longer lines at cathode)
-	- Reworked igbt: New anchors G,gate and new L-shaped form Lnigbt, Lpigbt
-	- Improved shape of all fet-transistors and mirrored p-chan fets as default, as pnp, pmos, pfet are already. This means a backward-incompatibility, but smaller code, because p-channels mosfet are by default in the correct direction(source at top). Just remove the 'yscale=-1' from your p-chan fets at old pictures.
+    - Added Mechanical Symbols (damper,mass,spring)
+    - Added new connection style diamond, use (d-d)
+    - Added new sources voosource and ioosource (double zero-style)
+    - All diode can now drawn in a stroked way, just use globel option "strokediode" or stroke instead of full/empty, or D-. Use this option for compliance with DIN standard EN-60617
+    - Improved Shape of Diodes:tunnel diode, Zener diode, schottky diode (bit longer lines at cathode)
+    - Reworked igbt: New anchors G,gate and new L-shaped form Lnigbt, Lpigbt
+    - Improved shape of all fet-transistors and mirrored p-chan fets as default, as pnp, pmos, pfet are already. This means a backward-incompatibility, but smaller code, because p-channels mosfet are by default in the correct direction(source at top). Just remove the 'yscale=-1' from your p-chan fets at old pictures.
 
 * Version 0.5 (2016-04-24)
-	- new option boxed and dashed for hf-symbols
-	- new option solderdot to enable/disable solderdot at source port of some fets
-	- new parts: photovoltaic source, piezo crystal, electrolytic capacitor, electromechanical device(motor, generator)
-	- corrected voltage and current direction(option to use old behaviour)
-	- option to show body diode at fet transistors
+    - new option boxed and dashed for hf-symbols
+    - new option solderdot to enable/disable solderdot at source port of some fets
+    - new parts: photovoltaic source, piezo crystal, electrolytic capacitor, electromechanical device(motor, generator)
+    - corrected voltage and current direction(option to use old behaviour)
+    - option to show body diode at fet transistors
 
 * Version 0.4
     - minor improvements to documentation
@@ -718,7 +720,7 @@ A detailed list of changes can be seen below.
     - fixed infinite in arctan computation
 
 * Version 0.3.0
-	- fixed gate node for a few transistors
+    - fixed gate node for a few transistors
     - added mixer
     - added fully differential op amp (by Kristofer M. Monisit)
     - now general settings for the drawing of voltage can be overridden for specific components
@@ -733,59 +735,60 @@ A detailed list of changes can be seen below.
     - added noiseless, protective, chassis, signal and reference grounds (Luigi «Liverpool»)
 
 * Version 0.2.4
-	- added square voltage source (contributed by Alistair Kwan)
-	- added buffer and plain amplifier (contributed by Danilo Piazzalunga)
-	- added squid and barrier (contributed by  Cor Molenaar)
-	- added antenna and transmission line symbols contributed by Leonardo Azzinnari
-	- added the changeover switch spdt (suggestion of Fabio Maria Antoniali)
-	- rename of context.tex and context.pdf (thanks to Karl Berry)
-	- updated the email address
+    - added square voltage source (contributed by Alistair Kwan)
+    - added buffer and plain amplifier (contributed by Danilo Piazzalunga)
+    - added squid and barrier (contributed by  Cor Molenaar)
+    - added antenna and transmission line symbols contributed by Leonardo Azzinnari
+    - added the changeover switch spdt (suggestion of Fabio Maria Antoniali)
+    - rename of context.tex and context.pdf (thanks to Karl Berry)
+    - updated the email address
     - in documentation, fixed wrong (non-standard) labelling of the axis in an example (thanks to prof. Claudio Beccaria)
     - fixed scaling inconsistencies in quadrupoles
     - fixed division by zero error on certain vertical paths
     - introduced options straighlabels, rotatelabels, smartlabels
 
 * Version 0.2.3
-	- fixed compatibility problem with label option from tikz
-	- Fixed resizing problem for shape ground
-	- Variable capacitor
-	- polarized capacitor
-	- ConTeXt support (read the manual!)
-	- nfet, nigfete, nigfetd, pfet, pigfete, pigfetd (contribution of Clemens Helfmeier and Theodor
+    - fixed compatibility problem with label option from tikz
+    - Fixed resizing problem for shape ground
+    - Variable capacitor
+    - polarized capacitor
+    - ConTeXt support (read the manual!)
+    - nfet, nigfete, nigfetd, pfet, pigfete, pigfetd (contribution of Clemens Helfmeier and Theodor
 Borsche)
-	- njfet, pjfet (contribution of Danilo Piazzalunga)
-	- pigbt, nigbt
-	- *backward incompatibility* potentiometer is now the standard resistor-with-arrow-in-the-middle; the old potentiometer is now known as variable resistor (or vR), similarly to variable inductor and variable capacitor
-	- triac, thyristor, memristor
-	- new property "name" for bipoles
-	- fixed voltage problem for batteries in american voltage mode
-	- european logic gates
-	- *backward incompatibility* new american standard inductor. Old american inductor now called "cute inductor"
-	- *backward incompatibility* transformer now linked with the chosen type of inductor, and version with core, too. Similarly for variable inductor
-	- *backward incompatibility* styles for selecting shape variants now end are in the plural to avoid conflict with paths
-	- new placing option for some tripoles (mostly transistors)
-	- mirror path style
+    - njfet, pjfet (contribution of Danilo Piazzalunga)
+    - pigbt, nigbt
+    - *backward incompatibility* potentiometer is now the standard resistor-with-arrow-in-the-middle; the old potentiometer is now known as variable resistor (or vR), similarly to variable inductor and variable capacitor
+    - triac, thyristor, memristor
+    - new property "name" for bipoles
+    - fixed voltage problem for batteries in american voltage mode
+    - european logic gates
+    - *backward incompatibility* new american standard inductor. Old american inductor now called "cute inductor"
+    - *backward incompatibility* transformer now linked with the chosen type of inductor, and version with core, too. Similarly for variable inductor
+    - *backward incompatibility* styles for selecting shape variants now end are in the plural to avoid conflict with paths
+    - new placing option for some tripoles (mostly transistors)
+    - mirror path style
 
 
 * Version 0.2.2 - 20090520
     - Added the shape for lamps.
-	- Added options \texttt{europeanresistor}, \texttt{europeaninductor}, \texttt{americanresistor} and \texttt{americaninductor}, with corresponding styles.
-	- FIXED: error in transistor arrow positioning and direction under negative \texttt{xscale} and \texttt{yscale}.
+    - Added options \texttt{europeanresistor}, \texttt{europeaninductor}, \texttt{americanresistor} and \texttt{americaninductor}, with corresponding styles.
+    - FIXED: error in transistor arrow positioning and direction under negative \texttt{xscale} and \texttt{yscale}.
 
 * Version 0.2.1 - 20090503
-	- Op-amps added
-	- added options arrowmos and noarrowmos, to add arrows to pmos and nmos
+    - Op-amps added
+    - added options arrowmos and noarrowmos, to add arrows to pmos and nmos
 
 * Version 0.2 - 20090417
 First public release on CTAN
-   	- *Backward incompatibility*: labels ending with \texttt{:}\textit{angle} are not parsed for positioning anymore.
-	- Full use of \TikZ\ keyval features.
-	- White background is not filled anymore: now the network can be drawn on a background picture as well.
-	- Several new components added (logical ports, transistors, double bipoles, \ldots).
-	- Color support.
-	- Integration with {\ttfamily siunitx}.
-	- Voltage, american style.
-	- Better code, perhaps. General cleanup at the very least.
+    - *Backward incompatibility*: labels ending with \texttt{:}\textit{angle} are not parsed for positioning anymore.
+    - Full use of \TikZ\ keyval features.
+    - White background is not filled anymore: now the network can be drawn on a background picture as well.
+    - Several new components added (logical ports, transistors, double bipoles, \ldots).
+    - Color support.
+    - Integration with {\ttfamily siunitx}.
+    - Voltage, american style.
+    - Better code, perhaps. General cleanup at the very least.
 
 * Version 0.1 - 2007-10-29
 First public release
+

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.7.2-unreleased}
-\def\pgfcircversiondate{2025/01/12}
+\def\pgfcircversion{1.7.2}
+\def\pgfcircversiondate{2025/03/21}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.7.2-unreleased}
-\def\pgfcircversiondate{2025/01/12}
+\def\pgfcircversion{1.7.2}
+\def\pgfcircversiondate{2025/03/21}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
A couple of new components (wiggly bulbs and a new "oO" type autotransformer), and several small corrections.

- Fix leaking filament in `bulb` bipole
- Fix small incoherence between width/height in oo-type sources
- New component: Wiggly bulb (suggested by [Sebastiano](https://github.com/circuitikz/circuitikz/issues/845))
- New component: "zero-type" autotransformer (suggested by [Max Börjesson ](https://github.com/circuitikz/circuitikz/issues/852))
- Allow to set the index position for square instruments (by [Julien Labbé](https://github.com/circuitikz/circuitikz/pull/848))
- 