### PR TITLE
Fix names of anchors for advanced flows and currents

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -9698,7 +9698,7 @@ Finally, as ever, generators are treated differently, but you have all your anch
 
 When the anchors are activated, there are additional macros that you can use:
 \begin{itemize}
-    \item \texttt{\textbackslash ctikzgetanchor\{\emph{<name>}\}\{\emph{<anchor>}\}}: \emph{name} is the name of the bipole, and \emph{anchor} can be \texttt{Vlab}, \texttt{Fpos} or \texttt{Ipos}. This macro expands to the normal anchor position (something like \texttt{north}, \texttt{south west}). Notice that if you have not activated the corresponding anchor, the content of this macro is not specified. It could be equivalent to \verb|\relax| (basically, empty) or contains the anchor of a bipole with the same name from another drawing --- it's a global macro like the coordinates.
+    \item \texttt{\textbackslash ctikzgetanchor\{\emph{<name>}\}\{\emph{<anchor>}\}}: \emph{name} is the name of the bipole, and \emph{anchor} can be \texttt{Vlab}, \texttt{Flab} or \texttt{Ilab}. This macro expands to the normal anchor position (something like \texttt{north}, \texttt{south west}). Notice that if you have not activated the corresponding anchor, the content of this macro is not specified. It could be equivalent to \verb|\relax| (basically, empty) or contains the anchor of a bipole with the same name from another drawing --- it's a global macro like the coordinates.
     \item \texttt{\textbackslash ctikzgetdirection\{\emph{<name>}\}}: a number which is the direction of the \emph{name}d bipole.
     \item \texttt{\textbackslash ctikzgetdirection\{\emph{<name>}-Iarrow\}}: a number which is the direction of the current arrow requested for the \emph{name}d bipole; using \texttt{\emph{<name>}-Farrow} you get the same information for flow arrows.
 \end{itemize}


### PR DESCRIPTION
The anchor labels are called `Flab` and `Ilab`, not `Fpos` and `Ipos`. Sorry.
