### PR TITLE
CTAN release 1.8.0 (2025-05-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.0 (unreleased)
+* Version 1.8.0 (2025-05-25)
 
-    The change that deserves a version level bump is one applied to the path logic, which fixes a longstanding bug (or lack of feature), which enables the embedding of `circuitikz` paths into pics (among other things, see the related issue).
+    The change that deserves a version level bump is applied to the path logic, which fixes a longstanding bug (or lack of feature), which enables the embedding of `circuitikz` paths into pics (among other things; see the related issue).
 
     - Fix errors when path-style components are used in pics (and in some other place; fix by Romano, [see the related issue](https://github.com/circuitikz/circuitikz/issues/866)
     - Add rollback point for version 1.7.2

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.0-unreleased}
-\def\pgfcircversiondate{2025/05/23}
+\def\pgfcircversion{1.8.0}
+\def\pgfcircversiondate{2025/05/25}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.0-unreleased}
-\def\pgfcircversiondate{2025/05/23}
+\def\pgfcircversion{1.8.0}
+\def\pgfcircversiondate{2025/05/25}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
The change that deserves a version level bump is applied to the path logic, which fixes a longstanding bug (or lack of feature), which enables the embedding of `circuitikz` paths into pics (among other things; see the related issue).

- Fix errors when path-style components are used in pics (and in some other place; fix by Romano, [see the related issue](https://github.com/circuitikz/circuitikz/issues/866)
- Add rollback point for version 1.7.2
- Several fixes and additions to the manual