### PR TITLE
Prepare to release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.1 (2025-05-27)
+* Version 1.8.1 (2025-06-15)
+
+    Minor changes: better documentation on using `pic`s for subcircuits, a new style of MOSFETs, completing the "plain" amplifiers.
 
     - add Andrew Stacey's [`tikzmark` library](https://ctan.org/pkg/tikzmark?lang=en) to the manual
     - add FDSOI MOSFETs, [suggested by Raphael Nägele](https://github.com/circuitikz/circuitikz/issues/871)
-    - documentation enhancements
     - New component: `plain gm mono amp` (added by [Matthias Schweikardt](https://github.com/circuitikz/circuitikz/pull/873))
+    - documentation enhancements
 
 * Version 1.8.0 (2025-05-25)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.1-unreleased}
-\def\pgfcircversiondate{2025/05/27}
+\def\pgfcircversion{1.8.1}
+\def\pgfcircversiondate{2025/06/15}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.1-unreleased}
-\def\pgfcircversiondate{2025/05/27}
+\def\pgfcircversion{1.8.1}
+\def\pgfcircversiondate{2025/06/15}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
 Minor changes: better documentation on using `pic`s for subcircuits,
 a new style of MOSFETs, completing the "plain" amplifiers.

- add Andrew Stacey's `tikzmark` library to the manual
- add FDSOI MOSFETs #871
- New component: `plain gm mono amp` #873
- documentation enhancements