### PR TITLE
Prepare CTAN release 1.8.2 (2025-07-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.2 (unreleased)
+* Version 1.8.2 (2025-07-08)
 
     Another significant change for Circuitikz's internals: all the text anchors of the components are now stable, meaning they are meaningful after the component has been drawn. That was the case only for part of the components. It *shouldn't* affect anything for standard usage, but according to the Ti*k*Z manual, this is "the way".
     Additionally, new label positions for transistors, and a much better alphabetical index in the manual.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.2-unreleased}
-\def\pgfcircversiondate{2025/06/19}
+\def\pgfcircversion{1.8.2}
+\def\pgfcircversiondate{2025/07/08}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.2-unreleased}
-\def\pgfcircversiondate{2025/06/19}
+\def\pgfcircversion{1.8.2}
+\def\pgfcircversiondate{2025/07/08}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
Another significant change for Circuitikz's internals: all the text anchors of the components are now stable, meaning they are meaningful after the component has been drawn. That was the case only for part of the components. It *shouldn't* affect anything for standard usage, but according to the Ti*k*Z manual, this is "the way".

Additionally, new label positions for transistors, and a much better alphabetical index in the manual.

- Stabilize all the text anchors (problem [reported by user `@JPWiedemann` on GitHub](https://github.com/circuitikz/circuitikz/pull/876), while coding the [Circuitikz GUI](https://github.com/Circuit2TikZ/CircuiTikZ-Designer)
- Fix text anchors for blocks `oscillator` and `gridnode`, which were completely bogus
- Add `component text=up` or `...down` for transistor labels
- Documentation fixes for text anchors
- Better index entries (use *seealso*, hyperlink in every entry). Thanks to David Carlisle for the hint.