### PR TITLE
Add IGCTs thyristors

### DIFF
--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -4801,6 +4801,97 @@
 \pgfcircdeclaretriac{fulltriac}{0}
 \pgfcircdeclaretriac{emptytriac}{1}
 
+
+% IGCT : contributed by Paul Sacco
+
+\def\pgfcircdeclareIGCT#1#2#3{%name, fill (0-> black; 1-empty), gate position (1: catode, -1: anode)
+    \pgfcircdeclarebipolescaled{diodes}
+    {
+        \savedmacro{\gatekink}{\edef\gatekink{\ctikzvalof{tripoles/thyristor/gate kink}}}
+        \anchor{gate}{\northeast\pgf@x=\gatekink\pgf@x\pgf@x=#3\pgf@x}
+        \anchor{G}{\northeast\pgf@x=\gatekink\pgf@x\pgf@x=#3\pgf@x}
+        \anchor{anode}{\southwest\pgf@y=0cm}
+        \anchor{cathode}{\northeast\pgf@y=0cm }
+    }
+    {\ctikzvalof{tripoles/thyristor/height 2}}
+    {#1}
+    {\ctikzvalof{tripoles/thyristor/height}}
+    {\ctikzvalof{tripoles/thyristor/width}}
+    {
+        \pgf@circ@res@other = \ctikzvalof{tripoles/thyristor/diode width left}\pgf@circ@res@left
+        \pgf@circ@res@step = \ctikzvalof{tripoles/thyristor/diode width right}\pgf@circ@res@right
+
+        \pgfscope
+            % draw the thick parts here (shifted horizontally)
+            \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
+            % draw the basic triangle
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{-\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+            \pgfpathclose
+            \ifnum#2=0\relax
+                \pgfusepath{draw,fill}
+            \else
+                \pgf@circ@draworfill
+            \fi
+            % draw the vertical bar + IGCT symbol
+            \pgfsetroundjoin
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{-\pgf@circ@res@down}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@step}{\pgf@circ@res@down}}
+    			\pgfpathlineto{\pgfpoint{cos{45}*2*\pgf@circ@res@step /5}{cos{45}*2*\pgf@circ@res@down/5}}
+    	
+            \pgfusepath{draw}
+        \endpgfscope
+
+        % back to normal linewidth
+        % stroke if needed
+        \ifpgf@circuit@bipole@strokedsymbol
+            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+            \pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+            \pgfusepath{draw}
+        \fi
+
+        % draw the gate thing;
+        %
+    \pgfpathmoveto{\pgfpoint
+        {\pgf@circ@res@step}
+        {\ctikzvalof{tripoles/thyristor/gate height}*\ctikzvalof{tripoles/thyristor/diode height}*\pgf@circ@res@up}
+    }
+    \pgfpathlineto{\pgfpoint
+        {\ctikzvalof{tripoles/thyristor/gate kink}*\pgf@circ@res@right}
+        {\ctikzvalof{tripoles/thyristor/diode height}\pgf@circ@res@up}
+    }
+    \pgfpathlineto{\pgfpoint
+        {\ctikzvalof{tripoles/thyristor/gate kink}*\pgf@circ@res@right}
+        {\pgf@circ@res@up}
+    }
+    % draw bar line.
+    \pgfpathmoveto{\pgfpoint
+        {(\ctikzvalof{tripoles/thyristor/gate kink}-\ctikzvalof{tripoles/thyristor/gto bar width})*\pgf@circ@res@right}
+        {(1+\ctikzvalof{tripoles/thyristor/diode height})*0.5*\pgf@circ@res@up}
+    }
+    \pgfpathlineto{\pgfpoint
+        {(\ctikzvalof{tripoles/thyristor/gate kink}+\ctikzvalof{tripoles/thyristor/gto bar width})*\pgf@circ@res@right}
+        {(1+\ctikzvalof{tripoles/thyristor/diode height})*0.5*\pgf@circ@res@up}
+    } 
+    \pgfusepath{draw}
+
+        % draw the leads in/out
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{0pt}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@step}{0pt}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{0pt}}
+
+        \pgfusepath{draw}
+    }
+}
+
+\pgfcircdeclareIGCT{fulligct}{0}{1}
+\pgfcircdeclareIGCT{emptyigct}{1}{1}
+
 % end of shape definitions for diodes%>>>
 
 %% Paths definitions for Diodes%<<<
@@ -4840,6 +4931,8 @@
     \pgfcirc@style@to@style{#1 gtobar}{GTOb#2}
     \pgfcirc@activate@bipole{l}{#1agtobar}{#1agtobar}{#1 agtobar}
     \pgfcirc@style@to@style{#1 agtobar}{aGTOb#2}
+    \pgfcirc@activate@bipole{l}{#1igct}{#1igct}{#1 igct}
+    \pgfcirc@style@to@style{#1 igct}{IGCT#2}
     \pgfcirc@activate@bipole{l}{#1triac}{#1triac}{#1 triac}
     \pgfcirc@style@to@style{#1 triac}{Tr#2}
 }
@@ -4880,6 +4973,9 @@
     \pgfcirc@style@to@style{#1 gtobar}{GTOb#2}
     \pgfcirc@node@to@style{l}{emptyagtobar}{#1 agtobar}{\circuitikzbasekey/bipole/is strokedsymbol=true}
     \pgfcirc@style@to@style{#1 agtobar}{aGTOb#2}
+    \pgfcirc@style@to@style{#1 igct}{IGCT#2}
+    \pgfcirc@node@to@style{l}{emptyigct}{#1 igct}{\circuitikzbasekey/bipole/is strokedsymbol=true}
+    \pgfcirc@style@to@style{#1 igct}{IGCT#2}
     \pgfcirc@node@to@style{l}{emptytriac}{#1 triac}{\circuitikzbasekey/bipole/is strokedsymbol=true}
     \pgfcirc@style@to@style{#1 triac}{Tr#2}
     \pgfcirc@node@to@style{l}{emptytvsdiode}{#1 tvsdiode}{\circuitikzbasekey/bipole/is strokedsymbol=true}
@@ -4922,6 +5018,8 @@
 \pgfcirc@style@to@style{gtobar}{GTOb}
 \pgfcirc@style@to@style{\pgfcircdiodestylemacro agtobar}{agtobar}
 \pgfcirc@style@to@style{agtobar}{aGTOb}
+\pgfcirc@style@to@style{\pgfcircdiodestylemacro igct}{igct}
+\pgfcirc@style@to@style{igct}{IGCT}
 \pgfcirc@style@to@style{\pgfcircdiodestylemacro triac}{triac}
 \pgfcirc@style@to@style{triac}{Tr}
 % %>>>

--- a/tex/pgfcircbipoles.tex
+++ b/tex/pgfcircbipoles.tex
@@ -4975,7 +4975,6 @@
     \pgfcirc@style@to@style{#1 agtobar}{aGTOb#2}
     \pgfcirc@style@to@style{#1 igct}{IGCT#2}
     \pgfcirc@node@to@style{l}{emptyigct}{#1 igct}{\circuitikzbasekey/bipole/is strokedsymbol=true}
-    \pgfcirc@style@to@style{#1 igct}{IGCT#2}
     \pgfcirc@node@to@style{l}{emptytriac}{#1 triac}{\circuitikzbasekey/bipole/is strokedsymbol=true}
     \pgfcirc@style@to@style{#1 triac}{Tr#2}
     \pgfcirc@node@to@style{l}{emptytvsdiode}{#1 tvsdiode}{\circuitikzbasekey/bipole/is strokedsymbol=true}


### PR DESCRIPTION
Hello everyone,

I added the IGCTs to the thyristor family. Integrated gate-commutated thyristor (IGCT) are an evolution of the classic GTO thyristors. They are used in high power (MW) power electronics applications.
Here are an IEEE article : https://ieeexplore.ieee.org/abstract/document/629064/ and the wikipedia page : https://en.wikipedia.org/wiki/Integrated_gate-commutated_thyristor which show the use of the IGCT symbol.
The IGCT symbol is similar to the GTO one but with a line between the edge of the vertical bar and the body of the triangle.

I first tried to use the existing \pgfcircdeclarethyristor function but the line joint with the vertical bar was not fine so I decided to recreate a new \pgfcircdeclareIGCT function.

Also I tried to add these entries to the manual but I don't know why github is trying to convert the original encoding of the file tu UTF-8, which is changing plenty of symbols in code to �.

Here are the entries I wanted to add to the manual : 
`
\circuitdescbip*[emptyigct]{igct}{Standard IGCT}{IGCT}(G/0/0.3, gate/45/0.3, anode/-90/0.2, cathode/-90/0.2)
 \footnotetext{The IGCTs family has been suggested by Paul Sacco}
 \circuitdescbip*[emptyigct]{empty igct}{Empty IGCT}{IGCTo}
 \circuitdescbip[fulligct]{full igct}{Full IGCT}{IGCT*}
 \circuitdescbip*[emptyigct]{stroke igct}{Stroke IGCT}{IGCT-}
`

and in the compact style section : 
`
\circuitdescbip*[emptyigct]{igct}{Standard igct (shape depends on package option)}{IGCT}(G/0/0.3, gate/45/0.3, anode/-90/0.2, cathode/-90/0.2)
`

Can you tell me how to add these in the manual ?

Thanks,
Paul

