### PR TITLE
Fix encoding of the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.8.3 (unreleased)
 
-    - Bump version number
+    - Fix encoding of the manual, removing some latin1 chars and converting to utf8. Why that was working is a mystery.
 
 * Version 1.8.2 (2025-07-08)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1,10 +1,3 @@
-% % Konfiguration für Texstudio (Version > 2.9)
-% !TeX program = xelatex
-% !TeX TXS-program:compile = txs:///xelatex/[-8bit]
-% !BIB program = biber
-% !TeX spellcheck = en_US
-% !TeX encoding = utf8
-
 % Copyright 2018-2025 by Romano Giannetti
 % Copyright 2015-2025 by Stefan Lindner
 % Copyright 2013-2025 by Stefan Erhardt
@@ -58,9 +51,6 @@
 \makeindex[title=Index, intoc=true]
 \indexprologue{Here you will find, in alphabetical order, all the components, keys, and styles defined by the package. Components have the page number in straight text, while keys and styles have \emph{italic} page numbers.}
 \renewcommand*\seealso[2]{#2, \emph{\alsoname} #1}
-% vim macro to set indexes
-% let q='ciwIndexKey'
-% let w='ciwIndexKey[]�kl�kr�kryi{�kl�klP'
 % Local utilities packages
 \usepackage{ctikzmanutils}
 %
@@ -134,7 +124,7 @@ Copyright \copyright{}
 2013--2025 by Stefan Erhardt,
 2015--2025 by Stefan Lindner,
 and 2018--2025 by Romano Giannetti.
-This package is author-maintained. Permission is granted to copy, distribute and/or modify this software under the terms of the \LaTeX\ Project Public License, version 1.3.1, or the GNU Public License. This software is provided ‘as is’, without warranty of any kind, either expressed or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose.
+This package is author-maintained. Permission is granted to copy, distribute and/or modify this software under the terms of the \LaTeX\ Project Public License, version 1.3.1, or the GNU Public License. This software is provided ``as is'', without warranty of any kind, either expressed or implied, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose.
 \subsection{Loading the package}
 
 \begin{table}[h]
@@ -436,7 +426,7 @@ Feel free to load the package with your own cultural options:
         \item \IndexKey{nolegacytransistorstext} or \texttt{centertransistorstext}: the text of transistor nodes is typeset near the center of the component;
         \item \IndexKey{straightlabels}: labels on bipoles are always printed straight up, i.e.~with horizontal baseline;
         \item \IndexKey{rotatelabels}: labels on bipoles are always printed aligned along the bipole;
-        \item \IndexKey{smartlabels}: labels on bipoles are rotated along the bipoles, unless the rotation is very close to multiples of 90°;
+        \item \IndexKey{smartlabels}: labels on bipoles are rotated along the bipoles, unless the rotation is very close to multiples of \SI{90}{\degree};
         \item \IndexKey{compatibility}: makes it possibile to load \Circuitikz\ and \TikZ\ circuit library together.
         \item Voltage directions: until v0.8.3, there was an error in the coherence between american and european voltages styles (see section~\ref{curr-and-volt}) for the batteries. This has been fixed, but to guarantee backward compatibility and to avoid nasty surprises, the fix is available with new options:
             \begin{itemize}
@@ -547,7 +537,7 @@ Finally, we would like to add voltages indication for carrying out the current f
 \end{circuitikz}
 \end{LTXexample}
 
-\emph{Et voilà!}. Remember that this is still \LaTeX, which means that you have done a description of your circuit, which is, in a lot of way, independent of the visualization of it. If you ever have to adapt the circuit to, say, a journal that forces European style and flows instead of currents, you just change a couple of things and you have what seems a completely different diagram:
+\emph{Et voila!}. Remember that this is still \LaTeX, which means that you have done a description of your circuit, which is, in a lot of way, independent of the visualization of it. If you ever have to adapt the circuit to, say, a journal that forces European style and flows instead of currents, you just change a couple of things and you have what seems a completely different diagram:
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}[european, voltage shift=0.5]
@@ -2162,7 +2152,7 @@ For the grounds, the \texttt{center} anchor is put on the connecting point of th
     \circuitdesc{nground}{Noiseless ground}{}
     \circuitdesc*{pground}{Protective ground}{}
     \circuitdesc{cground}{Chassis ground\footnotemark}{}
-    \footnotetext{These last three were contributed by Luigi «Liverpool»}
+    \footnotetext{These last three were contributed by Luigi ``Liverpool''}
     \circuitdesc{eground}{European style ground}{}
     \circuitdesc{eground2}{European style ground, version 2\footnotemark}{}
     \footnotetext{These last two were contributed by \texttt{@fotesan}}
@@ -3045,7 +3035,7 @@ Notice that if you choose the dashed style, the noise sources are fillable:
     \endgroup
 \end{groupdesc}
 
-The transformer shapes vector group options can be specified for the primary (\IndexKey[prim]{prim=\emph{value}}), the secondary (\IndexKey[sec]{sec=\emph{value}}) and tertiary (\IndexKey[tert]{tert=\emph{value}}) three-phase vector groups: the value can be one of \IndexKey{delta}, \IndexKey{wye}, \IndexKey{eyw}\footnote{The \IndexKey{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob «DraUX» on GitHub}} and \IndexKey{zig}.
+The transformer shapes vector group options can be specified for the primary (\IndexKey[prim]{prim=\emph{value}}), the secondary (\IndexKey[sec]{sec=\emph{value}}) and tertiary (\IndexKey[tert]{tert=\emph{value}}) three-phase vector groups: the value can be one of \IndexKey{delta}, \IndexKey{wye}, \IndexKey{eyw}\footnote{The \IndexKey{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob ``DraUX'' on GitHub}} and \IndexKey{zig}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -3614,7 +3604,7 @@ Here you'll find bipoles that are not easily grouped in the categories above.
     \circuitdescbip*{afuse}{Asymmetric fuse}{asymmetric fuse}
     \circuitdescbip{wfuse}{``wiggly'' fuse}{wiggly fuse}()[left/110/0.2, right/70/0.2]
     \circuitdescbip*{relais}{Relais\footnotemark}{}
-    \footnotetext{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/795}{Jakob «DraUX»}}
+    \footnotetext{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/795}{Jakob ``DraUX''}}
     \circuitdescbip{squid}{Squid}{}
     \circuitdescbip{barrier}{Barrier}{}
     \circuitdescbip{openbarrier}{Open barrier}{}
@@ -6560,7 +6550,7 @@ These are all of the to-style type:
     \circuitdescbip[cncs]{closing normal closed switch}{Closing normally closed switch}{cncs}
     \circuitdescbip[onos]{opening normal open switch}{Opening normally open switch}{onos}
     \circuitdescbip[cnos]{closing normal open switch}{Closing normally open switch\footnotemark}{cnos}
-    \footnotetext{These last four were contributed by \href{https://tex.stackexchange.com/questions/693446/new-switch-components-for-circuitikz}{Jakob «DraUX»}}
+    \footnotetext{These last four were contributed by \href{https://tex.stackexchange.com/questions/693446/new-switch-components-for-circuitikz}{Jakob ``DraUX''}}
     \circuitdescbip[pushbutton]{push button}{Normally open push button}{normally open push button, nopb}(tip/0/0.2, mid/-90/0.2)
     \circuitdescbip[ncpushbutton]{normally closed push button}{Normally closed push button}{ncpb}(tip/0/0.2, mid/-90/0.2)
     \circuitdescbip[pushbuttonc]{normally open push button closed}{Normally open push button (in closed position)}{nopbc}(tip/0/0.2, mid/-90/0.2)


### PR DESCRIPTION
It has several latin1 chars in it, although it is declared as UTF8. No idea why it worked.