### PR TITLE
Preparing CTAN release 1.8.3 (2025-11-23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.3 (unreleased)
+* Version 1.8.3 (2025-11-23)
     
     The main highlight of this version is the fix of the oo-type sources and transformers. They used parameters different from width and height to define the shape, and the anchors were not stable (and some of them were plain wrong). It also adds several capabilities to them (anchors, additional windings, and so on).
-    Additionally, a couple of generic shapes (AC/DC symbols) have been added.
+    Additionally, IGT thyristors and a couple of generic shapes (AC/DC symbols) have been added.
     
-    - Fix definition and stabilize anchors of oo- and ooo-type components.
     - Add anchors, additional winding, global scale switch and symbol rotation to the oo-type component, suggested by [Jakob Leide](https://github.com/circuitikz/circuitikz/issues/886)
     - Add IGCT thyristors by [Paul Sacco](https://github.com/circuitikz/circuitikz/pull/881)
     - Add ac/dc symbols (by Romano)
+    - Fix definition and stabilize anchors of oo- and ooo-type components.
     - Fix encoding of the manual, removing some latin1 chars and converting to utf8. Why that was working is a mystery.
 
 * Version 1.8.2 (2025-07-08)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.3-unreleased}
-\def\pgfcircversiondate{2025/07/23}
+\def\pgfcircversion{1.8.3}
+\def\pgfcircversiondate{2025/11/23}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.3-unreleased}
-\def\pgfcircversiondate{2025/07/23}
+\def\pgfcircversion{1.8.3}
+\def\pgfcircversiondate{2025/11/23}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
The main highlight of this version is the fix of the oo-type sources and transformers. They used parameters different from width and height to define the shape, and the anchors were not stable (and some of them were plain wrong). It also adds several capabilities to them (anchors, additional windings, and so on). Additionally, IGT thyristors and a couple of generic shapes (AC/DC symbols) have been added.

- Add anchors, additional winding, global scale switch and symbol rotation to the oo-type component
- Add IGCT thyristors
- Add ac/dc symbols
- Fix definition and stabilize anchors of oo- and ooo-type components.
- Fix encoding of the manual, removing some latin1 chars and converting to utf8. Why that was working is a mystery.