### PR TITLE
Fix the dc/ac symbol thickness and allow different thickness for dc symbol lines

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3827,6 +3827,26 @@ The node text is positioned above the symbol, at a distance controlled by the ke
 
 As shown in the example above, the \texttt{dc symbols} has an additional options. By default the lower line of the symbol has two segments, but you can change this with the \texttt{circuitikz} key \IndexKey{dc symbol/segments} (with also the direct key, at \TikZ{} level, \IndexKey{dc symbol segments} (default \texttt{2})) with any value greater than 0.
 
+Additionally, you can change the relative thickness of the bottom line with the key \texttt{dc symbols/relative thickness} (default \texttt{1}).
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+    \begin{tikzpicture}
+    \tikzset{my dc symbol/.style={
+        dc symbol,
+        circuitikz/misc/thickness=3,
+        circuitikz/dc symbol/height=0.1,
+        circuitikz/dc symbol/width=0.2,
+        circuitikz/dc symbol/relative thickness=.5,
+        circuitikz/dc symbol/segments=3
+    }}
+    \node (A) at (0,0) {A}; \node (V) at (1,0) {V};
+    % standard
+    \node [dc symbol, above, circuitikz/misc/thickness=4] at (A.north) {};
+    % tweaked
+    \node [my dc symbol, above] at (V.north) {};
+\end{tikzpicture}
+\end{LTXexample}
+
 \subsection{Multiple wires (buses)}
 
 These are simple drawings to indicate multiple wires.

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -899,6 +899,7 @@
 \ctikzset{dc symbol/segments/.initial=2}
 \ctikzset{dc symbol/text offset/.initial=6pt}
 \tikzset{dc symbol segments/.code={\ctikzset{dc symbol/segments=#1}}}
+\ctikzset{dc symbol/relative thickness/.initial=1}
 \pgfdeclareshape{dc symbol}{
     \savedmacro{\ctikzclass}{\edef\ctikzclass{misc}}
     \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{misc/scale}\pgf@circ@Rlen}}
@@ -932,6 +933,8 @@
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
             \pgfusepath{draw}
             % lower line
+            \edef\@@tmp{\ctikzvalof{dc symbol/relative thickness}}
+            \pgfsetlinewidth{\@@tmp\pgflinewidth}
             \edef\@@dashes{\ctikzvalof{dc symbol/segments}}
             \ifnum\@@dashes>1
                 \pgfmathsetlength{\pgf@circ@res@other}{2*\pgf@circ@res@right/(2*(\@@dashes-1)+1)}


### PR DESCRIPTION
<img width="771" height="341" alt="image" src="https://github.com/user-attachments/assets/1de9fdcb-7831-4b7e-964c-f2f8a45f76a2" />
