### PR TITLE
Add the option to *not* draw the wiper in rotary switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     The main highlights of this release is a new appearance (optional!) for blocks representing filters, and some option to add style to the inner drawings of (most) blocks.
 
     - Add a new set of filter blocks, add options for inner block drawings (by Romano)
+    - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
 
 * Version 1.8.3 (2025-11-23)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -7009,16 +7009,19 @@ Finally, notice that the value of width for the rotary switches is taken from th
 
 \paragraph{Rotary switch customization}
 
-Apart from the basic customization seen above (number of channels, etc.) you can change, as in the cute switches, the shape used by the connection points with the parameter \IndexKey{multipoles/rotary/shape}, and the thickness of the wiper with \IndexKey{multipoles/rotary/thickness}. The optional arrow has thickness equal to the standard bipole thickness \texttt{bipoles/thickness} (default 2).
+Apart from the basic customization seen above (number of channels, etc.) you can change, as in the cute switches, the shape used by the connection points with the parameter \IndexKey{multipoles/rotary/shape}, and the thickness of the wiper with \IndexKey{multipoles/rotary/thickness}; if you specify a negative value here, the wiper is not drawn at all\footnote{Suggested by users \texttt{kabenyuk} and \texttt{cis} on TeX-SX.com; see \href{https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display}{this question\&answer for an application}.}(but the anchors, and the additional arrow if you specify it, are still there).
+The optional arrow has thickness equal to the standard bipole thickness \texttt{bipoles/thickness} (default 2).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
     \ctikzset{multipoles/rotary/thickness=0.5}
-    \draw (0,1.6) node[rotary switch ->, color=blue](S1){};
+    \draw (0,2) node[rotary switch ->, color=blue](S1){};
     \ctikzset{multipoles/rotary/shape=circ}
     \draw (0,0) node[rotary switch ->](S2){};
     \ctikzset{bipoles/thickness=0.5}
-    \draw (0,-1.6) node[rotary switch ->, color=red](S3){};
+    \draw (2,2) node[rotary switch ->, color=red](S3){};
+    \ctikzset{multipoles/rotary/thickness=-1}
+    \draw (2,0) node[rotary switch, color=purple](S4){};
 \end{circuitikz}
 \end{LTXexample}
 

--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -811,13 +811,15 @@
         \pgf@circ@res@left = -\width
 
         \pgfscope %wiper
-        % This is the radius of the "ocirc" shape (see pgfcircshapes.tex)
-        \pgf@circ@res@temp=\radius\relax
-        \pgf@circ@res@temp=\ctikzvalof{multipoles/rotary/thickness}\pgf@circ@res@temp
-        \pgfsetlinewidth{2\pgf@circ@res@temp}
-        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
-        \pgfpathlineto{\pgfpointadd{\pgfpoint{\pgf@circ@res@left}{0pt}}{\pgfpointpolar{\wiper}{2\pgf@circ@res@right}}}
-        \pgfsetroundcap\pgfusepath{draw}
+            % This is the radius of the "ocirc" shape (see pgfcircshapes.tex)
+            \pgf@circ@res@temp=\radius\relax
+            \pgf@circ@res@temp=\ctikzvalof{multipoles/rotary/thickness}\pgf@circ@res@temp
+            \ifdim\pgf@circ@res@temp<0pt \else
+                \pgfsetlinewidth{2\pgf@circ@res@temp}
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+                \pgfpathlineto{\pgfpointadd{\pgfpoint{\pgf@circ@res@left}{0pt}}{\pgfpointpolar{\wiper}{2\pgf@circ@res@right}}}
+                \pgfsetroundcap\pgfusepath{draw}
+            \fi
         \endpgfscope
 
         \ifpgf@circ@rotaryarrow


### PR DESCRIPTION
This is achieved by setting the thickness to a negative value. For an example of usage, look at
https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display

<img width="794" height="361" alt="image" src="https://github.com/user-attachments/assets/cf8c23a0-22f7-44b9-9b36-f7cae93929df" />

<img width="711" height="48" alt="image" src="https://github.com/user-attachments/assets/d053c213-1eea-4840-83dd-9bd80981d6b5" />

