### PR TITLE
Fix dc symbol dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Add a new set of filter blocks, add options for inner block drawings (by Romano)
     - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
+    - Fix a problem with dc symbol dashes, see [this issue on GitHub](https://github.com/circuitikz/circuitikz/issues/897)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
 
 * Version 1.8.3 (2025-11-23)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3830,19 +3830,19 @@ As shown in the example above, the \texttt{dc symbols} has an additional options
 Additionally, you can change the relative thickness of the bottom line with the key \texttt{dc symbols/relative thickness} (default \texttt{1}).
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
-    \begin{tikzpicture}
+    \begin{tikzpicture}[scale=2, transform shape]
     \tikzset{my dc symbol/.style={
         dc symbol,
-        circuitikz/misc/thickness=3,
+        circuitikz/misc/thickness=4,
         circuitikz/dc symbol/height=0.1,
         circuitikz/dc symbol/width=0.2,
         circuitikz/dc symbol/relative thickness=.5,
         circuitikz/dc symbol/segments=3
     }}
     \node (A) at (0,0) {A}; \node (V) at (1,0) {V};
-    % standard
-    \node [dc symbol, above, circuitikz/misc/thickness=4] at (A.north) {};
-    % tweaked
+    % standard and customized
+    \node [dc symbol, above,
+        circuitikz/misc/thickness=4] at (A.north) {};
     \node [my dc symbol, above] at (V.north) {};
 \end{tikzpicture}
 \end{LTXexample}
@@ -4594,19 +4594,23 @@ Moreover, the key \IndexKey{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|)
 \paragraph{Dashing the DC symbol in blocks.}
 The symbol for the DC side can be different across countries,\footnote{Head-up from \href{https://github.com/circuitikz/circuitikz/issues/680}{user \texttt{@dbstf} on GitHub}} with different kind of dashing on the bottom line.
 Moreover, sometimes the dashing is used to convey different meanings (like rectified sinusoidal or stabilized DC).
-You can change the general style for the DC symbol using the key \IndexKey{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \IndexKey{blocks dc in segments} and \IndexKey{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} option overrides these ones.
+You can change the general style for the DC symbol using the key \IndexKey{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \IndexKey{blocks dc in segments} and \IndexKey{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} can have strange interaction with these ones.
 
-\begin{LTXexample}[varwidth=true]
-\begin{tikzpicture}[scale=0.9]
+
+\begin{LTXexample}[varwidth=true, basicstyle=\footnotesize\ttfamily]
+\begin{tikzpicture}[scale=0.8]
     \ctikzset{blocks dc segments=3}
     \draw (0,2) to[sacdc] ++(2,0) to[sdcdc]
         ++(2,0) to[sdcac] ++(2,0);
     \ctikzset{blocks dc segments=1}
-    \draw (0,0) to[sacdc, blocks dc out segments=2]
-        ++(2,0) to[sdcdc, blocks dc in segments=2]
+    \draw[dashed] (0,0) to[sacdc, blocks dc out segments=2]
+        ++(2,0) to[sdcdc, blocks dc in segments=2,
+            inner blocks dashed,
+            dashed blocks pattern={{0.4pt}{0.4pt}}]
         ++(2,0) to[sdcac] ++(2,0);
 \end{tikzpicture}
 \end{LTXexample}
+
 
 \paragraph{Blocks inner drawing.}
 Most of the inner block drawings can be customized, without affecting the external box, with the keys \IndexKey{blocks/inner color} (default \texttt{default}, which means ``don't change color'') and \IndexKey{blocks/inner thickness} (default \texttt{1}; this is relative to the class-specified thickness).

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -262,6 +262,22 @@
 %
 \def\ctikz@hook@start@draw@default{\pgf@circ@reset@arrows@rounded}
 %
+% we can't use dash pattern (not easily) to draw a fixed number of dashes.
+% See https://github.com/circuitikz/circuitikz/issues/897
+%
+\def\pgf@circ@do@n@hdashes#1#2#3#4{%
+    % this does the following: draw #1 dashes, each of length #2
+    % separated by a blank space of the same length
+    % starting from (#3, #4) and going horizontal
+    \pgf@circ@count@a=0 %
+    \pgfmathloop%
+    \ifnum\pgf@circ@count@a<#1 %
+        \pgfpathmoveto{\pgfpointadd{\pgfpoint{#3}{#4}}{\pgfpoint{(2*\pgf@circ@count@a)*(#2)}{0pt}}}
+        \pgfpathlineto{\pgfpointadd{\pgfpoint{#3}{#4}}{\pgfpoint{(2*\pgf@circ@count@a+1)*(#2)}{0pt}}}
+        \advance\pgf@circ@count@a by 1\relax%
+    \repeatpgfmathloop
+}
+%
 %
 %>>>
 

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -1554,21 +1554,27 @@
 \def\pgf@circ@twoport@converter@dc#1#2{%
     \pgfscope
     \pgftransformshift{\pgfpoint{#1\pgf@circ@res@step}{#2\pgf@circ@res@step}}
+    % upper line, always continuos
     \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfusepath{draw}
-    \ifpgf@circuit@full@dashed\else % do not apply the specific dash if fully dashing
-        \edef\@@up{\ctikzvalof{blocks dc in segments}}
-        \edef\@@down{\ctikzvalof{blocks dc out segments}}
-        \ifdim\dimexpr#1\pgf@circ@res@step\relax<0pt
-            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@up-2)}
-        \else
-            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@down-2)}
-        \fi
-        \pgfsetdash{{\pgf@circ@res@other}{\pgf@circ@res@other}}{0pt}
+    % lower line, may be dashed
+    % let us dash everything is needed (this is a change from before)
+    \ifdim\dimexpr#1\pgf@circ@res@step\relax<0pt
+        % this is the upper side
+        \edef\@@tmp{\ctikzvalof{blocks dc in segments}}
+    \else
+        % this is the lower side
+        \edef\@@tmp{\ctikzvalof{blocks dc out segments}}
     \fi
-    \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+        \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@tmp-2)}
+    \ifnum\@@tmp>1
+        % we can't use dash here; the dash length is not scaled
+        \pgf@circ@do@n@hdashes{\@@tmp}{\pgf@circ@res@other}{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}
+    \else
+        \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+        \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+    \fi
     \pgfusepath{draw}
     \endpgfscope
 }

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -938,10 +938,11 @@
             \edef\@@dashes{\ctikzvalof{dc symbol/segments}}
             \ifnum\@@dashes>1
                 \pgfmathsetlength{\pgf@circ@res@other}{2*\pgf@circ@res@right/(2*(\@@dashes-1)+1)}
-                \pgfsetdash{{\pgf@circ@res@other}{\pgf@circ@res@other}}{0pt}
+                \pgf@circ@do@n@hdashes{\@@dashes}{\pgf@circ@res@other}{\pgf@circ@res@left}{\pgf@circ@res@down}
+            \else
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
             \fi
-            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
-            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
             \pgfusepath{draw}
         \endpgfscope
     }


### PR DESCRIPTION
Dash pattern do not scale with the global scaling, so to draw a fixed number of dashes in dc symbols we need to draw them manually.

Fixes #897

<img width="1036" height="482" alt="image" src="https://github.com/user-attachments/assets/16a15899-1e39-422c-ba3c-ed71ac53db40" />

<img width="1234" height="423" alt="image" src="https://github.com/user-attachments/assets/b208b58f-3ff9-4609-a353-e8651e3706cb" />

Zoom on the mid lower block:

<img width="458" height="434" alt="image" src="https://github.com/user-attachments/assets/c9cb534f-4768-4405-89c5-1c01e755d8ec" />
