### PR TITLE
fixed bug with gridnode

### DIFF
--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -2379,11 +2379,12 @@
         \advance\pgf@circ@res@other by \pgf@circ@res@step
         \pgfcirc@twoport@maybedash
         % draw outer box
+        \pgfstartlinewidth=\pgflinewidth
         \pgf@circ@twoportbox
         \pgf@circ@inputarrow
-        \pgfsetdash{}{0pt}	% always draw solid line for inner symbol
+        \ifpgf@circuit@full@dashed\else\pgfsetdash{}{0pt}\fi
         \pgfsetarrows{-} %never draw arrows
-        \pgfsetlinewidth{0.05mm}
+        \pgfstartlinewidth=\pgflinewidth
         % draw grid
         \foreach \line in {-1,-.5,...,1}
         {


### PR DESCRIPTION
I noticed that there were a few problems with the gridnode component
- the outer box had no thickness
- the inner lines had an absolute thickness instead of a relative one
- it was impossible to draw the inner lines dashed, even with the `inner blocks dashed`-option

This pr should fix these issues. The first two points are bugs imo, but the third one was hard coded, even with a comment stating that the inner lines should never be drawn dashed. Since you can switch the `inner blocks dashed`-option on and off before drawing the component, and therefore control the style, I don't think this will cause an issue. However, it may affect backwards compatibility.