### PR TITLE
CTAN Release 1.8.4 (2026-01-07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.4 (unreleased)
+* Version 1.8.4 (2026-01-07)
 
-    The main highlights of this release is a new appearance (optional!) for blocks representing filters, and some option to add style to the inner drawings of blocks.
+    The main highlights of this release is a new appearance (optional!) for blocks representing filters, some option to add style to the inner drawings of blocks (and some fixes for anchors too), and several new options.
 
     - Add a new set of filter blocks, add options for inner block drawings (by Romano)
     - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
     - Add an option to change the aspect of `msrstub` (thanks to user cis, see [relevant chat on TeX.SX](https://chat.stackexchange.com/transcript/message/68629615#68629615))
+    - Add the singeneric (sine generic bipole) component (by [Jakob Leide](https://github.com/circuitikz/circuitikz/pull/907))
     - Fix a problem with dc symbol dashes, see [this issue on GitHub](https://github.com/circuitikz/circuitikz/issues/897)
     - Fix position of the left/right up/down anchors for node-type blocks (they did not obey the `pos` keys) and for amplifier-type blocks when boxed
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
     - Make the value of `bipoles/length` usable by `\ctikzvalof` (by [Jonathan P. Spratte](https://github.com/circuitikz/circuitikz/pull/900))
-    - Added a key to customise the number of lines of the \texttt{gridnode} inner drawing (by [Jakob Leide](https://github.com/circuitikz/circuitikz/pull/906))
-    - Added the singeneric (Sine generic bipole) component (by [Jakob Leide](https://github.com/circuitikz/circuitikz/pull/907))
+    - Add a key to customise the number of lines of the `gridnode` inner drawing (by [Jakob Leide](https://github.com/circuitikz/circuitikz/pull/906))
 
 
 * Version 1.8.3 (2025-11-23)

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.4-unreleased}
-\def\pgfcircversiondate{2025/11/25}
+\def\pgfcircversion{1.8.4}
+\def\pgfcircversiondate{2026/01/07}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.4-unreleased}
-\def\pgfcircversiondate{2025/11/25}
+\def\pgfcircversion{1.8.4}
+\def\pgfcircversiondate{2026/01/07}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
The main highlights of this release is a new appearance (optional!) for blocks representing filters, some option to add style to the inner drawings of blocks (and some fixes for anchors too), and several new options.

- Add a new set of filter blocks, add options for inner block drawings
- Add the option to *not* draw the wiper in rotary switches
- Add an option to change the aspect of `msrstub`
- Add the singeneric (sine generic bipole) component
- Fix a problem with dc symbol dashes
- Fix the position of the left/right up/down anchors for node-type blocks
- Minor fixes in the manual
- Make the value of `bipoles/length` usable by `\ctikzvalof`
- Add a key to customise the number of lines of the `gridnode` inner drawing

For a complete list of the contributors, see CHANGELOG.md