### PR TITLE
In the documentation, `--cycle` is rendered as –cycle, with en-dash

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -10500,7 +10500,7 @@ Placing labels, currents and voltages also works, please note, that mirroring an
 \subsection{Line joins between Path Components}
 \label{sec:line-joins}
 
-Line joins should be calculated correctly - if they are on the same path, and the path is not closed. For example, the following path is not closed correctly (\textit{--cycle} does not work here!):
+Line joins should be calculated correctly - if they are on the same path, and the path is not closed. For example, the following path is not closed correctly (\texttt{--cycle} does not work here!):
 \begin{LTXexample}[varwidth=true]
 	\begin{tikzpicture}[line width=3pt,european]
 	\draw (0,0) to[R]++(2,0)to[R]++(0,2)


### PR DESCRIPTION
With \textit, `--` becomes an en-dash. Replaced with \texttt.

The code was : 
<img width="476" height="37" alt="image" src="https://github.com/user-attachments/assets/95ef21e6-a473-494d-b4eb-988f4ecf682c" />

and in the manual (p. 245) as:
<img width="370" height="63" alt="image" src="https://github.com/user-attachments/assets/28e1f6f5-0a07-4150-b46f-b4266bd68e78" />

