### PR TITLE
Prepare for CTAN release 1.8.5 2026-02-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.5 (unreleased)
+* Version 1.8.5 (2026-02-4)
 
-     The main highlight of this version is a new mechanism to manage advanced (that is, user-defined) voltage, current and flow elements.
+    The main highlight of this version is a new mechanism for managing advanced (that is, user-defined) voltage, current, and flow elements. Additionally, a new set of shapes for ideal filter blocks has been added.
 
     - Add "automatic advanced voltages/currents/flows" [(by Romano)](https://github.com/circuitikz/circuitikz/discussions/911), marked as experimental for now.
     - Add an `ideal filter` option for plot-type filters, to draw ideal (square) filter shapes.

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.5-unreleased}
-\def\pgfcircversiondate{2026/01/08}
+\def\pgfcircversion{1.8.5}
+\def\pgfcircversiondate{2026/02/04}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.5-unreleased}
-\def\pgfcircversiondate{2026/01/08}
+\def\pgfcircversion{1.8.5}
+\def\pgfcircversiondate{2026/02/04}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
The main highlight of this version is a new mechanism for managing advanced (that is, user-defined) voltage, current, and flow elements.
Additionally, a new set of shapes for ideal filter blocks has been added.
    
- Add "automatic advanced voltages/currents/flows" [(by   Romano)](https://github.com/circuitikz/circuitikz/discussions/911),   marked as experimental for now.
- Add an `ideal filter` option for plot-type filters, to draw ideal   (square) filter shapes.