### PR TITLE
Add an option for text positions in `twoportsplit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 * Version 1.8.6 (unreleased)
 
     A shiny new style for the manual, with a new example code implementation by Jonathan P. Spratte, based on [the package `enverb`](https://ctan.org/pkg/enverb?lang=en). The manual now avoid writing *hundreds* of auxiliary files, and compiles significantly faster. Additionally, now the manual can be compiled with `lwarp`, enabling the creation of a pure-HTML version.
+    Additionally, a new option to simplify building custom blocks, thanks to a [suggestion by Matthias Jung](https://github.com/circuitikz/circuitikz/issues/925)
 
     - New manual style, with new example code based on `enverb` (mainly by [Jonathan P. Spratte](https://github.com/circuitikz/circuitikz/pull/920))
+    - New option `border` for `component text` that applies to the `twoportsplit` component
 
 * Version 1.8.5 (2026-02-4)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4616,6 +4616,49 @@ Each block determines where the text is added:
 \end{circuitikz}
 \end{ctikzExample}
 
+For the \IndexKey{twoportsplit} block, you can change how the text is positioned using the key (shared with amplifiers and logic ports, so better use it locally) \IndexKey{component text} (default value \texttt{center}), which gives the standard positioning (text centered in each one of the triangles in which the block is divided).
+If you set it to the value \texttt{border}, the text will be positioned at the corner (upper left or bottom right, depending on orientation) with a distance set by \IndexKey{border text distance} (default \texttt{\ctikzvalof{border text distance}}).
+This option makes it easy to define additional blocks, like these \href{https://github.com/circuitikz/circuitikz/issues/925}{suggested by Matthias Jung}:
+
+\begin{ctikzExample}[only code, exec outside]
+% define a macro to draw a "safe" four-dot symbol
+% basic LaTeX pictures are usable inside TikZ nodes,
+% no nesting problems.
+\newcommand{\fourdots}{%
+    \begingroup
+    \setlength{\unitlength}{0.8mm}%
+    \begin{picture}(4,4)(-2,-2)
+        \put(-2,0){\line(1,0){4}}
+        \put(0,-2){\line(0,1){4}}
+        \multiput(-1,1)(2,0){2}{\circle*{1}}
+        \multiput(-1,-1)(2,0){2}{\circle*{1}}
+    \end{picture}%
+    \endgroup
+}
+% define the new blocks
+\tikzset{%
+    tinysplits/.style 2 args={twoportsplit,
+        component text=border, border text distance=3pt,
+        t1={\tiny\ttfamily #1}, t2={\tiny\ttfamily #2}},
+    source coder/.style={tinysplits={0101}{01}},
+    channel coder/.style={tinysplits={01}{01+01}},
+    mapper/.style={tinysplits={01}{\fourdots}},
+}
+\end{ctikzExample}
+
+\begin{ctikzExample}
+\begin{circuitikz}
+ \draw (0,0)
+        to[source coder, >] ++(2.5,0)
+        to[channel coder, >] ++(0,2.5)
+        to[mapper, >] ++(-2.5,0)
+        to[source coder,>] ++(0,-2.5)
+        ;
+\end{circuitikz}
+\end{ctikzExample}
+
+
+
 \paragraph{Box option}
 \label{par:box-option}
 Several devices have the possibility to add a box around them with the \IndexKey{box} or \IndexKey{boxed} option. The inner symbol scales down to fit inside the box. For the ``circled'' devices (mixer, adder, oscillator and circulator) the inner circle is normally drawn, unless you use the \IndexKey{box only} or \IndexKey{boxed only} option.\footnote{Since 1.5.0, suggested by \href{https://github.com/circuitikz/circuitikz/issues/621}{GitHub user myzinsky}}

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -924,6 +924,11 @@
 \ctikzset{component text/up/.code={\pgf@circ@center@textfalse\pgf@circ@up@texttrue}}%
 \ctikzset{component text/down/.code={\pgf@circ@center@textfalse\pgf@circ@up@textfalse}}%
 \ctikzset{left text distance/.initial=0.3em}%
+% used by blocks (twoportsplit for now)
+\ctikzset{border text distance/.initial=2pt}
+\ctikzset{component text/border/.code={\pgf@circ@center@textfalse}}%
+\tikzset{border text distance/.code={\ctikzset{border text distance=#1}}}
+\tikzset{component text/border/.code={\pgf@circ@center@textfalse}}%
 %>>>
 
 %% voltage direction options%<<<1

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -973,12 +973,24 @@
     \pgfcirc@twoport@draw@splitline
     %
     \pgf@circ@text@strokecolor
-    \ifnum\@@rotation<145
-        \pgftext[center,x=0.45\pgf@circ@res@left,y=0.45\pgf@circ@res@up]{\pgfcirc@tin}
-        \pgftext[center,x=0.45\pgf@circ@res@right,y=0.45\pgf@circ@res@down]{\pgfcirc@tout}
+    % see where we want the text to reside
+    \ifpgf@circ@center@text
+        \ifnum\@@rotation<145
+            \pgftext[center,x=0.45\pgf@circ@res@left,y=0.45\pgf@circ@res@up]{\pgfcirc@tin}
+            \pgftext[center,x=0.45\pgf@circ@res@right,y=0.45\pgf@circ@res@down]{\pgfcirc@tout}
+        \else
+            \pgftext[center,x=0.45\pgf@circ@res@left,y=0.45\pgf@circ@res@up]{\pgfcirc@tout}
+            \pgftext[center,x=0.45\pgf@circ@res@right,y=0.45\pgf@circ@res@down]{\pgfcirc@tin}
+        \fi
     \else
-        \pgftext[center,x=0.45\pgf@circ@res@left,y=0.45\pgf@circ@res@up]{\pgfcirc@tout}
-        \pgftext[center,x=0.45\pgf@circ@res@right,y=0.45\pgf@circ@res@down]{\pgfcirc@tin}
+        \edef\@@dist{\ctikzvalof{border text distance}}
+        \ifnum\@@rotation<145
+            \pgftext[top,left,x=\pgf@circ@res@left+\@@dist,y=\pgf@circ@res@up-\@@dist]{\pgfcirc@tin}
+            \pgftext[bottom,right,x=\pgf@circ@res@right-\@@dist,y=\pgf@circ@res@down+\@@dist]{\pgfcirc@tout}
+        \else
+            \pgftext[top,left,x=\pgf@circ@res@left+\@@dist,y=\pgf@circ@res@up-\@@dist]{\pgfcirc@tout}
+            \pgftext[bottom,right,x=\pgf@circ@res@right-\@@dist,y=\pgf@circ@res@down+\@@dist]{\pgfcirc@tin}
+        \fi
     \fi
 }
 %% bandpass filter


### PR DESCRIPTION
Suggested in issue #925 by @myzinsky

<img width="847" height="929" alt="Image" src="https://github.com/user-attachments/assets/1b08a9bc-5e0e-48b4-8f44-9a96ad8503c0" />


