### PR TITLE
JFET gate position fix and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - New manual style, with new example code based on `enverb` (mainly by [Jonathan P. Spratte](https://github.com/circuitikz/circuitikz/pull/920))
     - New option `border` for `component text` that applies to the `twoportsplit` component
+    - New option `jfet gate height` to move the vertical position of JFET gate, triggered by [this question by Vector](https://tex.stackexchange.com/q/762783/38080)
 
 * Version 1.8.5 (2026-02-4)
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -5336,6 +5336,18 @@ They also have path-style syntax, as the other transistors.
 \end{circuitikz}
 \end{ctikzExample}
 
+\paragraph{JFET gate position.} Since version \texttt{1.8.6}\footnote{the change was triggered by the question by user Vector on \href{https://tex.stackexchange.com/q/762783/38080}{TeX StackExchange}.}, you can change the vertical position of the gate terminal in the junction transistor \texttt{njfet} and \texttt{pjfet} using the key \IndexKey{transistors/jfet gate height} (default \texttt{1.0}, which means that the gate arrow is at the same height as the source terminal).
+In the following example you can see its use and effect (notice that when it is set to zero, there is complete symmetry between drain and source terminal; this is physically right for ideal/simplified devices, but not always for real ones).
+
+\begin{ctikzExample}
+    \begin{tikzpicture}
+        \ctikzset{transistors/arrow pos=end}
+        \draw (0,0) node[njfet]{}
+        ++(2,0) node[njfet, circuitikz/transistors/jfet gate height=0.15]{}
+        ++(2,0) node[njfet, circuitikz/transistors/jfet gate height=0]{};
+    \end{tikzpicture}
+\end{ctikzExample}
+
 \paragraph{Gate/Base gap coloring.} You can color the space representing the gate capacitor or the insulated base by using the key \IndexKey{tr gap fill} (default \texttt{none}, which means nothing is drawn there). This fill is done \emph{after} any circle fill but before any additional modifier (see the example below). You can use it locally or set it globally (normal scoping works, as ever).
 \label{par:gate-base-gap}
 

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -5863,7 +5863,7 @@
             }
             \anchor{kink}{
                 \northeast
-                \pgf@ya=-\ctikzvalof{tripoles/#1/gate height 2}\pgf@y
+                \pgf@ya=-\ctikzvalof{tripoles/#1/conn height}\pgf@y
                 \left
                 \pgf@y=\ctikzvalof{tripoles/#1/curr direction}\pgf@ya
                 \pgf@x=\ctikzvalof{tripoles/#1/conn kink}\pgf@x
@@ -5928,11 +5928,11 @@
                 \pgf@circ@res@step=\ctikzvalof{tripoles/#1/conn kink}\pgf@circ@res@left
                 \pgf@circ@res@other=\ctikzvalof{tripoles/#1/gate width}\pgf@circ@res@left
                 \pgf@circ@res@zero=\ctikzvalof{tripoles/#1/union height}\pgf@circ@res@down
-                \pgf@circ@res@temp=\ctikzvalof{tripoles/#1/gate height 2}\pgf@circ@res@down
+                \pgf@circ@res@temp=\ctikzvalof{tripoles/#1/conn height}\pgf@circ@res@down
             \else
                 \pgf@circ@res@step=\ctikzvalof{tripoles/#1/gate width}\pgf@circ@res@left
                 \pgf@circ@res@other=\ctikzvalof{tripoles/#1/conn kink}\pgf@circ@res@left
-                \pgf@circ@res@zero=\ctikzvalof{tripoles/#1/gate height 2}\pgf@circ@res@up
+                \pgf@circ@res@zero=\ctikzvalof{tripoles/#1/conn height}\pgf@circ@res@up
                 \pgf@circ@res@temp=\ctikzvalof{tripoles/#1/union height}\pgf@circ@res@up
             \fi
             %

--- a/tex/pgfcirctripoles.tex
+++ b/tex/pgfcirctripoles.tex
@@ -3309,6 +3309,16 @@
 \ctikzset{tripoles/pjfet/bodydiode distance/.initial=.3}
 \ctikzset{tripoles/pjfet/bodydiode conn/.initial=.6}
 \ctikzset{tripoles/pjfet/curr direction/.initial=-1}
+% set the gate height of jfet
+\ctikzset{transistors/jfet gate height/.code={%
+    \pgfmathsetmacro{\@@tmp}{\ctikzvalof{tripoles/njfet/width}*0.5*(#1)}%
+    \ctikzset{tripoles/njfet/conn height=\@@tmp}%
+    \ctikzset{tripoles/njfet/union height=\@@tmp}%
+    \pgfmathsetmacro{\@@tmp}{\ctikzvalof{tripoles/pjfet/width}*0.5*(#1)}%
+    \ctikzset{tripoles/pjfet/conn height=\@@tmp}%
+    \ctikzset{tripoles/pjfet/union height=\@@tmp}%
+    }
+}
 
 \ctikzset{tripoles/nujt/width/.initial=.7}
 \ctikzset{tripoles/nujt/gate height/.initial=.5}


### PR DESCRIPTION
Fix a bug in the usage of internal parameters for JFET and UJT. Additionally, add an option to move the gate position for JFET (UJT is more difficult if we want to maintain the nice drawing when used with circles).

<img width="1013" height="426" alt="image" src="https://github.com/user-attachments/assets/02765736-1617-4804-8435-1af9059809dc" />
