### PR TITLE
Prepare CTAN version 1.8.6 (2026-05-24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.6 (unreleased)
+* Version 1.8.6 (2026-05-24)
 
     A shiny new style for the manual, with a new example code implementation by Jonathan P. Spratte, based on [the package `enverb`](https://ctan.org/pkg/enverb?lang=en). The manual now avoid writing *hundreds* of auxiliary files, and compiles significantly faster. Additionally, now the manual can be compiled with `lwarp`, enabling the creation of a pure-HTML version.
     Additionally, a new option to simplify building custom blocks, thanks to a [suggestion by Matthias Jung](https://github.com/circuitikz/circuitikz/issues/925)
@@ -10,7 +10,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - New option `border` for `component text` that applies to the `twoportsplit` component
     - New option `jfet gate height` to move the vertical position of JFET gate, triggered by [this question by Vector](https://tex.stackexchange.com/q/762783/38080)
     - New options for relative gate thickness in FETs and MOSFETs, and rounded caps for transistors; suggested by [Michael Köfinger et al.](https://github.com/circuitikz/circuitikz/issues/934)
-    - Fixed a nasty bug with `ooosourcetrans`, thanks to [user sputeanus](https://github.com/circuitikz/circuitikz/issues/935) for spotting it
+    - Fixed a nasty bug with `ooosourcetrans`, thanks to [user sputeanus](https://github.com/circuitikz/circuitikz/issues/935) for spotting it.
 
 * Version 1.8.5 (2026-02-4)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.6-unreleased}
-\def\pgfcircversiondate{2026/02/10}
+\def\pgfcircversion{1.8.6}
+\def\pgfcircversiondate{2026/05/24}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.6-unreleased}
-\def\pgfcircversiondate{2026/02/10}
+\def\pgfcircversion{1.8.6}
+\def\pgfcircversiondate{2026/05/24}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
A shiny new style for the manual, with a new example code implementation by Jonathan P. Spratte, based on the package `enverb`. The manual now avoid writing *hundreds* of auxiliary files, and compiles significantly faster. Additionally, now the manual can be compiled with `lwarp`, enabling the creation of a pure-HTML version.

Additionally, a new option to simplify building custom blocks, thanks to a suggestion by Matthias Jung.

- New manual style, with new example code based on `enverb` (mainly by Jonathan P. Spratte)
- New option `border` for `component text` that applies to the `twoportsplit` component
- New option `jfet gate height` to move the vertical position of JFET gate
- New options for relative gate thickness in FETs and MOSFETs, and rounded caps for transistors
- Fixed a nasty bug with `ooosourcetrans`, thanks to user @sputeanus.