### PR TITLE
doc: list Heaviside under Related packages

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -220,6 +220,8 @@ Finally, the \TikZ{} library \texttt{bending} is loaded by the package, and its 
 At the Friedrich-Alexander-Universität, a group of developers are implementing a graphical user interface to draw circuits with \Circuitikz{}.
 You can find more information \href{https://github.com/circuitikz/circuitikz/issues/782}{in this GitHub issue} or, better, on their \href{https://circuit2tikz.tf.fau.de/}{main site}. You can try out the GUI \href{https://circuit2tikz.tf.fau.de/designer/}{here}.
 
+A group at the University of Colorado Colorado Springs (UCCS) are building a cross-platform desktop editor called \href{https://github.com/whileman133/Heaviside}{Heaviside} to draw circuit diagrams with \Circuitikz{}. You draw the schematic on a grid and it generates the corresponding \Circuitikz{} code, with a live preview of the compiled figure. It integrates into \LaTeX{}, Overleaf, and LyX workflows. More information and downloads are on its \href{https://github.com/whileman133/Heaviside}{GitHub page}.
+
 \subsubsection{Extension packages}
 \label{sec:extension-packages}
 


### PR DESCRIPTION
This adds **Heaviside** to the *Related packages* subsection of the manual (§1.7.1), alongside the existing circuit2tikz entry.

[Heaviside](https://github.com/whileman133/Heaviside) is a free, cross-platform desktop editor for drawing CircuiTikZ circuit diagrams: you draw the schematic on a grid and it generates the corresponding CircuiTikZ code, with a live preview of the compiled figure, and exports into LaTeX / Overleaf / LyX workflows.

Opening this at the maintainer's suggestion. Happy to adjust the wording or placement as preferred.

### Notes
- Single-paragraph prose addition in the same style as the existing entry; no new macros (uses `\href`, `\Circuitikz{}`, `\LaTeX{}`).
- Verified the manual still builds: `pdflatex` of `doc/circuitikzmanual.tex` (with `TEXINPUTS=.:../tex/:` and the freshly generated `enverb.sty`) completes cleanly — 289 pages, no errors.