### PR TITLE
Prepare for CTAN Release 1.8.7 (2026-09-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 <!--- CircuiTikz - Changelog --->
 The major changes among the different CircuiTikZ versions are listed here. See <https://github.com/circuitikz/circuitikz/commits> for a full list of changes.
 
-* Version 1.8.7 (unreleased)
+* Version 1.8.7 (2026-09-12)
 
     Quite a bit of work on the [HTML version of the manual](https://rmano.github.io/circuitikz/index.html), and a new three-phase symbol.
+    Also fixes a bit of manual formatting and a wrong anchor that no one used...
 
     - New three-phase symbol `xdelta` (extended delta), [suggested by user sputeanus on GitHub](https://github.com/circuitikz/circuitikz/issues/940)
-    - Fix `nogate` anchor on some transistor [(without gates, but well...)](https://github.com/circuitikz/circuitikz/issues/949)
-    - Minor fixes to the manual formatting: avoid overfull lines, change the voltage direction table code to play nicer with the html code, improve some example, and fix code snippet rendering.
+    - Fix `nogate` anchor on some transistors [(without gates, but well...)](https://github.com/circuitikz/circuitikz/issues/949)
+    - Minor fixes to the manual formatting: avoid overfull lines, change the voltage direction table code to play nicer with the html code, improve some examples, and fix code snippet rendering.
 
 * Version 1.8.6 (2026-05-24)
 

--- a/tex/circuitikz.sty
+++ b/tex/circuitikz.sty
@@ -16,8 +16,8 @@
 \providecommand\DeclareRelease[3]{}
 \providecommand\DeclareCurrentRelease[2]{}
 
-\def\pgfcircversion{1.8.7-unreleased}
-\def\pgfcircversiondate{2026/06/05}
+\def\pgfcircversion{1.8.7}
+\def\pgfcircversiondate{2026/09/12}
 
 \DeclareRelease{0.4}{2012/12/20}{circuitikz-0.4-body.tex}
 \DeclareRelease{v0.4}{2012/12/20}{circuitikz-0.4-body.tex}

--- a/tex/t-circuitikz.tex
+++ b/tex/t-circuitikz.tex
@@ -16,8 +16,8 @@
 \startmodule[circuitikz]
 \usemodule[tikz]
 
-\def\pgfcircversion{1.8.7-unreleased}
-\def\pgfcircversiondate{2026/06/05}
+\def\pgfcircversion{1.8.7}
+\def\pgfcircversiondate{2026/09/12}
 \writestatus{loading}{\pgfcircversiondate{} The CircuiTikz circuit drawing package version \pgfcircversion}
 
 


### PR DESCRIPTION
Quite a bit of work on the HTML version of the
manual (https://rmano.github.io/circuitikz/index.html), and a new three-phase symbol. Also fixes a bit of manual formatting and a wrong anchor that no one used...

- New three-phase symbol `xdelta` (extended delta), suggested by user sputeanus on GitHub (https://github.com/circuitikz/circuitikz/issues/940)
- Fix `nogate` anchor on some transistors (without gates, but well...) (https://github.com/circuitikz/circuitikz/issues/949)
- Minor fixes to the manual formatting: avoid overfull lines, change the voltage direction table code to play nicer with the HTML code, improve some examples, and fix code snippet rendering.