### PR TITLE
Last minute ConTeXt fix for 1.8.7

### DIFF
--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -1256,41 +1256,41 @@
 \def\pgf@circ@do@wedge@left{
     \pgf@circ@res@temp=0pt\relax
     \ifnum\ctikzvalof{multipoles/flipflop/c\the\pgf@circ@count@c}>0
-        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step+\wedge}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+\wedge}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step-\wedge}}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step+\pgfcirc@@wedge}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left+\pgfcirc@@wedge}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step-\pgfcirc@@wedge}}
         \pgfusepath{stroke}
-        \pgf@circ@res@temp=\wedge
+        \pgf@circ@res@temp=\pgfcirc@@wedge
     \fi
 }
 \def\pgf@circ@do@wedge@right{
     \pgf@circ@res@temp=0pt\relax
     \ifnum\ctikzvalof{multipoles/flipflop/c\the\pgf@circ@count@c}>0
-        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step+\wedge}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\wedge}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step}}
-        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step-\wedge}}
+        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step+\pgfcirc@@wedge}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right-\pgfcirc@@wedge}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step}}
+        \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up+(\pgf@circ@dip@pin@shift-\the\pgf@circ@count@a)*\pgf@circ@res@step-\pgfcirc@@wedge}}
         \pgfusepath{stroke}
-        \pgf@circ@res@temp=-\wedge
+        \pgf@circ@res@temp=-\pgfcirc@@wedge
     \fi
 }
 \def\pgf@circ@do@wedge@up{
     \pgf@circ@res@temp=0pt\relax
     \ifnum\ctikzvalof{multipoles/flipflop/cu}>0
-        \pgfpathmoveto{\pgfpoint{-\wedge}{\pgf@circ@res@up}}
-        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@up-\wedge}}
-        \pgfpathlineto{\pgfpoint{\wedge}{\pgf@circ@res@up}}
+        \pgfpathmoveto{\pgfpoint{-\pgfcirc@@wedge}{\pgf@circ@res@up}}
+        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@up-\pgfcirc@@wedge}}
+        \pgfpathlineto{\pgfpoint{\pgfcirc@@wedge}{\pgf@circ@res@up}}
         \pgfusepath{stroke}
-        \pgf@circ@res@temp=-\wedge
+        \pgf@circ@res@temp=-\pgfcirc@@wedge
     \fi
 }
 \def\pgf@circ@do@wedge@down{
     \pgf@circ@res@temp=0pt\relax
     \ifnum\ctikzvalof{multipoles/flipflop/cd}>0
-        \pgfpathmoveto{\pgfpoint{-\wedge}{\pgf@circ@res@down}}
-        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down+\wedge}}
-        \pgfpathlineto{\pgfpoint{\wedge}{\pgf@circ@res@down}}
+        \pgfpathmoveto{\pgfpoint{-\pgfcirc@@wedge}{\pgf@circ@res@down}}
+        \pgfpathlineto{\pgfpoint{0pt}{\pgf@circ@res@down+\pgfcirc@@wedge}}
+        \pgfpathlineto{\pgfpoint{\pgfcirc@@wedge}{\pgf@circ@res@down}}
         \pgfusepath{stroke}
-        \pgf@circ@res@temp=\wedge
+        \pgf@circ@res@temp=\pgfcirc@@wedge
     \fi
 }
 % generic flip-flop shape
@@ -1390,7 +1390,7 @@
                 \pgf@circ@strut\space}
         % \typeout{TEXT\space\mytext}
         \pgfmathloop%
-        \def\wedge{\ctikzvalof{multipoles/flipflop/clock wedge size}\pgf@circ@res@step}
+        \def\pgfcirc@@wedge{\ctikzvalof{multipoles/flipflop/clock wedge size}\pgf@circ@res@step}
         \pgf@circ@res@temp=0pt\relax
         \ifnum\pgf@circ@count@a>0
             \ifcase\quadrant % rotation 0
@@ -1786,12 +1786,12 @@
             \pgf@circ@res@temp=0pt
         \else\pgfscope
             \pgftransformrotate{#2}
-            \pgfpathmoveto{\pgfpoint{+0pt}{-\clockwedge}}
-            \pgfpathlineto{\pgfpoint{\clockwedge}{+0pt}}
-            \pgfpathlineto{\pgfpoint{+0pt}{\clockwedge}}
+            \pgfpathmoveto{\pgfpoint{+0pt}{-\pgfcirc@@clockwedge}}
+            \pgfpathlineto{\pgfpoint{\pgfcirc@@clockwedge}{+0pt}}
+            \pgfpathlineto{\pgfpoint{+0pt}{\pgfcirc@@clockwedge}}
             \pgfusepath{draw}
         \endpgfscope
-            \pgf@circ@res@temp=\clockwedge
+            \pgf@circ@res@temp=\pgfcirc@@clockwedge
         \fi
     }{}
 }
@@ -2145,7 +2145,7 @@
         \fi
         % clockwedge size
         \pgfmathsetlength{\pgf@circ@res@temp}{\ctikzvalof{muxdemux/clock wedge size}*\ctikzvalof{multipoles/muxdemux/base len}*\scaledRlen}
-        \edef\clockwedge{\the\pgf@circ@res@temp}
+        \edef\pgfcirc@@clockwedge{\the\pgf@circ@res@temp}
         % select which negation ball to use
         \ifpgf@circuit@ieeelogicport
             \def\@@notcirc{circleinv}


### PR DESCRIPTION
Apparently, ConTeXt reserved the macro `\wedge`, which was used in `circuitikz`. Rename it to a safer name.